### PR TITLE
feat(ci): restrict image publishing to tags/manual triggers and run integrations on PR

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,6 +10,15 @@ on:
       - "versions.env"
       - "Makefile"
       - ".github/workflows/integration.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "cli/**"
+      - "kates/**"
+      - "images.env"
+      - "versions.env"
+      - "Makefile"
+      - ".github/workflows/integration.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -4,14 +4,6 @@ on:
   push:
     tags:
       - "v*"
-    branches:
-      - "**"
-    paths:
-      - "kates/**"
-      - "cli/**"
-      - "images.env"
-      - "versions.env"
-      - ".github/workflows/publish-docker.yml"
   workflow_dispatch:
     inputs:
       variant:

--- a/.github/workflows/publish-tester.yml
+++ b/.github/workflows/publish-tester.yml
@@ -4,11 +4,6 @@ on:
   push:
     tags:
       - "v*"
-    branches:
-      - "**"
-    paths:
-      - "tester/**"
-      - ".github/workflows/publish-tester.yml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This PR updates the GitHub Actions workflow triggers to restrict automatic image publishing to explicit version tags (v*) and manual triggers only, while enabling integration tests on pull requests to ensure thorough PR verification.