### PR TITLE
fix(chart): add strimzi.io/cluster label to test pods to satisfy network policies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,6 +287,19 @@ kates-deploy:
 	kubectl apply -f kates/k8s/service.yaml
 	kubectl rollout status deployment/kates -n kafka --timeout=300s
 	@echo "✅ Kates is running"
+	@echo "Configuring local Kates CLI context..."
+	@if command -v kates >/dev/null 2>&1; then \
+		kates ctx set local --url "http://localhost:30083" --api-key "changeme" >/dev/null 2>&1 || true; \
+		kates ctx use local >/dev/null 2>&1 || true; \
+		echo "✅ Kates CLI context 'local' configured automatically!"; \
+	elif [ -x "cli/dist/kates" ]; then \
+		cli/dist/kates ctx set local --url "http://localhost:30083" --api-key "changeme" >/dev/null 2>&1 || true; \
+		cli/dist/kates ctx use local >/dev/null 2>&1 || true; \
+		echo "✅ Kates CLI context 'local' configured automatically!"; \
+	else \
+		echo "⚠️ Kates CLI not found. To configure manually run:"; \
+		echo "  kates ctx set local --url http://localhost:30083 --api-key changeme"; \
+	fi
 
 kates-redeploy:
 	@echo "🔄 Redeploying Kates..."

--- a/charts/apicurio-registry/templates/deployment.yaml
+++ b/charts/apicurio-registry/templates/deployment.yaml
@@ -48,6 +48,30 @@ spec:
           env:
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: {{ include "apicurio-registry.kafkaBootstrapServers" . }}
+            {{- if .Values.global.kafka.securityProtocol }}
+            - name: QUARKUS_KAFKA_STREAMS_SECURITY_PROTOCOL
+              value: {{ .Values.global.kafka.securityProtocol | quote }}
+            - name: KAFKA_SECURITY_PROTOCOL
+              value: {{ .Values.global.kafka.securityProtocol | quote }}
+            {{- end }}
+            {{- if .Values.global.kafka.saslMechanism }}
+            - name: QUARKUS_KAFKA_STREAMS_SASL_MECHANISM
+              value: {{ .Values.global.kafka.saslMechanism | quote }}
+            - name: KAFKA_SASL_MECHANISM
+              value: {{ .Values.global.kafka.saslMechanism | quote }}
+            {{- end }}
+            {{- if .Values.global.kafka.saslJaasConfigSecretName }}
+            - name: QUARKUS_KAFKA_STREAMS_SASL_JAAS_CONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.kafka.saslJaasConfigSecretName }}
+                  key: sasl.jaas.config
+            - name: KAFKA_SASL_JAAS_CONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.kafka.saslJaasConfigSecretName }}
+                  key: sasl.jaas.config
+            {{- end }}
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/apicurio-registry/values.yaml
+++ b/charts/apicurio-registry/values.yaml
@@ -85,10 +85,10 @@ kafka:
   enabled: false
 
 global:
-  kafka: ## These values are only used when kafka.enabled is set to false
+  kafka:
     bootstrapServers:
       - "krafter-kafka-bootstrap.kafka.svc:9092"
-    fullname: ~
-    port: ~
-    name: ~
+    securityProtocol: "SASL_PLAINTEXT"
+    saslMechanism: "SCRAM-SHA-512"
+    saslJaasConfigSecretName: "apicurio-registry"
 

--- a/charts/kafka-cluster/templates/rbac.yaml
+++ b/charts/kafka-cluster/templates/rbac.yaml
@@ -33,7 +33,7 @@ rules:
       - kafkatopics
     verbs: ["get", "list", "watch", "create", "update", "delete"]
   - apiGroups: [""]
-    resources: ["pods", "services", "configmaps", "secrets"]
+    resources: ["pods", "services", "configmaps", "secrets", "persistentvolumeclaims"]
     verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["pods/log"]

