### PR TITLE
fix: align cluster topology output and upgrade RBAC for component discovery

### DIFF
--- a/charts/kates/Chart.yaml
+++ b/charts/kates/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kates
 description: Kates — Kafka Advanced Testing & Engineering Suite
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: "1.11.0"
 keywords:
   - kafka

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -143,14 +143,11 @@ var clusterTopologyCmd = &cobra.Command{
 					if v {
 						icon = "✓"
 					}
-					statusParts = append(statusParts, fmt.Sprintf("  %s %s", icon, label))
+					statusParts = append(statusParts, fmt.Sprintf("%s %s", icon, label))
 				}
 			}
 			if len(statusParts) > 0 {
-				output.KeyValue("Components", "")
-				for _, p := range statusParts {
-					fmt.Println(p)
-				}
+				output.KeyValue("Components", strings.Join(statusParts, "\n                           "))
 			}
 		}
 


### PR DESCRIPTION
## Description
This pull request addresses two distinct but related issues causing the `kates cluster topology` command to display incorrectly and fail to retrieve cluster state:

1. **CLI Component Formatting**: Fixed a formatting bug in `cli/cmd/cluster.go` where `Strimzi Operator` components were inconsistently outputted on newlines rather than perfectly aligned to their 30-character boundary.
2. **Helm RBAC Chart Bump**: Bumped the Kates Helm chart version to `0.4.1`. The local `rbac.yaml` previously correctly defined the `nodes` and `kafka.strimzi.io` resource permissions, but because the cluster wasn't upgraded to deploy these updated policies, the backend lacked the necessary RBAC to fetch node counts or Kafka broker topology. By bumping the chart version, we force Helm / CI deployments to upgrade, ensuring the backend successfully receives RBAC access to these missing metrics.

## Changes Made
* `cli/cmd/cluster.go`: Fixed spacing and padding in `statusParts` formatting loop.
* `charts/kates/Chart.yaml`: Bumped chart version to `0.4.1`.

## Validation
* Tested CLI binary locally and ensured components pad perfectly next to their keys.
* Upgrading to chart `0.4.1` on the cluster immediately populates `Kafka Version` and `Nodes`.