### PR TITLE
feat: enhance clean process and improve lab TUI

### DIFF
--- a/cli/cmd/clean.go
+++ b/cli/cmd/clean.go
@@ -94,6 +94,7 @@ func cleanRunOutput(ctx context.Context, name string, args ...string) ([]byte, e
 }
 
 func runClean(cmd *cobra.Command, args []string) error {
+	startTime := time.Now()
 	// ── Banner ──
 	fmt.Println()
 	fmt.Println(lipgloss.NewStyle().Bold(true).Foreground(clrRed).
@@ -120,13 +121,25 @@ func runClean(cmd *cobra.Command, args []string) error {
 	_ = exec.Command("pkill", "-f", "kubectl port-forward").Run()
 	time.Sleep(500 * time.Millisecond)
 
-	// Strimzi CRD resource types that carry finalizers.
-	strimziCRDTypes := []string{
+	// Operator CRD resource types that may carry finalizers or webhooks.
+	operatorCRDTypes := []string{
+		// Strimzi
 		"kafkas.kafka.strimzi.io",
 		"kafkatopics.kafka.strimzi.io",
 		"kafkausers.kafka.strimzi.io",
 		"kafkaconnects.kafka.strimzi.io",
 		"kafkabridges.kafka.strimzi.io",
+		// Litmus Chaos
+		"chaosengines.litmuschaos.io",
+		"chaosexperiments.litmuschaos.io",
+		"chaosresults.litmuschaos.io",
+		// Cert-Manager
+		"certificates.cert-manager.io",
+		"issuers.cert-manager.io",
+		"clusterissuers.cert-manager.io",
+		// Kyverno
+		"clusterpolicies.kyverno.io",
+		"policies.kyverno.io",
 	}
 
 	// CustomResourceDefinitions (CRDs) deployed by the Kates stack.
@@ -159,6 +172,26 @@ func runClean(cmd *cobra.Command, args []string) error {
 		"scrapeconfigs.monitoring.coreos.com",
 		"servicemonitors.monitoring.coreos.com",
 		"thanosrulers.monitoring.coreos.com",
+
+		// Cert-Manager CRDs
+		"certificaterequests.cert-manager.io",
+		"certificates.cert-manager.io",
+		"challenges.acme.cert-manager.io",
+		"clusterissuers.cert-manager.io",
+		"issuers.cert-manager.io",
+		"orders.acme.cert-manager.io",
+
+		// Kyverno CRDs
+		"admissionreports.kyverno.io",
+		"backgroundscanreports.kyverno.io",
+		"clusteradmissionreports.kyverno.io",
+		"clusterbackgroundscanreports.kyverno.io",
+		"cleanuppolicies.kyverno.io",
+		"clustercleanuppolicies.kyverno.io",
+		"clusterpolicies.kyverno.io",
+		"policies.kyverno.io",
+		"policyexceptions.kyverno.io",
+		"updaterequests.kyverno.io",
 	}
 
 	var appReleases []helmRelease
@@ -325,26 +358,26 @@ func runClean(cmd *cobra.Command, args []string) error {
 	okStyle := lipgloss.NewStyle().Foreground(clrGreen).Bold(true)
 	errStyle := lipgloss.NewStyle().Foreground(clrRed)
 
-	// ── 1. Delete Strimzi CRs FIRST (while operator is still running) ──
-	// The Strimzi operator handles finalizer removal. If we delete it first,
+	// ── 1. Delete Operator CRs FIRST (while operators are still running) ──
+	// Operators handle finalizer removal. If we delete operators first,
 	// finalizers become orphaned and namespaces hang in Terminating forever.
 	fmt.Println(lipgloss.NewStyle().Foreground(clrCyan).Bold(true).
-		Render("  Step 1: Removing Strimzi custom resources..."))
-	for _, crdType := range strimziCRDTypes {
-		for _, ns := range strimziNS {
+		Render("  Step 1: Removing operator custom resources..."))
+	for _, crdType := range operatorCRDTypes {
+		for _, ns := range managedNamespaces {
 			dCtx, dCancel := context.WithTimeout(ctx, 30*time.Second)
 			cleanRun(dCtx, "kubectl", "delete", crdType, "--all", "-n", ns, "--ignore-not-found")
 			dCancel()
 		}
 	}
-	// Wait briefly for the operator to process finalizer removal.
+	// Wait briefly for operators to process finalizer removal.
 	cleanSleepFn(5 * time.Second)
 
 	// ── 2. Strip orphaned finalizers on any remaining stuck resources ──
 	fmt.Println(lipgloss.NewStyle().Foreground(clrCyan).Bold(true).
 		Render("  Step 2: Stripping orphaned finalizers..."))
-	for _, crdType := range strimziCRDTypes {
-		for _, ns := range strimziNS {
+	for _, crdType := range operatorCRDTypes {
+		for _, ns := range managedNamespaces {
 			pCtx, pCancel := context.WithTimeout(ctx, 10*time.Second)
 			// Get any remaining resources and patch their finalizers to empty
 			out, _ := cleanRunOutput(pCtx, "kubectl", "get", crdType, "-n", ns, "-o", "jsonpath={.items[*].metadata.name}")
@@ -429,8 +462,11 @@ func runClean(cmd *cobra.Command, args []string) error {
 
 	// ── Done ──
 	fmt.Println()
+	
+	elapsed := time.Since(startTime).Round(time.Second)
+	
 	fmt.Println(lipgloss.NewStyle().Bold(true).Foreground(clrGreen).
-		Render("  ✅ Cluster cleaned successfully."))
+		Render(fmt.Sprintf("  ✅ Cluster cleaned successfully in %s.", elapsed)))
 	fmt.Println()
 	return nil
 }

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -659,7 +659,7 @@ spec:
 						namePadded = namePadded[:15] + "..."
 					}
 					
-					statusStr := dim("⏳ provisioning")
+					statusStr := dim("⏳ pending")
 					progress := 0
 					if u.ready {
 						statusStr = blue("✔ ready")

--- a/cli/tui/lab.go
+++ b/cli/tui/lab.go
@@ -26,6 +26,7 @@ type labIteration struct {
 	Number     int
 	Throughput float64
 	P99Ms      float64
+	AvgMs      float64
 	ErrorRate  float64
 	TestID     string
 	Delta      string
@@ -115,8 +116,9 @@ type LabModel struct {
 }
 
 type labTestDoneMsg struct {
-	run *client.TestRun
-	err error
+	run     *client.TestRun
+	summary *client.ReportSummary
+	err     error
 }
 
 type labTickMsg struct{}
@@ -347,7 +349,7 @@ func (m LabModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.medianActive = false
 			return m, nil
 		}
-		iter := m.buildIteration(msg.run)
+		iter := m.buildIteration(msg.run, msg.summary)
 
 		// Warmup: discard this iteration silently
 		if m.warmupRemaining > 0 {
@@ -629,6 +631,11 @@ func (m LabModel) viewParams(width int) string {
 		}
 	}
 
+	if len(m.iterations) > 0 {
+		last := m.iterations[len(m.iterations)-1]
+		b.WriteString("\n" + m.latencyHistogram(last.P99Ms, width))
+	}
+
 	return b.String()
 }
 
@@ -676,30 +683,35 @@ func (m LabModel) viewResults(width int) string {
 	b.WriteString(detailTitleStyle.Render("Iteration History") + "\n\n")
 
 	numW := 4
-	deltaW := 8
-	remaining := width - numW - deltaW - 6
-	if remaining < 20 {
-		remaining = 20
-	}
-	thrW := remaining * 40 / 100
-	p99W := remaining * 30 / 100
-	errW := remaining - thrW - p99W
+	gap := "  " // 2-space gap between columns
+	showErr := width >= 60
 
-	showErr := width >= 50
+	// Fixed column widths — generous enough for typical values
+	thrW := 16 // e.g. "122.9K rec/s"
+	p99W := 10 // e.g. "0.01ms"
+	errPctW := 10 // e.g. "0.0000%"
+	deltaW := 8  // e.g. "▲133%"
 
 	if showErr {
-		b.WriteString(fmt.Sprintf("  %s%s%s%s%s\n",
+		b.WriteString(fmt.Sprintf("  %s%s%s%s%s%s%s%s%s\n",
 			dimStyle.Render(padRight("#", numW)),
+			gap,
 			dimStyle.Render(padRight("Throughput", thrW)),
+			gap,
 			dimStyle.Render(padRight("P99", p99W)),
-			dimStyle.Render(padRight("Err", errW)),
+			gap,
+			dimStyle.Render(padRight("Err %", errPctW)),
+			gap,
 			dimStyle.Render(padRight("Δ", deltaW)),
 		))
 	} else {
-		b.WriteString(fmt.Sprintf("  %s%s%s%s\n",
+		b.WriteString(fmt.Sprintf("  %s%s%s%s%s%s%s\n",
 			dimStyle.Render(padRight("#", numW)),
-			dimStyle.Render(padRight("Throughput", thrW+errW)),
+			gap,
+			dimStyle.Render(padRight("Throughput", thrW)),
+			gap,
 			dimStyle.Render(padRight("P99", p99W)),
+			gap,
 			dimStyle.Render(padRight("Δ", deltaW)),
 		))
 	}
@@ -735,21 +747,28 @@ func (m LabModel) viewResults(width int) string {
 		if showErr {
 			thrStr := padRight(fmtLabNum(iter.Throughput)+" rec/s", thrW)
 			p99Str := padRight(fmtLabFloat(iter.P99Ms)+"ms", p99W)
-			errStr := padRight(fmtLabFloat(iter.ErrorRate), errW)
-			b.WriteString(fmt.Sprintf("  %s%s%s%s%s\n",
+			errPctStr := padRight(fmt.Sprintf("%.4f%%", iter.ErrorRate), errPctW)
+			b.WriteString(fmt.Sprintf("  %s%s%s%s%s%s%s%s%s\n",
 				numStr,
+				gap,
 				healthyStyle.Render(thrStr),
+				gap,
 				warnStyle.Render(p99Str),
-				dimStyle.Render(errStr),
+				gap,
+				dimStyle.Render(errPctStr),
+				gap,
 				delta,
 			))
 		} else {
-			thrStr := padRight(fmtLabNum(iter.Throughput), thrW+errW)
-			p99Str := padRight(fmtLabFloat(iter.P99Ms), p99W)
-			b.WriteString(fmt.Sprintf("  %s%s%s%s\n",
+			thrStr := padRight(fmtLabNum(iter.Throughput)+" rec/s", thrW)
+			p99Str := padRight(fmtLabFloat(iter.P99Ms)+"ms", p99W)
+			b.WriteString(fmt.Sprintf("  %s%s%s%s%s%s%s\n",
 				numStr,
+				gap,
 				healthyStyle.Render(thrStr),
+				gap,
 				warnStyle.Render(p99Str),
+				gap,
 				delta,
 			))
 		}
@@ -759,11 +778,6 @@ func (m LabModel) viewResults(width int) string {
 		b.WriteString("\n")
 		b.WriteString("  " + dimStyle.Render("Throughput: ") + sparkline(extractMetric(m.iterations, func(i labIteration) float64 { return i.Throughput })) + "\n")
 		b.WriteString("  " + dimStyle.Render("P99 ms:     ") + sparkline(extractMetric(m.iterations, func(i labIteration) float64 { return i.P99Ms })) + "\n")
-	}
-
-	if len(m.iterations) > 0 {
-		last := m.iterations[len(m.iterations)-1]
-		b.WriteString("\n" + m.latencyHistogram(last.P99Ms, width))
 	}
 
 	return b.String()
@@ -816,7 +830,7 @@ func (m LabModel) latencyHistogram(p99 float64, width int) string {
 		}
 		bar := strings.Repeat("█", barLen)
 		pctStr := fmt.Sprintf("%4.0f%%", bk.pct*100)
-		sb.WriteString(fmt.Sprintf("  %s %s %s\n",
+		sb.WriteString(fmt.Sprintf("  %s  %s  %s\n",
 			dimStyle.Render(bk.label),
 			healthyStyle.Render(bar),
 			dimStyle.Render(pctStr),
@@ -1057,13 +1071,14 @@ func (m LabModel) pollTest(testID string, records int) tea.Msg {
 
 		status := strings.ToUpper(updated.Status)
 		if status == "DONE" || status == "COMPLETED" || status == "FAILED" || status == "ERROR" {
-			return labTestDoneMsg{run: updated}
+			summary, _ := m.client.ReportSummary(context.Background(), testID)
+			return labTestDoneMsg{run: updated, summary: summary}
 		}
 	}
 	return labTestDoneMsg{err: fmt.Errorf("test timed out after %s", maxWait.Truncate(time.Minute))}
 }
 
-func (m *LabModel) buildIteration(run *client.TestRun) labIteration {
+func (m *LabModel) buildIteration(run *client.TestRun, summary *client.ReportSummary) labIteration {
 	iter := labIteration{
 		Number: len(m.iterations) + 1,
 		TestID: truncID(run.ID),
@@ -1077,7 +1092,10 @@ func (m *LabModel) buildIteration(run *client.TestRun) labIteration {
 		}
 		iter.Throughput = totalThroughput / float64(len(run.Results))
 		iter.P99Ms = totalP99 / float64(len(run.Results))
-		iter.ErrorRate = run.Results[len(run.Results)-1].AvgLatencyMs
+		iter.AvgMs = run.Results[len(run.Results)-1].AvgLatencyMs
+	}
+	if summary != nil {
+		iter.ErrorRate = summary.ErrorRate * 100
 	}
 	if len(m.iterations) > 0 {
 		prev := m.iterations[len(m.iterations)-1]
@@ -1385,6 +1403,13 @@ func truncID(id string) string {
 func padRight(s string, w int) string {
 	for len(s) < w {
 		s += " "
+	}
+	return s
+}
+
+func padLeft(s string, w int) string {
+	for len(s) < w {
+		s = " " + s
 	}
 	return s
 }


### PR DESCRIPTION
## Summary

This PR enhances the `kates clean` command and improves the Lab TUI for better usability across terminals.

### Clean Process Enhancements
- Broaden finalizer stripping to include **Litmus Chaos**, **Cert-Manager**, and **Kyverno** CRDs
- Update `allCRDs` list for complete removal during clean
- Refactor `runClean` to loop through all managed namespaces
- Add execution time measurement to clean command output

### Lab TUI Improvements
- Fix table alignment with explicit 2-space column gaps (works correctly in iTerm2 and other terminals)
- Add actual **Error Rate** column sourced from the test report summary
- Remove redundant Avg ms column — table now shows: `#`, `Throughput`, `P99`, `Err %`, `Δ`
- Move **Latency Distribution** histogram below the parameters panel (left side)
- Revert histogram bars to `█` block characters for consistent terminal rendering
- Fix provisioning status string length to fit within the deploy box layout