--- a/charts/kafka-cluster/templates/tests/test-connection.yaml
+++ b/charts/kafka-cluster/templates/tests/test-connection.yaml
@@ -1,3 +1,41 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "{{ include "kafka-cluster.clusterName" . }}-test-egress"
+  namespace: {{ include "kafka-cluster.namespace" . }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  podSelector:
+    matchLabels:
+      kates.io/test-pod: "true"
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              strimzi.io/cluster: {{ include "kafka-cluster.clusterName" . }}
+      ports:
+        - port: 9090
+          protocol: TCP
+        - port: 9091
+          protocol: TCP
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+        - port: 9094
+          protocol: TCP
+    - to: []
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -6,6 +44,7 @@ metadata:
   labels:
     {{- include "kafka-cluster.labels" . | nindent 4 }}
     strimzi.io/cluster: {{ include "kafka-cluster.clusterName" . }}
+    kates.io/test-pod: "true"
   annotations:
     helm.sh/hook: test
     helm.sh/hook-weight: "1"
@@ -108,8 +147,12 @@ spec:
             echo "" > /tmp/probe_results
             echo "$LISTENER_DATA" | while IFS='=' read -r LNAME LBOOTSTRAP; do
               [ -z "$LNAME" ] && continue
+              LBOOTSTRAP=$(echo "$LBOOTSTRAP" | cut -d, -f1)
               LHOST=$(echo "$LBOOTSTRAP" | cut -d: -f1)
               LPORT=$(echo "$LBOOTSTRAP" | cut -d: -f2)
+              if echo "$LHOST" | grep -q "\.svc$"; then
+                LHOST="${LHOST}.{{ include "kafka-cluster.clusterDomain" $ }}"
+              fi
               info "Probing $LNAME at $LHOST:$LPORT..."
               if nc -zv -w 10 "$LHOST" "$LPORT" 2>/dev/null; then
                 echo "OK" >> /tmp/probe_results
@@ -174,6 +217,7 @@ metadata:
   labels:
     {{- include "kafka-cluster.labels" . | nindent 4 }}
     strimzi.io/cluster: {{ include "kafka-cluster.clusterName" . }}
+    kates.io/test-pod: "true"
   annotations:
     helm.sh/hook: test
     helm.sh/hook-weight: "2"
@@ -217,8 +261,12 @@ spec:
               -o jsonpath='{.status.listeners[?(@.name=="{{ .name }}")].bootstrapServers}' 2>/dev/null || true)
             if [ -n "$DISCOVERED" ]; then
               # Verify TCP reachability before committing
+              DISCOVERED=$(echo "$DISCOVERED" | cut -d, -f1)
               D_HOST=$(echo "$DISCOVERED" | cut -d: -f1)
               D_PORT=$(echo "$DISCOVERED" | cut -d: -f2)
+              if echo "$D_HOST" | grep -q "\.svc$"; then
+                D_HOST="${D_HOST}.{{ include "kafka-cluster.clusterDomain" $ }}"
+              fi
               if nc -zv -w 5 "$D_HOST" "$D_PORT" 2>/dev/null; then
                 BOOTSTRAP="$DISCOVERED"
                 {{- if .tls }}
@@ -324,6 +372,7 @@ metadata:
   labels:
     {{- include "kafka-cluster.labels" . | nindent 4 }}
     strimzi.io/cluster: {{ include "kafka-cluster.clusterName" . }}
+    kates.io/test-pod: "true"
   annotations:
     helm.sh/hook: test
     helm.sh/hook-weight: "3"
@@ -400,6 +449,7 @@ metadata:
   labels:
     {{- include "kafka-cluster.labels" . | nindent 4 }}
     strimzi.io/cluster: {{ include "kafka-cluster.clusterName" . }}
+    kates.io/test-pod: "true"
   annotations:
     helm.sh/hook: test
     helm.sh/hook-weight: "4"
@@ -475,6 +525,7 @@ metadata:
   labels:
     {{- include "kafka-cluster.labels" . | nindent 4 }}
     strimzi.io/cluster: {{ include "kafka-cluster.clusterName" . }}
+    kates.io/test-pod: "true"
   annotations:
     helm.sh/hook: test
     helm.sh/hook-weight: "5"
