### PR TITLE
fix(ui): align Kafka Users table and add timeout progress bar

### DIFF
--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -654,20 +654,20 @@ spec:
 					return lines
 				}
 				for _, u := range users {
-					namePadded := fmt.Sprintf("%-18s", u.name)
-					if len(namePadded) > 18 {
-						namePadded = namePadded[:15] + "..."
+					namePadded := fmt.Sprintf("%-12s", u.name)
+					if len(u.name) > 12 {
+						namePadded = u.name[:9] + "..."
 					}
 					
-					statusStr := dim("⏳ pending")
+					statusStr := red("pending")
 					progress := 0
 					if u.ready {
-						statusStr = blue("✔ ready")
+						statusStr = blue("ready")
 						progress = 1
 					} else if finalFailed {
-						statusStr = red("✖ failed")
+						statusStr = red("failed")
 						if isTimedOut {
-							statusStr = red("✖ timed out")
+							statusStr = red("timed out")
 						}
 					}
 					
@@ -681,16 +681,19 @@ spec:
 				return lines
 			}
 
+			elapsedSecs := int(elapsed.Seconds())
+			totalSecs := int(userTimeout.Seconds())
+
 			if total > 0 && ready == total {
 				// Final success UI
 				renderUsers(false)
 				fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s / %s",
-					dim(fmt.Sprintf("%-18s", "Timeout")),
-					renderProgressBar(int(elapsed.Seconds()), int(userTimeout.Seconds()), 15, false),
-					blue(fmtElapsed(int(elapsed.Seconds()))), blue(fmtElapsed(int(userTimeout.Seconds())))), 58))
+					dim(fmt.Sprintf("%-12s", "Timeout")),
+					renderProgressBar(elapsedSecs, totalSecs, 15, false),
+					blue(fmtElapsed(elapsedSecs)), blue(fmtElapsed(totalSecs))), 58))
 				fmt.Printf("    %s\033[K\n", boxBottom(58))
 				fmt.Printf("    %s All %d KafkaUser credentials ready  %s %s\033[K\n\n",
-					green("✔"), total, dim("elapsed"), bold(fmtElapsed(int(elapsed.Seconds()))))
+					green("✔"), total, dim("elapsed"), bold(fmtElapsed(elapsedSecs)))
 				break
 			}
 
@@ -698,9 +701,9 @@ spec:
 				// Show final failed state
 				renderUsers(true)
 				fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s / %s",
-					dim(fmt.Sprintf("%-18s", "Timeout")),
-					renderProgressBar(int(userTimeout.Seconds()), int(userTimeout.Seconds()), 15, true),
-					red(fmtElapsed(int(userTimeout.Seconds()))), red(fmtElapsed(int(userTimeout.Seconds())))), 58))
+					dim(fmt.Sprintf("%-12s", "Timeout")),
+					renderProgressBar(totalSecs, totalSecs, 15, true),
+					red(fmtElapsed(totalSecs)), red(fmtElapsed(totalSecs))), 58))
 				fmt.Printf("    %s\033[K\n", boxBottom(58))
 				break
 			}
@@ -708,9 +711,9 @@ spec:
 			// Render active progress
 			lines := renderUsers(failed)
 			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s / %s",
-				dim(fmt.Sprintf("%-18s", "Timeout")),
-				renderProgressBar(int(elapsed.Seconds()), int(userTimeout.Seconds()), 15, failed),
-				fmtElapsed(int(elapsed.Seconds())), fmtElapsed(int(userTimeout.Seconds()))), 58))
+				dim(fmt.Sprintf("%-12s", "Timeout")),
+				renderProgressBar(elapsedSecs, totalSecs, 15, failed),
+				fmtElapsed(elapsedSecs), fmtElapsed(totalSecs)), 58))
 			lines++
 			fmt.Printf("    %s\033[K\n", boxBottom(58))
 			lines++

--- a/cli/cmd/kafka_wait.go
+++ b/cli/cmd/kafka_wait.go
@@ -156,6 +156,9 @@ func renderProgressBar(running, total int, width int, failed bool) string {
 	if filled < 0 {
 		filled = 0
 	}
+	if running > 0 && filled == 0 {
+		filled = 1
+	}
 	if failed {
 		return red(strings.Repeat(charFilled, filled) + strings.Repeat(charUnfilled, width-filled))
 	}
@@ -264,7 +267,7 @@ func waitKafkaReady(ctx context.Context, namespace string, timeout time.Duration
 				blue("✔ running")), 58))
 			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s / %s",
 				dim("Timeout     "),
-				renderProgressBar(totalSecs, totalSecs, 15, false),
+				renderProgressBar(elapsed, totalSecs, 15, false),
 				blue(fmtElapsed(elapsed)), blue(fmtElapsed(totalSecs))), 58))
 			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  %s", dim("Entity Op   "), eoIcon), 58))
 			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  %s", dim("CR status   "), blue("✔ Ready=True")), 58))


### PR DESCRIPTION
## Summary

Fixes the Kafka Users table alignment during `kates deploy` and makes the timeout progress bar fill based on elapsed time percentage — matching the Brokers/Controllers table style.

### Changes
- **12-char padded labels** instead of 18-char — matches the Brokers/Controllers row layout
- **Text-only status indicators** (`pending`, `ready`, `failed`) — removes emoji that render at inconsistent widths across terminals (iTerm2 vs others)
- **Timeout progress bar** now shows elapsed time as a percentage of total timeout (e.g. `▰▰▰▱▱▱▱  0:30 / 5:00`) — same as the Kafka cluster table
- **Consistent column alignment** across success, failed, and in-progress states

### Before
```
apicurio-registry   [▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱]  0/1   ⏳ provisioning
```
(emoji causes misalignment in iTerm2, name column too wide)

### After
```
apicurio-re. [▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱]  0/1   pending
```
(consistent alignment, text-only status, matching Brokers/Controllers style)