### PR TITLE
fix: detect improvements, progress box overhaul & dashboard alignment

### DIFF
--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -212,7 +213,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 			var response string
 			fmt.Scanln(&response)
 			if strings.ToLower(response) == "y" || strings.ToLower(response) == "yes" {
-				fmt.Println("🚀 Creating Kind cluster via 'make cluster'...")
+				fmt.Println("📦 Creating Kind cluster via 'make cluster'...")
 				cmd := exec.Command("make", "cluster")
 				cmd.Stdout = os.Stdout
 				cmd.Stderr = os.Stderr
@@ -307,7 +308,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 				fmt.Println("⏭️  Strimzi Operator already deployed. Skipping.")
 				return nil
 			}
-			fmt.Println("\n🚀 Deploying Strimzi Operator (Namespace: strimzi-operator)...")
+			fmt.Println("\n📦 Deploying Strimzi Operator (Namespace: strimzi-operator)...")
 			// Create namespace properly
 			runExecStdinFn(gCtx, "kubectl", []string{"apply", "-f", "-"}, `apiVersion: v1
 kind: Namespace
@@ -328,7 +329,7 @@ metadata:
 				fmt.Println("⏭️  Cert-Manager already deployed. Skipping.")
 				return nil
 			}
-			fmt.Printf("\n🚀 Deploying Cert-Manager (Namespace: %s)...\n", "cert-manager")
+			fmt.Printf("\n📦 Deploying Cert-Manager (Namespace: %s)...\n", "cert-manager")
 			runHelmFn(gCtx, "repo", "add", "jetstack", "https://charts.jetstack.io")
 			runHelmFn(gCtx, "repo", "update", "jetstack")
 			// global.clusterDomain ensures cert-manager generates webhook TLS certificates
@@ -443,7 +444,7 @@ spec:
 				fmt.Println("⏭️  Kyverno already deployed. Skipping.")
 				return nil
 			}
-			fmt.Println("\n🚀 Deploying Kyverno (Namespace: kyverno)...")
+			fmt.Println("\n📦 Deploying Kyverno (Namespace: kyverno)...")
 			runHelmFn(gCtx, "repo", "add", "kyverno", "https://kyverno.github.io/kyverno/")
 			runHelmFn(gCtx, "repo", "update", "kyverno")
 
@@ -501,7 +502,7 @@ spec:
 				fmt.Println("⏭️  Monitoring stack already deployed. Skipping.")
 				return nil
 			}
-			fmt.Printf("\n🚀 Deploying Monitoring (Prometheus + Grafana) (Namespace: %s)...\n", jaegerNS)
+			fmt.Printf("\n📦 Deploying Monitoring (Prometheus + Grafana) (Namespace: %s)...\n", jaegerNS)
 
 			// Update chart dependencies (kube-prometheus-stack subchart).
 			runHelmFn(g2Ctx, "dependency", "update", "charts/monitoring")
@@ -519,7 +520,7 @@ spec:
 	// Deploy Kafka
 	g2.Go(func() error {
 		if !isHelmReleaseDeployedFn(g2Ctx, "krafter", kafkaNS) {
-			fmt.Printf("\n🚀 Deploying Kafka Cluster (Namespace: %s)...\n", kafkaNS)
+			fmt.Printf("\n📦 Deploying Kafka Cluster (Namespace: %s)...\n", kafkaNS)
 
 			runHelmFn(g2Ctx, "dependency", "update", "charts/kafka-cluster")
 			// No --wait: Helm only needs to submit the manifests; the Strimzi
@@ -593,8 +594,9 @@ spec:
 		userDeadline := time.Now().Add(userTimeout)
 		start := time.Now()
 
-		fmt.Printf("\n    %s Kafka Users  %s %s\n",
-			dim("╭─"), bold(fmt.Sprintf("(%s timeout)", fmtRemaining(userTimeout))), dim("─────────────────────────────╮"))
+		fmt.Printf("\n    %s\n", boxTop(fmt.Sprintf(" Kafka Users  %s ", bold(fmt.Sprintf("(%s timeout)", fmtRemaining(userTimeout)))), 58))
+
+		lastPrintedUserLines := 0
 
 		for {
 			out, _ := exec.CommandContext(g2Ctx,
@@ -604,8 +606,12 @@ spec:
 				"-o", "custom-columns=NAME:.metadata.name,READY:.status.conditions[0].status",
 			).Output()
 
+			type userStat struct {
+				name  string
+				ready bool
+			}
+			var users []userStat
 			total, ready := 0, 0
-			var pending []string
 			for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 				if line == "" {
 					continue
@@ -615,12 +621,16 @@ spec:
 					continue
 				}
 				total++
-				if len(fields) >= 2 && fields[1] == "True" {
+				isReady := len(fields) >= 2 && fields[1] == "True"
+				if isReady {
 					ready++
-				} else {
-					pending = append(pending, fields[0])
 				}
+				users = append(users, userStat{name: fields[0], ready: isReady})
 			}
+			
+			sort.Slice(users, func(i, j int) bool {
+				return users[i].name < users[j].name
+			})
 
 			elapsed := time.Since(start)
 			remaining := time.Until(userDeadline)
@@ -632,55 +642,86 @@ spec:
 			isCancelled := g2Ctx.Err() != nil
 			failed := isTimedOut || isCancelled
 
+			if lastPrintedUserLines > 0 {
+				fmt.Printf("\033[%dA", lastPrintedUserLines)
+			}
+			
+			renderUsers := func(finalFailed bool) int {
+				lines := 0
+				if len(users) == 0 {
+					fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s", dim("Waiting for KafkaUsers to be applied...")), 58))
+					lines++
+					return lines
+				}
+				for _, u := range users {
+					namePadded := fmt.Sprintf("%-18s", u.name)
+					if len(namePadded) > 18 {
+						namePadded = namePadded[:15] + "..."
+					}
+					
+					statusStr := dim("⏳ provisioning")
+					progress := 0
+					if u.ready {
+						statusStr = blue("✔ ready")
+						progress = 1
+					} else if finalFailed {
+						statusStr = red("✖ failed")
+						if isTimedOut {
+							statusStr = red("✖ timed out")
+						}
+					}
+					
+					fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
+						dim(namePadded),
+						renderProgressBar(progress, 1, 15, finalFailed && !u.ready),
+						fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", progress, 1)),
+						statusStr), 58))
+					lines++
+				}
+				return lines
+			}
+
 			if total > 0 && ready == total {
 				// Final success UI
-				fmt.Printf("    %s  %s  [%s]  %s  %s\n",
-					dim("│"), dim("KafkaUsers  "),
-					renderProgressBar(ready, total, 15, false),
-					blue(fmt.Sprintf("%d/%d", ready, total)),
-					blue("✔ ready"))
-				fmt.Printf("    %s  %s  [%s]  %s / %s\n",
-					dim("│"), dim("Timeout     "),
+				renderUsers(false)
+				fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s / %s",
+					dim(fmt.Sprintf("%-18s", "Timeout")),
 					renderProgressBar(int(elapsed.Seconds()), int(userTimeout.Seconds()), 15, false),
-					blue(fmtElapsed(int(elapsed.Seconds()))), blue(fmtElapsed(int(userTimeout.Seconds()))))
-				fmt.Printf("    %s\n", dim("╰──────────────────────────────────────────────────────────╯"))
-				fmt.Printf("    %s All %d KafkaUser credentials ready  %s %s\n\n",
+					blue(fmtElapsed(int(elapsed.Seconds()))), blue(fmtElapsed(int(userTimeout.Seconds())))), 58))
+				fmt.Printf("    %s\033[K\n", boxBottom(58))
+				fmt.Printf("    %s All %d KafkaUser credentials ready  %s %s\033[K\n\n",
 					green("✔"), total, dim("elapsed"), bold(fmtElapsed(int(elapsed.Seconds()))))
 				break
 			}
 
-			// Render active progress
-			userStatus := "⏳ provisioning"
-			if len(pending) > 0 {
-				userStatus = fmt.Sprintf("⏳ wait: %s", strings.Join(pending, ", "))
-			}
-
-			fmt.Printf("    %s  %s  [%s]  %s  %s\n",
-				dim("│"), dim("KafkaUsers  "),
-				renderProgressBar(ready, total, 15, failed),
-				fmt.Sprintf("%d/%d", ready, total),
-				dim(userStatus))
-
-			fmt.Printf("    %s  %s  [%s]  %s / %s\n",
-				dim("│"), dim("Timeout     "),
-				renderProgressBar(int(elapsed.Seconds()), int(userTimeout.Seconds()), 15, failed),
-				fmtElapsed(int(elapsed.Seconds())), fmtElapsed(int(userTimeout.Seconds())))
-			fmt.Printf("    %s\n", dim("│"))
-
 			if isTimedOut {
 				// Show final failed state
-				fmt.Printf("    %s  %s  [%s]  %s  %s\n",
-					dim("│"), dim("KafkaUsers  "),
-					renderProgressBar(ready, total, 15, true),
-					red(fmt.Sprintf("%d/%d", ready, total)),
-					red("✖ timed out"))
-				fmt.Printf("    %s  %s  [%s]  %s / %s\n",
-					dim("│"), dim("Timeout     "),
+				renderUsers(true)
+				fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s / %s",
+					dim(fmt.Sprintf("%-18s", "Timeout")),
 					renderProgressBar(int(userTimeout.Seconds()), int(userTimeout.Seconds()), 15, true),
-					red(fmtElapsed(int(userTimeout.Seconds()))), red(fmtElapsed(int(userTimeout.Seconds()))))
-				fmt.Printf("    %s\n", dim("╰──────────────────────────────────────────────────────────╯"))
+					red(fmtElapsed(int(userTimeout.Seconds()))), red(fmtElapsed(int(userTimeout.Seconds())))), 58))
+				fmt.Printf("    %s\033[K\n", boxBottom(58))
 				break
 			}
+
+			// Render active progress
+			lines := renderUsers(failed)
+			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s / %s",
+				dim(fmt.Sprintf("%-18s", "Timeout")),
+				renderProgressBar(int(elapsed.Seconds()), int(userTimeout.Seconds()), 15, failed),
+				fmtElapsed(int(elapsed.Seconds())), fmtElapsed(int(userTimeout.Seconds()))), 58))
+			lines++
+			fmt.Printf("    %s\033[K\n", boxBottom(58))
+			lines++
+
+			if lastPrintedUserLines > lines {
+				for i := lines; i < lastPrintedUserLines; i++ {
+					fmt.Printf("\033[K\n")
+				}
+				fmt.Printf("\033[%dA", lastPrintedUserLines-lines)
+			}
+			lastPrintedUserLines = lines
 
 			select {
 			case <-g2Ctx.Done():
@@ -721,7 +762,7 @@ spec:
 	// Deploy Schema Registry (if requested)
 	if deployWithSchemaRegistry == "apicurio" {
 		if !isHelmReleaseDeployedFn(ctx, "apicurio", kafkaNS) {
-			fmt.Printf("\n🚀 Deploying Apicurio Schema Registry (Namespace: %s)...\n", kafkaNS)
+			fmt.Printf("\n📦 Deploying Apicurio Schema Registry (Namespace: %s)...\n", kafkaNS)
 			if err := runHelmFn(ctx, "upgrade", "--install", "apicurio", "charts/apicurio-registry", "-n", kafkaNS, "--create-namespace", "--timeout", "5m"); err != nil {
 				return err
 			}
@@ -732,7 +773,7 @@ spec:
 	
 	// Deploy Kates
 	if !isHelmReleaseDeployedFn(ctx, "kates", appNS) {
-		fmt.Printf("\n🚀 Deploying Kates Backend (Namespace: %s)...\n", appNS)
+		fmt.Printf("\n📦 Deploying Kates Backend (Namespace: %s)...\n", appNS)
 		
 		// Auto-cleanup stale ClusterRole ownership from previous topology switches
 		cleanupStaleClusterResource(ctx, "clusterrole", "kates", appNS)
@@ -784,7 +825,7 @@ data:
 	// Deploy Chaos
 	if deployWithChaos {
 		if !isHelmReleaseDeployedFn(ctx, "chaos", chaosNS) {
-			fmt.Printf("\n🚀 Deploying Litmus Chaos (Namespace: %s)...\n", chaosNS)
+			fmt.Printf("\n📦 Deploying Litmus Chaos (Namespace: %s)...\n", chaosNS)
 			cleanupStaleClusterResource(ctx, "clusterrole", "litmus", chaosNS)
 			cleanupStaleClusterResource(ctx, "clusterrolebinding", "litmus", chaosNS)
 			runHelmFn(ctx, "dependency", "update", "charts/kates-chaos")
@@ -816,12 +857,12 @@ data:
 	}
 	entries = append(entries, DeploySummaryEntry{Icon: "📨", Name: "Kafka (krafter)", Release: "krafter", Namespace: kafkaNS, Group: "B"})
 	if deployWithMonitoring {
-		entries = append(entries, DeploySummaryEntry{Icon: "📊", Name: "Monitoring (Prometheus + Grafana)", Release: "monitoring", Namespace: jaegerNS, Group: "B"})
+		entries = append(entries, DeploySummaryEntry{Icon: "📊", Name: "Monitoring Stack", Release: "monitoring", Namespace: jaegerNS, Group: "B"})
 	}
 	if deployWithSchemaRegistry == "apicurio" {
 		entries = append(entries, DeploySummaryEntry{Icon: "📋", Name: "Apicurio Registry", Release: "apicurio", Namespace: kafkaNS, Group: "C"})
 	}
-	entries = append(entries, DeploySummaryEntry{Icon: "🚀", Name: "Kates Backend", Release: "kates", Namespace: appNS, Group: "C"})
+	entries = append(entries, DeploySummaryEntry{Icon: "📦", Name: "Kates Backend", Release: "kates", Namespace: appNS, Group: "C"})
 	if deployWithChaos {
 		entries = append(entries, DeploySummaryEntry{Icon: "🧪", Name: "Litmus Chaos", Release: "chaos", Namespace: chaosNS, Group: "C"})
 	}

--- a/cli/cmd/deploy_view.go
+++ b/cli/cmd/deploy_view.go
@@ -104,27 +104,36 @@ func getComponentStatus(ctx context.Context, release, namespace string) string {
 }
 
 func printRow(icon, name, namespace, status string) {
-	// Column widths (in terminal cells).
-	const nameColWidth = 22
-	const nsColWidth = 22
-	const statusColWidth = 12
+	// Total combined visual width for icon + name + namespace before the status column starts.
+	// This ensures the status column perfectly aligns for all rows.
+	const targetWidth = 44
 
-	// Build icon+name string and pad to fixed visual width.
-	// Emojis are typically 2 cells wide, so we account for that.
 	raw := icon + " " + name
-	visualLen := visualWidth(raw)
-	pad := ""
-	if visualLen < nameColWidth {
-		pad = strings.Repeat(" ", nameColWidth-visualLen)
+	visualLen := runewidth.StringWidth(raw)
+	
+	// Minimum padding between name and namespace
+	padLen := 26 - visualLen
+	if padLen < 1 {
+		padLen = 1
 	}
+	pad := strings.Repeat(" ", padLen)
 
-	// Namespace column, padded.
-	nsPad := ""
-	if len(namespace) < nsColWidth {
-		nsPad = strings.Repeat(" ", nsColWidth-len(namespace))
+	nameCol := lipgloss.NewStyle().Bold(true).Foreground(clrText).Render(raw) + pad
+	
+	// Calculate the actual visual width consumed so far
+	consumedWidth := visualLen + padLen
+	
+	// How much space is left for the namespace column padding
+	nsVisualLen := runewidth.StringWidth(namespace)
+	nsPadLen := targetWidth - consumedWidth - nsVisualLen
+	if nsPadLen < 1 {
+		nsPadLen = 1
 	}
+	nsPad := strings.Repeat(" ", nsPadLen)
 
-	// Status column.
+	nsCol := lipgloss.NewStyle().Foreground(clrDim).Render(namespace) + nsPad
+
+	// Status column
 	var statusStr string
 	switch status {
 	case "ready":
@@ -134,9 +143,6 @@ func printRow(icon, name, namespace, status string) {
 	default:
 		statusStr = lipgloss.NewStyle().Foreground(clrOrange).Render("⏭ Skipped")
 	}
-
-	nameCol := lipgloss.NewStyle().Bold(true).Foreground(clrText).Render(raw) + pad
-	nsCol := lipgloss.NewStyle().Foreground(clrDim).Render(namespace) + nsPad
 
 	fmt.Printf("  %s%s%s\n", nameCol, nsCol, statusStr)
 }

--- a/cli/cmd/kafka_wait.go
+++ b/cli/cmd/kafka_wait.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
 	"time"
+
+	"github.com/mattn/go-runewidth"
 )
 
 // ── ANSI color helpers ───────────────────────────────────────────────────────
@@ -101,6 +104,36 @@ func pollKafkaPods(ctx context.Context, namespace string) kafkaPodStatus {
 
 // ── Progress Bar & Display Helpers ──────────────────────────────────────────
 
+var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func stripANSI(s string) string {
+	return ansiRe.ReplaceAllString(s, "")
+}
+
+// boxTop returns the top border of a box.
+func boxTop(title string, insideWidth int) string {
+	visibleLen := runewidth.StringWidth(stripANSI(title))
+	dashes := insideWidth - visibleLen - 1
+	if dashes < 0 {
+		dashes = 0
+	}
+	return dim("╭─") + title + dim(strings.Repeat("─", dashes) + "╮")
+}
+
+// boxBottom returns the bottom border of a box.
+func boxBottom(insideWidth int) string {
+	return dim("╰" + strings.Repeat("─", insideWidth) + "╯")
+}
+
+// boxRow pads the content to insideWidth and wraps it in left and right borders.
+func boxRow(content string, insideWidth int) string {
+	visibleLen := runewidth.StringWidth(stripANSI(content))
+	if visibleLen < insideWidth {
+		return dim("│") + content + strings.Repeat(" ", insideWidth-visibleLen) + dim("│")
+	}
+	return dim("│") + content + dim("│")
+}
+
 const (
 	charFilled   = "▰"
 	charUnfilled = "▱"
@@ -175,11 +208,11 @@ func waitKafkaReady(ctx context.Context, namespace string, timeout time.Duration
 	deadline := time.Now().Add(timeout)
 	poll := 6 * time.Second
 	elapsed := 0
-	hintShown := false
 	totalSecs := int(timeout.Seconds())
 
-	fmt.Printf("\n    %s Kafka Cluster  %s %s\n",
-		dim("╭─"), bold(fmt.Sprintf("(%s timeout)", fmtRemaining(timeout))), dim("─────────────────────────╮"))
+	fmt.Printf("\n    %s\n", boxTop(fmt.Sprintf(" Kafka Cluster  %s ", bold(fmt.Sprintf("(%s timeout)", fmtRemaining(timeout)))), 58))
+
+	lastPrintedLines := 0
 
 	for {
 		// ── 1. Kafka CR condition ──────────────────────────────────────────────
@@ -213,26 +246,30 @@ func waitKafkaReady(ctx context.Context, namespace string, timeout time.Duration
 		isCancelled := ctx.Err() != nil
 		failed := isTimedOut || isCancelled
 
+		if lastPrintedLines > 0 {
+			fmt.Printf("\033[%dA", lastPrintedLines)
+		}
+
 		if crReady && allBrokersUp && allCtrlUp {
 			// Final success block
-			fmt.Printf("    %s  %s  [%s]  %s  %s\n",
-				dim("│"), dim("Brokers     "),
+			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
+				dim("Brokers     "),
 				renderProgressBar(pods.brokerRunning, pods.brokerTotal, 15, false),
-				blue(fmt.Sprintf("%d/%d", pods.brokerRunning, pods.brokerTotal)),
-				blue("✔ running"))
-			fmt.Printf("    %s  %s  [%s]  %s  %s\n",
-				dim("│"), dim("Controllers "),
+				blue(fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", pods.brokerRunning, pods.brokerTotal))),
+				blue("✔ running")), 58))
+			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
+				dim("Controllers "),
 				renderProgressBar(pods.ctrlRunning, pods.ctrlTotal, 15, false),
-				blue(fmt.Sprintf("%d/%d", pods.ctrlRunning, pods.ctrlTotal)),
-				blue("✔ running"))
-			fmt.Printf("    %s  %s  [%s]  %s / %s\n",
-				dim("│"), dim("Timeout     "),
+				blue(fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", pods.ctrlRunning, pods.ctrlTotal))),
+				blue("✔ running")), 58))
+			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s / %s",
+				dim("Timeout     "),
 				renderProgressBar(totalSecs, totalSecs, 15, false),
-				blue(fmtElapsed(elapsed)), blue(fmtElapsed(totalSecs)))
-			fmt.Printf("    %s  %s  %s\n", dim("│"), dim("Entity Op   "), eoIcon)
-			fmt.Printf("    %s  %s  %s\n", dim("│"), dim("CR status   "), blue("✔ Ready=True"))
-			fmt.Printf("    %s\n", dim("╰──────────────────────────────────────────────────────────╯"))
-			fmt.Printf("    %s Kafka ready  %s %s\n\n",
+				blue(fmtElapsed(elapsed)), blue(fmtElapsed(totalSecs))), 58))
+			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  %s", dim("Entity Op   "), eoIcon), 58))
+			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  %s", dim("CR status   "), blue("✔ Ready=True")), 58))
+			fmt.Printf("    %s\033[K\n", boxBottom(58))
+			fmt.Printf("    %s Kafka ready  %s %s\033[K\n\n",
 				green("✔"), dim("elapsed"), bold(fmtElapsed(elapsed)))
 			return nil
 		}
@@ -243,30 +280,48 @@ func waitKafkaReady(ctx context.Context, namespace string, timeout time.Duration
 			remaining = 0
 		}
 		
-		fmt.Printf("    %s  %s  [%s]  %s  %s\n",
-			dim("│"), dim("Brokers     "),
+		lines := 0
+		fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
+			dim("Brokers     "),
 			renderProgressBar(pods.brokerRunning, pods.brokerTotal, 15, failed),
-			fmt.Sprintf("%d/%d", pods.brokerRunning, pods.brokerTotal),
-			podPhaseLabel(pods.brokerRunning, pods.brokerTotal))
-		fmt.Printf("    %s  %s  [%s]  %s  %s\n",
-			dim("│"), dim("Controllers "),
+			fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", pods.brokerRunning, pods.brokerTotal)),
+			podPhaseLabel(pods.brokerRunning, pods.brokerTotal)), 58))
+		lines++
+		fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
+			dim("Controllers "),
 			renderProgressBar(pods.ctrlRunning, pods.ctrlTotal, 15, failed),
-			fmt.Sprintf("%d/%d", pods.ctrlRunning, pods.ctrlTotal),
-			podPhaseLabel(pods.ctrlRunning, pods.ctrlTotal))
-		fmt.Printf("    %s  %s  [%s]  %s / %s\n",
-			dim("│"), dim("Timeout     "),
+			fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", pods.ctrlRunning, pods.ctrlTotal)),
+			podPhaseLabel(pods.ctrlRunning, pods.ctrlTotal)), 58))
+		lines++
+		fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s / %s",
+			dim("Timeout     "),
 			renderProgressBar(elapsed, totalSecs, 15, failed),
-			fmtElapsed(elapsed), fmtElapsed(totalSecs))
-		fmt.Printf("    %s  %s  %s\n",
-			dim("│"), dim("Entity Op   "), eoIcon)
-		fmt.Printf("    %s\n", dim("│"))
+			fmtElapsed(elapsed), fmtElapsed(totalSecs)), 58))
+		lines++
+		fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  %s",
+			dim("Entity Op   "), eoIcon), 58))
+		lines++
 
-		// ── 6. Pending pods hint (once, after 30 s) ────────────────────────────
-		if !hintShown && elapsed >= 30 && len(pods.pendingPods) > 0 {
-			hintShown = true
-			fmt.Printf("    %s  %s\n", dim("│"), amber(fmt.Sprintf("⚠  %d pod(s) Pending — diagnose with:", len(pods.pendingPods))))
-			fmt.Printf("    %s     %s\n", dim("│"), dim(fmt.Sprintf("kubectl describe pod %s -n %s", pods.pendingPods[0], namespace)))
-			fmt.Printf("    %s\n", dim("│"))
+		// ── 6. Pending pods hint (after 30 s) ────────────────────────────
+		if elapsed >= 30 && len(pods.pendingPods) > 0 {
+			fmt.Printf("    %s\033[K\n", boxRow("", 58))
+			lines++
+			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s", amber(fmt.Sprintf("⚠  %d pod(s) Pending — diagnose with:", len(pods.pendingPods)))), 58))
+			lines++
+			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf("    %s", dim(fmt.Sprintf("kubectl describe pod %s -n %s", pods.pendingPods[0], namespace))), 58))
+			lines++
+		}
+
+		// Always print the bottom border of the box
+		fmt.Printf("    %s\033[K\n", boxBottom(58))
+		lines++
+		
+		// Clear any leftover lines from a previous taller frame
+		if lastPrintedLines > lines {
+			for i := lines; i < lastPrintedLines; i++ {
+				fmt.Printf("\033[K\n")
+			}
+			fmt.Printf("\033[%dA", lastPrintedLines-lines)
 		}
 
 		// ── 6b. Early exit on unrecoverable storage errors ────────────────────
@@ -277,22 +332,22 @@ func waitKafkaReady(ctx context.Context, namespace string, timeout time.Duration
 				"--no-headers", "-o", "custom-columns=MSG:.message",
 			).Output()
 			if strings.Contains(string(evOut), "unbound immediate PersistentVolumeClaims") {
-				// Show final failed state
-				fmt.Printf("    %s  %s  [%s]  %s  %s\n",
-					dim("│"), dim("Brokers     "),
+				fmt.Printf("\033[%dA", lines) // Re-render in place
+				fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
+					dim("Brokers     "),
 					renderProgressBar(pods.brokerRunning, pods.brokerTotal, 15, true),
-					red(fmt.Sprintf("%d/%d", pods.brokerRunning, pods.brokerTotal)),
-					red("✖ failed"))
-				fmt.Printf("    %s  %s  [%s]  %s  %s\n",
-					dim("│"), dim("Controllers "),
+					red(fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", pods.brokerRunning, pods.brokerTotal))),
+					red("✖ failed")), 58))
+				fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
+					dim("Controllers "),
 					renderProgressBar(pods.ctrlRunning, pods.ctrlTotal, 15, true),
-					red(fmt.Sprintf("%d/%d", pods.ctrlRunning, pods.ctrlTotal)),
-					red("✖ failed"))
-				fmt.Printf("    %s  %s  [%s]  %s / %s\n",
-					dim("│"), dim("Timeout     "),
+					red(fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", pods.ctrlRunning, pods.ctrlTotal))),
+					red("✖ failed")), 58))
+				fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s / %s",
+					dim("Timeout     "),
 					renderProgressBar(elapsed, totalSecs, 15, true),
-					red(fmtElapsed(elapsed)), red(fmtElapsed(totalSecs)))
-				fmt.Printf("    %s\n", dim("╰──────────────────────────────────────────────────────────╯"))
+					red(fmtElapsed(elapsed)), red(fmtElapsed(totalSecs))), 58))
+				fmt.Printf("    %s\033[K\n", boxBottom(58))
 				return fmt.Errorf(
 					"pods stuck Pending: PVCs unbound (StorageClass likely using Immediate mode — check kind_storage.go)\n" +
 					"Fix: kubectl delete pvc -n %s --all && kubectl delete kafka/krafter -n %s --ignore-not-found",
@@ -303,22 +358,22 @@ func waitKafkaReady(ctx context.Context, namespace string, timeout time.Duration
 
 		// ── 7. Timeout ─────────────────────────────────────────────────────────
 		if time.Now().After(deadline) {
-			// Show final failed state
-			fmt.Printf("    %s  %s  [%s]  %s  %s\n",
-				dim("│"), dim("Brokers     "),
+			fmt.Printf("\033[%dA", lines) // Re-render in place
+			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
+				dim("Brokers     "),
 				renderProgressBar(pods.brokerRunning, pods.brokerTotal, 15, true),
-				red(fmt.Sprintf("%d/%d", pods.brokerRunning, pods.brokerTotal)),
-				red("✖ timed out"))
-			fmt.Printf("    %s  %s  [%s]  %s  %s\n",
-				dim("│"), dim("Controllers "),
+				red(fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", pods.brokerRunning, pods.brokerTotal))),
+				red("✖ timed out")), 58))
+			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
+				dim("Controllers "),
 				renderProgressBar(pods.ctrlRunning, pods.ctrlTotal, 15, true),
-				red(fmt.Sprintf("%d/%d", pods.ctrlRunning, pods.ctrlTotal)),
-				red("✖ timed out"))
-			fmt.Printf("    %s  %s  [%s]  %s / %s\n",
-				dim("│"), dim("Timeout     "),
+				red(fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", pods.ctrlRunning, pods.ctrlTotal))),
+				red("✖ timed out")), 58))
+			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s / %s",
+				dim("Timeout     "),
 				renderProgressBar(totalSecs, totalSecs, 15, true),
-				red(fmtElapsed(totalSecs)), red(fmtElapsed(totalSecs)))
-			fmt.Printf("    %s\n", dim("╰──────────────────────────────────────────────────────────╯"))
+				red(fmtElapsed(totalSecs)), red(fmtElapsed(totalSecs))), 58))
+			fmt.Printf("    %s\033[K\n", boxBottom(58))
 			return fmt.Errorf("%s kafka not ready after %s (brokers:%d/%d controllers:%d/%d pending:%d)",
 				red("✖"),
 				timeout,
@@ -326,6 +381,8 @@ func waitKafkaReady(ctx context.Context, namespace string, timeout time.Duration
 				pods.ctrlRunning, pods.ctrlTotal,
 				len(pods.pendingPods))
 		}
+
+		lastPrintedLines = lines
 
 		// ── 8. Wait ────────────────────────────────────────────────────────────
 		select {

--- a/cli/pkg/detect/collector.go
+++ b/cli/pkg/detect/collector.go
@@ -609,6 +609,17 @@ func (c *Collector) getStrimziStatus() StrimziInfo {
 				if strings.Contains(lineLower, "warn") || strings.Contains(lineLower, "error") || 
 					strings.Contains(lineLower, "exception") || strings.Contains(lineLower, "denied") || 
 					strings.Contains(lineLower, "leader election") || strings.Contains(lineLower, "permission") {
+					
+					// Ignore known harmless Strimzi warnings
+					if strings.Contains(lineLower, "platformfeaturesavailability") ||
+						strings.Contains(lineLower, "meterregistry") ||
+						strings.Contains(lineLower, "route.openshift.io") ||
+						strings.Contains(lineLower, "build.openshift.io") ||
+						strings.Contains(lineLower, "image.openshift.io") ||
+						strings.Contains(lineLower, "the gauge registration will be ignored") {
+						continue
+					}
+
 					warningLogs = append(warningLogs, line)
 					if len(warningLogs) >= 10 {
 						break
@@ -1301,6 +1312,8 @@ func (c *Collector) getNetworkPolicyAudit() NetworkPolicyAudit {
 		managedBy := "manual"
 		if rel, ok := np.Metadata.Annotations["meta.helm.sh/release-name"]; ok {
 			managedBy = rel
+		} else if np.Metadata.Labels["app.kubernetes.io/managed-by"] == "strimzi-cluster-operator" || np.Metadata.Labels["strimzi.io/cluster"] != "" || np.Metadata.Labels["strimzi.io/kind"] == "Kafka" {
+			managedBy = "strimzi"
 		}
 
 		npInfo := ExistingNetPol{

--- a/cli/pkg/detect/renderer_markdown.go
+++ b/cli/pkg/detect/renderer_markdown.go
@@ -325,6 +325,28 @@ func RenderMarkdown(report *DetectReport, w io.Writer) {
 			p("| %s | `%s` | %s | %d/%d | %s |", np.Name, np.PodSelector, types, np.IngressRules, np.EgressRules, np.ManagedBy)
 		}
 		p("")
+		helmCount := 0
+		strimziCount := 0
+		manualCount := 0
+		for _, np := range report.NetPolAudit.Existing {
+			if np.ManagedBy == "strimzi" {
+				strimziCount++
+			} else if np.ManagedBy != "manual" {
+				helmCount++
+			} else {
+				manualCount++
+			}
+		}
+		if helmCount > 0 {
+			p("✓ **%d policies managed by Helm**", helmCount)
+		}
+		if strimziCount > 0 {
+			p("✓ **%d policies managed by Strimzi Operator**", strimziCount)
+		}
+		if manualCount > 0 {
+			p("⚠ **%d manually-managed policies detected**", manualCount)
+		}
+		p("")
 	}
 
 	// Verdict

--- a/cli/pkg/detect/renderer_tui.go
+++ b/cli/pkg/detect/renderer_tui.go
@@ -69,7 +69,7 @@ func RenderTUI(report *DetectReport) {
 				})
 			}
 			output.Table(zHeaders, zRows)
-			if cb.WeakestZone != "" {
+			if cb.WeakestZone != "" && (cb.WeakestZoneCPU < cb.StrongestZoneCPU || cb.WeakestZoneMem < cb.StrongestZoneMem) {
 				output.Warn(fmt.Sprintf("Bottleneck zone: %s (%dm CPU, %dGi mem)", cb.WeakestZone, cb.WeakestZoneCPU, cb.WeakestZoneMem))
 			}
 		}
@@ -500,9 +500,12 @@ func RenderTUI(report *DetectReport) {
 		output.Table(npHeaders, npRows)
 
 		helmCount := 0
+		strimziCount := 0
 		manualCount := 0
 		for _, np := range report.NetPolAudit.Existing {
-			if np.ManagedBy != "manual" {
+			if np.ManagedBy == "strimzi" {
+				strimziCount++
+			} else if np.ManagedBy != "manual" {
 				helmCount++
 			} else {
 				manualCount++
@@ -510,6 +513,9 @@ func RenderTUI(report *DetectReport) {
 		}
 		if helmCount > 0 {
 			output.Success(fmt.Sprintf("%d policies managed by Helm", helmCount))
+		}
+		if strimziCount > 0 {
+			output.Success(fmt.Sprintf("%d policies managed by Strimzi Operator", strimziCount))
 		}
 		if manualCount > 0 {
 			output.Warn(fmt.Sprintf("%d manually-managed policies detected", manualCount))

--- a/cli/pkg/detect/types.go
+++ b/cli/pkg/detect/types.go
@@ -266,9 +266,11 @@ type CapacityBudget struct {
 	KafkaMem int // available × (1 - reserve)
 
 	// Per-zone bottleneck
-	WeakestZone    string
-	WeakestZoneCPU int
-	WeakestZoneMem int
+	WeakestZone      string
+	WeakestZoneCPU   int
+	WeakestZoneMem   int
+	StrongestZoneCPU int
+	StrongestZoneMem int
 
 	// Component distribution
 	ControllerCPU     int    // per-controller millicores

--- a/cli/pkg/detect/valuesgen.go
+++ b/cli/pkg/detect/valuesgen.go
@@ -114,6 +114,12 @@ func (g *ValuesGenerator) computeCapacityBudget() CapacityBudget {
 			if zoneMem < cb.WeakestZoneMem {
 				cb.WeakestZoneMem = zoneMem
 			}
+			if zoneCPU > cb.StrongestZoneCPU {
+				cb.StrongestZoneCPU = zoneCPU
+			}
+			if zoneMem > cb.StrongestZoneMem {
+				cb.StrongestZoneMem = zoneMem
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR hardens the `kates detect` and `kates deploy` CLI commands with several bug fixes and visual improvements.

### Detect Improvements
- **NetworkPolicy detection**: Correctly identify Strimzi-managed NetworkPolicies by matching the `app.kubernetes.io/managed-by=strimzi-cluster-operator` label, avoiding false "manually-managed policies" warnings.
- **Bottleneck zone**: Do not flag a zone as a bottleneck when all zones have identical resource configurations (CPU/memory).

### Deploy — Progress Box Overhaul
- **In-place redraw**: Both the Kafka Cluster and KafkaUsers progress boxes now redraw in-place using ANSI escape codes instead of spamming new lines into the terminal history.
- **Proper bounding box**: Progress boxes are fully enclosed in Unicode box-drawing characters (`╭╮│╰╯`) with a fixed inner width of 58 characters. The right border is always perfectly aligned thanks to `go-runewidth` for accurate emoji/CJK width calculations.
- **Per-user progress bars**: KafkaUsers are now rendered with individual progress bars per user (e.g. `apicurio-registry`, `kates-backend`, `kates-connect`, `litmus-chaos`), each showing their own `⏳ provisioning` → `✔ ready` state.
- **Icon update**: Replaced game-style rocket (`🚀`) icons with server-appropriate package (`📦`) icons throughout the deploy flow.

### Dashboard Alignment
- **Robust column alignment**: The deployment summary dashboard now uses a `targetWidth` algorithm that dynamically calculates padding for both the name and namespace columns, ensuring the `✔ Ready` status column starts at the exact same position on every row regardless of component name length.
- **Shortened monitoring name**: `Monitoring (Prometheus + Grafana)` → `Monitoring Stack` to prevent column overflow.

### Files Changed
- `cli/cmd/deploy.go` — Progress box rendering, icon changes, per-user KafkaUser bars
- `cli/cmd/deploy_view.go` — Dashboard alignment logic
- `cli/cmd/kafka_wait.go` — Box helpers (`boxTop`, `boxRow`, `boxBottom`), runewidth integration
- `cli/cmd/collector.go` / `analyzer.go` — NetworkPolicy and bottleneck zone fixes