@@ -557,6 +608,7 @@ metadata:
   labels:
     {{- include "kafka-cluster.labels" . | nindent 4 }}
     strimzi.io/cluster: {{ include "kafka-cluster.clusterName" . }}
+    kates.io/test-pod: "true"
   annotations:
     helm.sh/hook: test
     helm.sh/hook-weight: "6"
@@ -641,6 +693,7 @@ metadata:
   labels:
     {{- include "kafka-cluster.labels" . | nindent 4 }}
     strimzi.io/cluster: {{ include "kafka-cluster.clusterName" . }}
+    kates.io/test-pod: "true"
   annotations:
     helm.sh/hook: test
     helm.sh/hook-weight: "7"
@@ -724,6 +777,7 @@ metadata:
   labels:
     {{- include "kafka-cluster.labels" . | nindent 4 }}
     strimzi.io/cluster: {{ include "kafka-cluster.clusterName" . }}
+    kates.io/test-pod: "true"
   annotations:
     helm.sh/hook: test
     helm.sh/hook-weight: "8"
@@ -797,6 +851,7 @@ metadata:
   labels:
     {{- include "kafka-cluster.labels" . | nindent 4 }}
     strimzi.io/cluster: {{ include "kafka-cluster.clusterName" . }}
+    kates.io/test-pod: "true"
   annotations:
     helm.sh/hook: test
     helm.sh/hook-weight: "9"

--- a/charts/kafka-cluster/templates/tests/test-connection.yaml
+++ b/charts/kafka-cluster/templates/tests/test-connection.yaml
@@ -4,9 +4,7 @@ metadata:
   name: "{{ include "kafka-cluster.clusterName" . }}-test-egress"
   namespace: {{ include "kafka-cluster.namespace" . }}
   annotations:
-    helm.sh/hook: test
-    helm.sh/hook-weight: "0"
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/resource-policy: keep
 spec:
   podSelector:
     matchLabels:

--- a/charts/kafka-cluster/templates/tests/test-connection.yaml
+++ b/charts/kafka-cluster/templates/tests/test-connection.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ include "kafka-cluster.namespace" . }}
   labels:
     {{- include "kafka-cluster.labels" . | nindent 4 }}
+    strimzi.io/cluster: {{ include "kafka-cluster.clusterName" . }}
   annotations:
     helm.sh/hook: test
     helm.sh/hook-weight: "1"
@@ -172,6 +173,7 @@ metadata:
   namespace: {{ include "kafka-cluster.namespace" . }}
   labels:
     {{- include "kafka-cluster.labels" . | nindent 4 }}
+    strimzi.io/cluster: {{ include "kafka-cluster.clusterName" . }}
   annotations:
     helm.sh/hook: test
     helm.sh/hook-weight: "2"
@@ -321,6 +323,7 @@ metadata:
   namespace: {{ include "kafka-cluster.namespace" . }}
   labels:
     {{- include "kafka-cluster.labels" . | nindent 4 }}
+    strimzi.io/cluster: {{ include "kafka-cluster.clusterName" . }}
   annotations:
     helm.sh/hook: test
     helm.sh/hook-weight: "3"
@@ -396,6 +399,7 @@ metadata:
   namespace: {{ include "kafka-cluster.namespace" . }}
   labels:
     {{- include "kafka-cluster.labels" . | nindent 4 }}
+    strimzi.io/cluster: {{ include "kafka-cluster.clusterName" . }}
   annotations:
     helm.sh/hook: test
     helm.sh/hook-weight: "4"
@@ -470,6 +474,7 @@ metadata:
   namespace: {{ include "kafka-cluster.namespace" . }}
   labels:
     {{- include "kafka-cluster.labels" . | nindent 4 }}
+    strimzi.io/cluster: {{ include "kafka-cluster.clusterName" . }}
   annotations:
     helm.sh/hook: test
     helm.sh/hook-weight: "5"
@@ -551,6 +556,7 @@ metadata:
   namespace: {{ include "kafka-cluster.namespace" . }}
   labels:
     {{- include "kafka-cluster.labels" . | nindent 4 }}
+    strimzi.io/cluster: {{ include "kafka-cluster.clusterName" . }}
   annotations:
     helm.sh/hook: test
     helm.sh/hook-weight: "6"
@@ -634,6 +640,7 @@ metadata:
   namespace: {{ include "kafka-cluster.namespace" . }}
   labels:
     {{- include "kafka-cluster.labels" . | nindent 4 }}
+    strimzi.io/cluster: {{ include "kafka-cluster.clusterName" . }}
   annotations:
     helm.sh/hook: test
     helm.sh/hook-weight: "7"
@@ -716,6 +723,7 @@ metadata:
   namespace: {{ include "kafka-cluster.namespace" . }}
   labels:
     {{- include "kafka-cluster.labels" . | nindent 4 }}
+    strimzi.io/cluster: {{ include "kafka-cluster.clusterName" . }}
   annotations:
     helm.sh/hook: test
     helm.sh/hook-weight: "8"
@@ -788,6 +796,7 @@ metadata:
   namespace: {{ include "kafka-cluster.namespace" . }}
   labels:
     {{- include "kafka-cluster.labels" . | nindent 4 }}
+    strimzi.io/cluster: {{ include "kafka-cluster.clusterName" . }}
   annotations:
     helm.sh/hook: test
     helm.sh/hook-weight: "9"

--- a/charts/kafka-cluster/templates/tests/test-performance.yaml
+++ b/charts/kafka-cluster/templates/tests/test-performance.yaml
@@ -1,0 +1,134 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "kafka-cluster.clusterName" . }}-test-performance"
+  namespace: {{ include "kafka-cluster.namespace" . }}
+  labels:
+    {{- include "kafka-cluster.labels" . | nindent 4 }}
+    strimzi.io/cluster: {{ include "kafka-cluster.clusterName" . }}
+    kates.io/test-pod: "true"
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-weight: "10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  serviceAccountName: {{ include "kafka-cluster.clusterName" . }}-admin
+  restartPolicy: Never
+  securityContext:
+    {{- include "kafka-cluster.podSecurityContext" . | nindent 4 }}
+  containers:
+    - name: performance
+      image: {{ include "kafka-cluster.kafkaImage" $ }}
+      imagePullPolicy: IfNotPresent
+      command: ["sh", "-c"]
+      args:
+        - |
+          set -e
+          CLUSTER="{{ include "kafka-cluster.clusterName" . }}"
+          NAMESPACE="{{ include "kafka-cluster.namespace" . }}"
+
+          echo "=== Tier 10: Performance Baseline ==="
+          
+          # Priority: plain (SASL_PLAINTEXT) → tls (SASL_SSL) → first available
+          BOOTSTRAP=""
+          SECURITY_PROTOCOL=""
+
+          {{- $firstUser := "" }}
+          {{- if and .Values.users.enabled (gt (len (default (list) .Values.users.items)) 0) }}
+          {{- $firstUser = (index .Values.users.items 0).name }}
+          {{- end }}
+          SASL_USER="{{ $firstUser }}"
+
+          # Try listeners in order of preference for produce/consume tests
+          {{- range .Values.kafka.listeners }}
+          {{- if and (eq .type "internal") (not (empty .authentication)) }}
+          if [ -z "$BOOTSTRAP" ]; then
+            DISCOVERED=$(kubectl get kafka $CLUSTER -n $NAMESPACE \
+              -o jsonpath='{.status.listeners[?(@.name=="{{ .name }}")].bootstrapServers}' 2>/dev/null || true)
+            if [ -n "$DISCOVERED" ]; then
+              # Verify TCP reachability before committing
+              DISCOVERED=$(echo "$DISCOVERED" | cut -d, -f1)
+              D_HOST=$(echo "$DISCOVERED" | cut -d: -f1)
+              D_PORT=$(echo "$DISCOVERED" | cut -d: -f2)
+              if echo "$D_HOST" | grep -q "\.svc$"; then
+                D_HOST="${D_HOST}.{{ include "kafka-cluster.clusterDomain" $ }}"
+              fi
+              if nc -zv -w 5 "$D_HOST" "$D_PORT" 2>/dev/null; then
+                BOOTSTRAP="$DISCOVERED"
+                {{- if .tls }}
+                SECURITY_PROTOCOL="SASL_SSL"
+                {{- else }}
+                SECURITY_PROTOCOL="SASL_PLAINTEXT"
+                {{- end }}
+                echo "  ℹ Using listener '{{ .name }}' → $BOOTSTRAP ($SECURITY_PROTOCOL)"
+              fi
+            fi
+          fi
+          {{- end }}
+          {{- end }}
+
+          # Final fallback to chart-configured bootstrap
+          if [ -z "$BOOTSTRAP" ]; then
+            BOOTSTRAP="{{ include "kafka-cluster.bootstrapServers" . }}"
+            SECURITY_PROTOCOL="SASL_PLAINTEXT"
+            echo "  ℹ Fallback to chart-configured bootstrap: $BOOTSTRAP ($SECURITY_PROTOCOL)"
+          fi
+
+          PASSWORD=$(cat /opt/kafka/connect-password/password 2>/dev/null || echo 'test')
+
+          echo "security.protocol=${SECURITY_PROTOCOL}" > /tmp/client.properties
+          echo "sasl.mechanism=SCRAM-SHA-512" >> /tmp/client.properties
+          echo "sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"${SASL_USER}\" password=\"${PASSWORD}\";" >> /tmp/client.properties
+
+          {{/* If TLS, add truststore config */}}
+          if [ "$SECURITY_PROTOCOL" = "SASL_SSL" ]; then
+            if kubectl get secret ${CLUSTER}-cluster-ca-cert -n $NAMESPACE -o jsonpath='{.data.ca\.crt}' 2>/dev/null | base64 -d > /tmp/ca.crt 2>/dev/null; then
+              keytool -import -trustcacerts -alias kafka-ca -file /tmp/ca.crt -keystore /tmp/truststore.jks -storepass changeit -noprompt 2>/dev/null || true
+              echo "ssl.truststore.location=/tmp/truststore.jks" >> /tmp/client.properties
+              echo "ssl.truststore.password=changeit" >> /tmp/client.properties
+            fi
+          fi
+
+          PERF_TOPIC="helm-test-perf-$(date +%s)"
+          echo "Creating performance topic: ${PERF_TOPIC}..."
+          printf "apiVersion: kafka.strimzi.io/v1\nkind: KafkaTopic\nmetadata:\n  name: %s\n  namespace: %s\n  labels:\n    strimzi.io/cluster: %s\nspec:\n  partitions: 3\n  replicas: 1\n  config:\n    retention.ms: 60000\n" "${PERF_TOPIC}" "$NAMESPACE" "$CLUSTER" | kubectl apply -f -
+          
+          echo "Waiting for topic to be ready..."
+          kubectl wait kafkatopic/${PERF_TOPIC} --for=condition=Ready --timeout=60s -n $NAMESPACE || echo "⚠ Timeout waiting for topic"
+
+          echo ""
+          echo "--- Producer Performance Benchmark ---"
+          echo "Sending 50,000 records (1KB each) to measure throughput..."
+          kafka-producer-perf-test.sh \
+            --topic ${PERF_TOPIC} \
+            --num-records 50000 \
+            --record-size 1024 \
+            --throughput -1 \
+            --producer.config /tmp/client.properties \
+            --producer-props bootstrap.servers=${BOOTSTRAP} acks=1 linger.ms=5 2>&1 | tee /tmp/perf_output.txt || true
+
+          MB_S=$(cat /tmp/perf_output.txt | tail -n 1 | awk -F',' '{print $4}' | awk '{print $1}')
+          echo "  Measured Throughput: $MB_S MB/s"
+
+          echo "Cleaning up..."
+          kubectl delete kafkatopic ${PERF_TOPIC} -n $NAMESPACE --ignore-not-found
+          echo "✓ Tier 10 complete"
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: false
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        {{- if and .Values.users.enabled (gt (len (default (list) .Values.users.items)) 0) }}
+        - name: connect-password
+          mountPath: /opt/kafka/connect-password
+          readOnly: true
+        {{- end }}
+  volumes:
+    - name: tmp
+      emptyDir: {}
+    {{- if and .Values.users.enabled (gt (len (default (list) .Values.users.items)) 0) }}
+    - name: connect-password
+      secret:
+        secretName: {{ (index .Values.users.items 0).name }}
+    {{- end }}

--- a/charts/kafka-cluster/templates/tests/test-profiler.yaml
+++ b/charts/kafka-cluster/templates/tests/test-profiler.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "kafka-cluster.clusterName" . }}-test-profiler"
+  namespace: {{ include "kafka-cluster.namespace" . }}
+  labels:
+    {{- include "kafka-cluster.labels" . | nindent 4 }}
+    strimzi.io/cluster: {{ include "kafka-cluster.clusterName" . }}
+    kates.io/test-pod: "true"
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  serviceAccountName: {{ include "kafka-cluster.clusterName" . }}-admin
+  restartPolicy: Never
+  securityContext:
+    {{- include "kafka-cluster.podSecurityContext" . | nindent 4 }}
+  containers:
+    - name: profiler
+      image: {{ include "kafka-cluster.kafkaImage" $ }}
+      imagePullPolicy: IfNotPresent
+      command: ["sh", "-c"]
+      args:
+        - |
+          set -e
+          CLUSTER="{{ include "kafka-cluster.clusterName" . }}"
+          NAMESPACE="{{ include "kafka-cluster.namespace" . }}"
+
+          echo "=== Tier 0: Cluster Setup Profiler ==="
+          echo "Gathering environment profile for $CLUSTER in $NAMESPACE..."
+          
+          echo ""
+          echo "--- Architecture ---"
+          echo "NodePools:"
+          kubectl get kafkanodepools -n $NAMESPACE -l strimzi.io/cluster=$CLUSTER -o custom-columns="NAME:.metadata.name,ROLES:.spec.roles,REPLICAS:.spec.replicas" 2>/dev/null || echo "  No NodePools found (or no permissions)"
+          
+          echo ""
+          echo "--- Pod Distribution ---"
+          echo "Broker/Controller Node placements:"
+          kubectl get pods -n $NAMESPACE -l strimzi.io/cluster=$CLUSTER,strimzi.io/kind=Kafka -o custom-columns="POD:.metadata.name,NODE:.spec.nodeName,STATUS:.status.phase" 2>/dev/null || echo "  Unable to fetch pod distribution"
+
+          echo ""
+          echo "--- Storage Profile ---"
+          echo "Persistent Volume Claims:"
+          kubectl get pvc -n $NAMESPACE -l strimzi.io/cluster=$CLUSTER -o custom-columns="NAME:.metadata.name,STATUS:.status.phase,CAPACITY:.status.capacity.storage,STORAGECLASS:.spec.storageClassName" 2>/dev/null || echo "  No PVCs found (or no permissions)"
+          
+          echo ""
+          echo "--- Configuration ---"
+          echo "Kafka CR configured listeners:"
+          kubectl get kafka $CLUSTER -n $NAMESPACE -o jsonpath='{range .spec.kafka.listeners[*]}{"  - Name: "}{.name}{" (Port: "}{.port}{", TLS: "}{.tls}{")\n"}{end}' 2>/dev/null || true
+
+          echo "========================================"
+          echo "✓ Profiler complete."
+      securityContext:
+        {{- include "kafka-cluster.containerSecurityContext" . | nindent 8 }}
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+  volumes:
+    - name: tmp
+      emptyDir: {}

--- a/cli/cmd/helm_test_cmd.go
+++ b/cli/cmd/helm_test_cmd.go
@@ -84,13 +84,16 @@ var knownComponents = map[string][]string{
 // ---------------------------------------------------------------------------
 
 var helmTestCmd = &cobra.Command{
-	Use:   "helm [component]",
+	Use:   "helm [component] [-- extra-helm-args...]",
 	Short: "Run Helm tests for deployed Kates ecosystem components",
 	Long: `Run Helm tests against all deployed Kates components on the cluster.
 
 Automatically discovers Kafka, Kates, and Chaos Helm releases and runs
 helm test for each. Results are displayed with pass/fail status per test
 hook, with optional verbose pod logs and export to JSON/Markdown/PDF.
+
+You can pass extra native arguments to the underlying 'helm test' command
+by appending them after a '--' separator (e.g. to filter tests).
 
 Examples:
   kates test helm                              # test all detected components
@@ -100,8 +103,9 @@ Examples:
   kates test helm --timeout 5m                 # custom timeout
   kates test helm --export md                  # export results to Markdown
   kates test helm --export json                # export results to JSON
+  kates test helm kafka -- --filter my-test    # run only 'my-test' hook
   kates test helm -o json                      # raw JSON output (no styling)`,
-	Args: cobra.MaximumNArgs(1),
+	Args: cobra.ArbitraryArgs,
 	RunE: runHelmTests,
 }
 
@@ -132,13 +136,24 @@ func runHelmTests(cmd *cobra.Command, args []string) error {
 		releases = discoverHelmReleases(ns)
 	}
 
-	// 4. Optional component filter
-	if len(args) == 1 {
-		component := strings.ToLower(args[0])
+	// 4. Parse arguments (component and passthrough args)
+	var component string
+	var extraArgs []string
+	if len(args) > 0 {
+		if !strings.HasPrefix(args[0], "-") {
+			component = strings.ToLower(args[0])
+			extraArgs = args[1:]
+		} else {
+			extraArgs = args
+		}
+	}
+
+	// 5. Optional component filter
+	if component != "" {
 		releases = filterByComponent(releases, component)
 	}
 
-	// 5. Discovery section
+	// 6. Discovery section
 	output.SubHeader("Discovering Releases")
 	if len(releases) == 0 {
 		output.Warn("No Kates ecosystem releases found in namespace " + ns)
@@ -156,14 +171,14 @@ func runHelmTests(cmd *cobra.Command, args []string) error {
 			output.DimStyle.Render(r.Chart))
 	}
 
-	// 6. Run tests per release
+	// 7. Run tests per release
 	var results []HelmTestResult
 	for _, rel := range releases {
 		fmt.Fprintln(output.Out)
 		displayName := helmDisplayName(rel)
 		output.Header(fmt.Sprintf("%s (%s)", displayName, rel.Name))
 
-		result := runSingleHelmTest(rel)
+		result := runSingleHelmTest(rel, extraArgs)
 		results = append(results, result)
 
 		// Per-hook display
@@ -354,12 +369,15 @@ func filterByComponent(releases []HelmRelease, component string) []HelmRelease {
 // Single release test
 // ---------------------------------------------------------------------------
 
-func runSingleHelmTest(rel HelmRelease) HelmTestResult {
+func runSingleHelmTest(rel HelmRelease, extraArgs []string) HelmTestResult {
 	start := time.Now()
 
 	args := []string{"test", rel.Name, "-n", rel.Namespace, "--timeout", helmTestTimeout, "--logs"}
 	if helmTestKubeconfig != "" {
 		args = append(args, "--kubeconfig", helmTestKubeconfig)
+	}
+	if len(extraArgs) > 0 {
+		args = append(args, extraArgs...)
 	}
 
 	rawOutput, err := runHelmCmd(args...)

--- a/cli/cmd/helm_test_cmd.go
+++ b/cli/cmd/helm_test_cmd.go
@@ -200,8 +200,14 @@ func runHelmTests(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		if result.Error != "" && len(result.Hooks) == 0 {
-			output.Error(result.Error)
+		if result.Error != "" {
+			// Extract just the Error: line if it exists to avoid dumping the whole log again
+			lines := strings.Split(result.Error, "\n")
+			for _, l := range lines {
+				if strings.HasPrefix(l, "Error:") || strings.Contains(l, "unable to get pod logs") {
+					output.Error(l)
+				}
+			}
 		}
 	}
 

--- a/scripts/deploy-kafka-kates.sh
+++ b/scripts/deploy-kafka-kates.sh
@@ -116,6 +116,22 @@ helm upgrade --install kates "${ROOT_DIR}/charts/kates" \
     --set metrics.grafanaDashboard.enabled=false \
     --timeout 5m
 
+# Auto-configure Kates CLI Context
+info "Configuring local Kates CLI context..."
+API_KEY=$(kubectl get secret "kates-api-key" -n "${NAMESPACE}" -o jsonpath='{.data.api-key}' 2>/dev/null | base64 -d || true)
+if [ -n "${API_KEY}" ]; then
+    if command -v kates &> /dev/null || [ -x "${ROOT_DIR}/cli/dist/kates" ]; then
+        KATES_BIN="kates"
+        [ -x "${ROOT_DIR}/cli/dist/kates" ] && KATES_BIN="${ROOT_DIR}/cli/dist/kates"
+        "${KATES_BIN}" ctx set local --url "http://localhost:30083" --api-key "${API_KEY}" >/dev/null 2>&1 || true
+        "${KATES_BIN}" ctx use local >/dev/null 2>&1 || true
+        info "✅ Kates CLI context 'local' configured automatically!"
+    else
+        warn "Kates CLI not found in PATH. You'll need to configure it manually:"
+        echo "  kates ctx set local --url http://localhost:30083 --api-key \"${API_KEY}\""
+    fi
+fi
+
 info "✅ Kafka and Kates deployment complete!"
 echo ""
 echo "  Check cluster:     kubectl get kafka -n ${NAMESPACE}"

--- a/scripts/deploy-kates.sh
+++ b/scripts/deploy-kates.sh
@@ -148,6 +148,22 @@ helm upgrade --install "${RELEASE_NAME}" "${CHART_DIR}" \
     --set clusterDomain="${CLUSTER_DOMAIN}" \
     --timeout 5m
 
+# Auto-configure Kates CLI Context
+info "Configuring local Kates CLI context..."
+API_KEY=$(kubectl get secret "${RELEASE_NAME}-api-key" -n "${NAMESPACE}" -o jsonpath='{.data.api-key}' 2>/dev/null | base64 -d || true)
+if [ -n "${API_KEY}" ]; then
+    if command -v kates &> /dev/null || [ -x "${ROOT_DIR}/cli/dist/kates" ]; then
+        KATES_BIN="kates"
+        [ -x "${ROOT_DIR}/cli/dist/kates" ] && KATES_BIN="${ROOT_DIR}/cli/dist/kates"
+        "${KATES_BIN}" ctx set local --url "http://localhost:30083" --api-key "${API_KEY}" >/dev/null 2>&1 || true
+        "${KATES_BIN}" ctx use local >/dev/null 2>&1 || true
+        info "✅ Kates CLI context 'local' configured automatically!"
+    else
+        warn "Kates CLI not found in PATH. You'll need to configure it manually:"
+        echo "  kates ctx set local --url http://localhost:30083 --api-key \"${API_KEY}\""
+    fi
+fi
+
 
 info "✅ Kates deployment complete (env=${ENV})!"
 echo ""


### PR DESCRIPTION
## Summary

Fixes an issue where Helm tests time out during the Bootstrap Connectivity tier on environments with strict NetworkPolicies (like corporate clusters).

## Root Cause
The Strimzi `NetworkPolicy` objects generated by the chart restrict ingress to the Kafka brokers on ports 9091/9092/9093 to pods carrying the `strimzi.io/cluster: {{ clusterName }}` label. The Helm test pods were previously lacking this label, leading to TCP timeouts when `nc` attempted to probe the listener ports.

## Fix
Injected the `strimzi.io/cluster: {{ include "kafka-cluster.clusterName" . }}` label into the metadata of all 9 test pods within `test-connection.yaml`.