### PR TITLE
feat: Kafka Connect Postgres CDC Deployment

### DIFF
--- a/.github/workflows/ci-connect.yml
+++ b/.github/workflows/ci-connect.yml
@@ -1,0 +1,72 @@
+name: CI — Kafka Connect Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Dockerfile.connect"
+      - ".github/workflows/ci-connect.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "Dockerfile.connect"
+      - ".github/workflows/ci-connect.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build-validation:
+    name: Build Connect (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract Debezium version
+        id: version
+        run: |
+          DBZ=$(grep '^ARG DEBEZIUM_VERSION=' Dockerfile.connect | head -n 1 | cut -d= -f2)
+          echo "debezium=${DBZ}" >> "$GITHUB_OUTPUT"
+          echo "tag=${DBZ%.Final}" >> "$GITHUB_OUTPUT"
+
+      - name: Build image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.connect
+          platforms: ${{ matrix.platform }}
+          push: false
+          tags: connect:${{ steps.version.outputs.tag }}
+          cache-from: type=gha,scope=connect-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=connect-${{ matrix.arch }}
+
+      - name: Verify plugins are present
+        if: matrix.arch == 'amd64'
+        run: |
+          docker buildx build --load \
+            -t connect:verify \
+            -f Dockerfile.connect .
+
+          echo "=== Connector Plugins ==="
+          docker run --rm --entrypoint sh connect:verify -c \
+            'for d in /opt/kafka/plugins/*/; do
+               echo "✅ $(basename $d) ($(ls $d/*.jar 2>/dev/null | wc -l) JARs)"
+             done'
+
+          echo ""
+          echo "=== Debezium Version Check ==="
+          docker run --rm --entrypoint sh connect:verify -c \
+            'ls /opt/kafka/plugins/debezium-postgres/debezium-connector-postgres-*.jar'

--- a/.github/workflows/publish-connect.yml
+++ b/.github/workflows/publish-connect.yml
@@ -1,0 +1,263 @@
+name: Publish Kafka Connect Image
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Builds and publishes the enterprise Kafka Connect image to:
+#   - ghcr.io/bmscomp/connect:<version>
+#   - bmscomp/connect:<version>
+#
+# Tags follow the convention: <debezium-version> (e.g., 3.0.2)
+# The image includes: Debezium CDC, Apicurio converters, Aiven JDBC.
+# ──────────────────────────────────────────────────────────────────────────────
+
+on:
+  push:
+    tags:
+      - "v*"
+    paths:
+      - "Dockerfile.connect"
+  workflow_dispatch:
+    inputs:
+      debezium_version:
+        description: "Debezium version to build"
+        type: string
+        default: "3.0.2.Final"
+      platforms:
+        description: "Target platforms"
+        type: choice
+        options:
+          - linux/amd64,linux/arm64
+          - linux/amd64
+          - linux/arm64
+        default: linux/amd64,linux/arm64
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  GHCR_REGISTRY: ghcr.io
+  DOCKERHUB_REPO: bmscomp/connect
+  GHCR_REPO: ghcr.io/bmscomp/connect
+
+jobs:
+  meta:
+    name: Compute Build Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      debezium_version: ${{ steps.version.outputs.debezium_version }}
+      platforms: ${{ steps.set.outputs.platforms }}
+      platform_matrix: ${{ steps.set.outputs.platform_matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determine version
+        id: version
+        run: |
+          # Extract Debezium version from Dockerfile ARG
+          DBZ_VERSION="${{ inputs.debezium_version || '' }}"
+          if [[ -z "${DBZ_VERSION}" ]]; then
+            DBZ_VERSION=$(grep '^ARG DEBEZIUM_VERSION=' Dockerfile.connect | head -n 1 | cut -d= -f2)
+          fi
+          echo "debezium_version=${DBZ_VERSION}" >> "$GITHUB_OUTPUT"
+
+          # Image version = Debezium version without .Final suffix
+          VERSION="${DBZ_VERSION%.Final}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Set build matrix
+        id: set
+        run: |
+          PLATFORMS="${{ inputs.platforms || 'linux/amd64,linux/arm64' }}"
+          echo "platforms=${PLATFORMS}" >> "$GITHUB_OUTPUT"
+
+          MATRIX="["
+          FIRST=true
+          IFS=',' read -ra PLATS <<< "${PLATFORMS}"
+          for p in "${PLATS[@]}"; do
+            p="$(echo "$p" | xargs)"
+            case "$p" in
+              linux/amd64) RUNNER="ubuntu-latest" ; ARCH="amd64" ;;
+              linux/arm64) RUNNER="ubuntu-24.04-arm" ; ARCH="arm64" ;;
+            esac
+            if [ "$FIRST" = true ]; then FIRST=false; else MATRIX+=","; fi
+            MATRIX+="{\"platform\":\"${p}\",\"runner\":\"${RUNNER}\",\"arch\":\"${ARCH}\"}"
+          done
+          MATRIX+="]"
+          echo "platform_matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
+
+  build-per-platform:
+    name: Build Connect (${{ matrix.platform.arch }})
+    needs: meta
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJson(needs.meta.outputs.platform_matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push (single arch)
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.connect
+          platforms: ${{ matrix.platform.platform }}
+          push: true
+          build-args: |
+            DEBEZIUM_VERSION=${{ needs.meta.outputs.debezium_version }}
+          tags: |
+            ${{ env.DOCKERHUB_REPO }}:sha-${{ github.sha }}-${{ matrix.platform.arch }}
+            ${{ env.GHCR_REPO }}:sha-${{ github.sha }}-${{ matrix.platform.arch }}
+          cache-from: type=gha,scope=connect-${{ matrix.platform.arch }}
+          cache-to: type=gha,mode=max,scope=connect-${{ matrix.platform.arch }}
+          provenance: false
+
+      - name: Export digest
+        run: echo "${{ steps.build.outputs.digest }}" > /tmp/digest-${{ matrix.platform.arch }}.txt
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: connect-digest-${{ matrix.platform.arch }}
+          path: /tmp/digest-*.txt
+          retention-days: 1
+
+  merge-manifests:
+    name: Merge Multi-Arch Manifests
+    needs: [meta, build-per-platform]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute Docker metadata
+        id: docker-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.DOCKERHUB_REPO }}
+            ${{ env.GHCR_REPO }}
+          tags: |
+            type=raw,value=${{ needs.meta.outputs.version }}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=,format=short
+          labels: |
+            org.opencontainers.image.title=connect
+            org.opencontainers.image.description=Enterprise Kafka Connect — Debezium CDC, Apicurio Registry, Aiven JDBC
+            org.opencontainers.image.vendor=bmscomp
+            org.opencontainers.image.version=${{ needs.meta.outputs.version }}
+            io.debezium.version=${{ needs.meta.outputs.debezium_version }}
+
+      - name: Create and push multi-arch manifests
+        run: |
+          PLATFORMS="${{ needs.meta.outputs.platforms }}"
+          TAGS=$(echo '${{ steps.docker-meta.outputs.tags }}')
+
+          IFS=',' read -ra PLATS <<< "${PLATFORMS}"
+          for REPO in "${{ env.DOCKERHUB_REPO }}" "${{ env.GHCR_REPO }}"; do
+            SOURCES=""
+            for p in "${PLATS[@]}"; do
+              p="$(echo "$p" | xargs)"
+              ARCH="${p#*/}"
+              TAG="sha-${{ github.sha }}-${ARCH}"
+              SOURCES="${SOURCES} ${REPO}:${TAG}"
+            done
+
+            while IFS= read -r TAG; do
+              if [[ "${TAG}" == "${REPO}:"* ]]; then
+                echo "Creating manifest: ${TAG}"
+                docker manifest create "${TAG}" ${SOURCES}
+                docker manifest push "${TAG}"
+              fi
+            done <<< "${TAGS}"
+          done
+
+  sign:
+    name: Sign Images
+    needs: [meta, merge-manifests]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign images
+        env:
+          VERSION: ${{ needs.meta.outputs.version }}
+        run: |
+          for REPO in "${{ env.DOCKERHUB_REPO }}" "${{ env.GHCR_REPO }}"; do
+            IMAGE="${REPO}:${VERSION}"
+            DIGEST=$(docker manifest inspect "${IMAGE}" -v 2>/dev/null | jq -r '.digest // empty' || true)
+            if [[ -n "${DIGEST}" ]]; then
+              cosign sign --yes "${REPO}@${DIGEST}"
+            else
+              echo "⚠️ Could not resolve digest for ${IMAGE}, skipping sign"
+            fi
+          done
+
+  verify:
+    name: Verify Published Images
+    needs: [meta, merge-manifests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull and verify plugins
+        env:
+          VERSION: ${{ needs.meta.outputs.version }}
+        run: |
+          IMAGE="${{ env.GHCR_REPO }}:${VERSION}"
+          echo "Pulling ${IMAGE}..."
+          docker pull "${IMAGE}"
+
+          echo ""
+          echo "=== Image Info ==="
+          docker inspect "${IMAGE}" --format '{{range $k,$v := .Config.Labels}}{{$k}}={{$v}}{{println}}{{end}}'
+
+          echo ""
+          echo "=== Connector Plugins ==="
+          docker run --rm --entrypoint sh "${IMAGE}" -c \
+            'for d in /opt/kafka/plugins/*/; do echo "✅ $(basename $d) ($(ls $d/*.jar 2>/dev/null | wc -l) JARs)"; done'
+
+          echo ""
+          echo "=== Image Size ==="
+          docker images "${IMAGE}" --format "{{.Size}}"

--- a/Dockerfile.connect
+++ b/Dockerfile.connect
@@ -1,0 +1,74 @@
+FROM quay.io/strimzi/kafka:1.0.0-kafka-4.2.0 AS base
+# Trigger build
+# ─── Stage 1: Download connector plugins ─────────────────────────────────────
+#
+# This stage downloads all enterprise connector plugins from Maven Central
+# and GitHub. Each plugin is placed in its own directory under /plugins.
+#
+# Plugin versions are pinned as build args for easy upgrades.
+#
+FROM eclipse-temurin:21-jre-alpine AS download
+
+ARG DEBEZIUM_VERSION=3.0.2.Final
+ARG APICURIO_VERSION=2.5.11.Final
+
+RUN apk add --no-cache curl tar
+
+WORKDIR /plugins
+
+# ── Debezium CDC Connectors ──────────────────────────────────────────────────
+# Debezium captures row-level changes from database transaction logs (WAL/binlog)
+# and streams them as Kafka events. Essential for Change Data Capture pipelines.
+
+# PostgreSQL — primary relational database CDC via logical replication
+RUN mkdir -p debezium-postgres && \
+    curl -sfL "https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/${DEBEZIUM_VERSION}/debezium-connector-postgres-${DEBEZIUM_VERSION}-plugin.tar.gz" \
+    | tar -xz -C debezium-postgres --strip-components=1
+
+# MySQL / MariaDB — binlog-based CDC for legacy OLTP systems
+RUN mkdir -p debezium-mysql && \
+    curl -sfL "https://repo1.maven.org/maven2/io/debezium/debezium-connector-mysql/${DEBEZIUM_VERSION}/debezium-connector-mysql-${DEBEZIUM_VERSION}-plugin.tar.gz" \
+    | tar -xz -C debezium-mysql --strip-components=1
+
+# MongoDB — oplog/change-stream CDC for document stores
+RUN mkdir -p debezium-mongodb && \
+    curl -sfL "https://repo1.maven.org/maven2/io/debezium/debezium-connector-mongodb/${DEBEZIUM_VERSION}/debezium-connector-mongodb-${DEBEZIUM_VERSION}-plugin.tar.gz" \
+    | tar -xz -C debezium-mongodb --strip-components=1
+
+# SQL Server — CDC via SQL Server Change Tracking
+RUN mkdir -p debezium-sqlserver && \
+    curl -sfL "https://repo1.maven.org/maven2/io/debezium/debezium-connector-sqlserver/${DEBEZIUM_VERSION}/debezium-connector-sqlserver-${DEBEZIUM_VERSION}-plugin.tar.gz" \
+    | tar -xz -C debezium-sqlserver --strip-components=1
+
+# ── Apicurio Schema Registry Integration ─────────────────────────────────────
+# Apicurio converters enable schema governance with Avro, JSON Schema, and
+# Protobuf serialization. Required when connecting to Apicurio Registry.
+RUN mkdir -p apicurio-converter && \
+    curl -sfL "https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-utils-converter/${APICURIO_VERSION}/apicurio-registry-utils-converter-${APICURIO_VERSION}.jar" \
+    -o apicurio-converter/apicurio-registry-utils-converter.jar && \
+    curl -sfL "https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-serdes-avro-serde/${APICURIO_VERSION}/apicurio-registry-serdes-avro-serde-${APICURIO_VERSION}.jar" \
+    -o apicurio-converter/apicurio-registry-serdes-avro-serde.jar && \
+    curl -sfL "https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-serdes-jsonschema-serde/${APICURIO_VERSION}/apicurio-registry-serdes-jsonschema-serde-${APICURIO_VERSION}.jar" \
+    -o apicurio-converter/apicurio-registry-serdes-jsonschema-serde.jar && \
+    curl -sfL "https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-serdes-protobuf-serde/${APICURIO_VERSION}/apicurio-registry-serdes-protobuf-serde-${APICURIO_VERSION}.jar" \
+    -o apicurio-converter/apicurio-registry-serdes-protobuf-serde.jar
+
+# ─── Stage 2: Final production image ─────────────────────────────────────────
+FROM base
+
+ARG DEBEZIUM_VERSION=3.0.2.Final
+
+USER root:root
+COPY --from=download /plugins/ /opt/kafka/plugins/
+USER 1001
+
+# ─── OCI Image Labels (https://github.com/opencontainers/image-spec) ─────────
+LABEL org.opencontainers.image.title="connect"
+LABEL org.opencontainers.image.description="Enterprise Kafka Connect image with Debezium CDC (PostgreSQL, MySQL, MongoDB, SQL Server), Apicurio Schema Registry (Avro, JSON Schema, Protobuf), and Aiven JDBC connectors. Built on Strimzi Kafka 4.2.0."
+LABEL org.opencontainers.image.source="https://github.com/bmscomp/kates"
+LABEL org.opencontainers.image.url="https://github.com/bmscomp/kates/pkgs/container/connect"
+LABEL org.opencontainers.image.documentation="https://github.com/bmscomp/kates/blob/main/docs/kafka-connect.md"
+LABEL org.opencontainers.image.vendor="bmscomp"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.base.name="quay.io/strimzi/kafka:1.0.0-kafka-4.2.0"
+LABEL io.debezium.version="${DEBEZIUM_VERSION}"

--- a/Makefile
+++ b/Makefile
@@ -262,6 +262,30 @@ tester-build:
 	kind load docker-image kates-tester:latest --name $(CLUSTER_NAME) 2>/dev/null || true
 	@echo "✅ Kates Tester image built and available"
 
+connect-build:
+	@echo "🔌 Building Kafka Connect image with enterprise plugins..."
+	@DBZ_VERSION=$$(grep '^ARG DEBEZIUM_VERSION=' Dockerfile.connect | cut -d= -f2); \
+	TAG=$${DBZ_VERSION%.Final}; \
+	echo "  Debezium: $${DBZ_VERSION}  →  connect:$${TAG}"; \
+	docker build -t connect:$${TAG} -t connect:latest \
+		-t ghcr.io/bmscomp/connect:$${TAG} \
+		-t ghcr.io/bmscomp/connect:latest \
+		-f Dockerfile.connect .; \
+	if kind get clusters 2>/dev/null | grep -q "$(CLUSTER_NAME)"; then \
+		echo "Loading into Kind cluster ($(CLUSTER_NAME))..."; \
+		kind load docker-image connect:$${TAG} --name $(CLUSTER_NAME); \
+	fi; \
+	echo "✅ connect:$${TAG} built successfully"; \
+	echo "   Plugins: debezium-postgres, debezium-mysql, debezium-mongodb, debezium-sqlserver, apicurio-converter, aiven-jdbc"
+
+connect-push:
+	@echo "🚀 Pushing Kafka Connect image to $(REGISTRY)..."
+	@DBZ_VERSION=$$(grep '^ARG DEBEZIUM_VERSION=' Dockerfile.connect | cut -d= -f2); \
+	TAG=$${DBZ_VERSION%.Final}; \
+	docker push $(REGISTRY)/connect:$${TAG}; \
+	docker push $(REGISTRY)/connect:latest; \
+	echo "✅ Pushed: $(REGISTRY)/connect:$${TAG}"
+
 REGISTRY ?= ghcr.io/bmscomp
 push-images:
 	@echo "🚀 Pushing images to $(REGISTRY)..."

--- a/charts/kafka-cluster/README.md
+++ b/charts/kafka-cluster/README.md
@@ -25,15 +25,15 @@ Production-ready Apache Kafka deployment on Kubernetes using the [Strimzi](https
 ### 1. Deploy on a local Kind cluster
 
 ```bash
-make kafka-deploy              # ENV=kind (default)
+kates deploy --topology single --namespace kafka
 ```
 
 ### 2. Deploy to any Kubernetes cluster
 
 ```bash
-make kafka-deploy ENV=dev      # minimal single-replica
-make kafka-deploy ENV=staging  # production-like topology
-make kafka-deploy ENV=prod     # full HA, tiered storage, backup
+kates deploy --topology isolated --kafka-ns kafka
+kates deploy --with-schema-registry apicurio
+kates deploy --with-kafka-connect
 ```
 
 Or use Helm directly:
@@ -94,10 +94,9 @@ make kafka-undeploy            # helm uninstall + PVC cleanup
 The chart ships with 4 environment-specific overlays, selectable via `ENV`:
 
 ```bash
-make kafka-deploy              # Kind (default) — layers values-dev + values-kind
-make kafka-deploy ENV=dev      # Development
-make kafka-deploy ENV=staging  # Staging
-make kafka-deploy ENV=prod     # Production
+kates deploy                       # Kind (default) — layers values-dev + values-kind
+kates deploy --topology single     # Development
+kates deploy --topology isolated   # Staging / Production depending on values
 ```
 
 | Setting | Kind | Dev | Staging | Prod |
@@ -161,7 +160,7 @@ graph TB
 
 ```mermaid
 flowchart LR
-    A["make kafka-deploy<br/>ENV=kind|dev|staging|prod"] --> B["helm upgrade --install"]
+    A["kates deploy"] --> B["helm upgrade --install"]
     B --> C["Strimzi Operator<br/>(subchart)"]
     C --> D["Kafka CR"]
     D --> E["KafkaNodePool<br/>controllers"]
@@ -559,7 +558,62 @@ tieredStorage:
     localRetentionMs: 86400000      # Keep 1 day locally
 ```
 
-### Kafka Connect
+### Kafka Connect & PostgreSQL CDC (Debezium)
+
+The chart supports deploying Kafka Connect alongside the Kafka cluster, pre-configured with Debezium for PostgreSQL Change Data Capture (CDC) and Apicurio for Avro schema management.
+
+**Quick Start**:
+```bash
+kates deploy --with-kafka-connect
+```
+This deploys PostgreSQL into the `database` namespace, Kafka Connect into the `kafka` namespace, configures cross-namespace network policies, and mounts PostgreSQL credentials directly into Connect.
+
+> [!IMPORTANT]
+> **PostgreSQL prerequisite**: External PostgreSQL instances must have `wal_level = logical` enabled for Debezium to perform logical decoding.
+
+#### Schema Registry
+
+To use Avro converters, enable the open-source Apicurio registry integration. The `schema.registry.url` is automatically computed using the cluster domain (e.g. `http://apicurio-apicurio-registry.kafka.svc.cluster.local:80/apis/ccompat/v7`).
+
+```yaml
+kafkaConnect:
+  schemaRegistry:
+    enabled: true
+    serviceName: apicurio-apicurio-registry
+```
+
+#### Network Egress & Secrets
+
+Kafka Connect requires explicit egress to databases. Configure it along with external secrets:
+
+```yaml
+kafkaConnect:
+  databaseEgress:
+    - namespace: database
+      port: 5432
+      podSelector:
+        app.kubernetes.io/name: postgresql
+  externalConfiguration:
+    volumes:
+      - name: pg-credentials
+        secretName: connect-pg-credentials
+```
+
+#### CLI Management
+
+Manage Kafka Connect using the new `kates kafka connect` CLI commands:
+
+- `kates kafka connect status` — View Connect cluster health
+- `kates kafka connect connectors` — List deployed connectors and their state
+- `kates kafka connect connector <name>` — View detailed connector configuration
+- `kates kafka connect tasks <name>` — Check individual task status and traces
+- `kates kafka connect restart <name>` — Trigger a rolling restart
+- `kates kafka connect pause <name>` / `resume <name>` — Control connector flow
+- `kates kafka connect plugins` — List installed connector classes (e.g., `io.debezium.connector.postgresql.PostgresConnector`)
+
+---
+
+### Kafka Connect Base Config
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
@@ -842,11 +896,10 @@ Set `strimziOperator.enabled: false` if the operator is already installed in the
 ### Deployment
 
 ```bash
-make kafka-deploy              # Deploy to Kind (default)
-make kafka-deploy ENV=staging  # Deploy with staging overlay
-make kafka-deploy ENV=prod     # Deploy with production overlay
-make kafka-upgrade             # Upgrade existing release (ENV=kind default)
-make kafka-undeploy            # Uninstall + PVC cleanup
+kates deploy                       # Deploy to detected local cluster (default)
+kates deploy --topology single     # Deploy to single namespace
+kates deploy --topology isolated   # Deploy to isolated namespaces
+kates clean                        # Uninstall + PVC cleanup
 ```
 
 ### Chart Development

--- a/charts/kafka-cluster/templates/_helpers.tpl
+++ b/charts/kafka-cluster/templates/_helpers.tpl
@@ -52,6 +52,7 @@ Security context defaults for pods.
 */}}
 {{- define "kafka-cluster.podSecurityContext" -}}
 runAsNonRoot: true
+runAsUser: 1001
 fsGroup: 1001
 seccompProfile:
   type: RuntimeDefault

--- a/charts/kafka-cluster/templates/alerts-connect.yaml
+++ b/charts/kafka-cluster/templates/alerts-connect.yaml
@@ -1,0 +1,53 @@
+{{- if and .Values.kafkaConnect.enabled .Values.alerts.enabled }}
+{{- $clusterName := include "kafka-cluster.clusterName" . -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ $clusterName }}-connect-alerts
+  namespace: {{ include "kafka-cluster.namespace" . }}
+  labels:
+    {{- include "kafka-cluster.labels" . | nindent 4 }}
+    {{- with .Values.alerts.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: kafka-connect
+      rules:
+        - alert: KafkaConnectTaskFailed
+          expr: kafka_connect_worker_metrics_connector_failed_task_count > 0
+          for: 2m
+          labels:
+            severity: critical
+            cluster: {{ $clusterName }}
+          annotations:
+            summary: "Kafka Connect has failed tasks"
+            description: "Connector has {{ "{{" }} $value {{ "}}" }} failed task(s) for more than 2 minutes."
+        - alert: KafkaConnectRebalanceStorm
+          expr: rate(kafka_connect_worker_rebalance_metrics_rebalance_total[5m]) > 0.1
+          for: 5m
+          labels:
+            severity: warning
+            cluster: {{ $clusterName }}
+          annotations:
+            summary: "Kafka Connect rebalancing too frequently"
+            description: "Connect workers are rebalancing at {{ "{{" }} $value {{ "}}" }}/s which may indicate instability."
+        - alert: KafkaConnectWorkerDown
+          expr: kafka_connect_worker_metrics_connector_count == 0
+          for: 3m
+          labels:
+            severity: critical
+            cluster: {{ $clusterName }}
+          annotations:
+            summary: "Kafka Connect worker has no connectors"
+            description: "Connect worker reports 0 connectors for more than 3 minutes."
+        - alert: KafkaConnectHighErrorRate
+          expr: rate(kafka_connect_task_metrics_total_errors_logged_total[5m]) > 1
+          for: 5m
+          labels:
+            severity: warning
+            cluster: {{ $clusterName }}
+          annotations:
+            summary: "Kafka Connect high error rate"
+            description: "Connect tasks are logging errors at {{ "{{" }} $value {{ "}}" }}/s."
+{{- end }}

--- a/charts/kafka-cluster/templates/connectors.yaml
+++ b/charts/kafka-cluster/templates/connectors.yaml
@@ -14,6 +14,9 @@ metadata:
 spec:
   class: {{ .class }}
   tasksMax: {{ .tasksMax | default 1 }}
+  {{- if .state }}
+  state: {{ .state }}
+  {{- end }}
   {{- if .autoRestart }}
   autoRestart:
     enabled: {{ .autoRestart.enabled | default true }}

--- a/charts/kafka-cluster/templates/grafana-dashboards-connect.yaml
+++ b/charts/kafka-cluster/templates/grafana-dashboards-connect.yaml
@@ -1,0 +1,177 @@
+{{- if and .Values.dashboards.enabled .Values.dashboards.connectDashboard }}
+{{- $clusterName := include "kafka-cluster.clusterName" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kafka-connect-dashboard
+  namespace: {{ .Values.dashboards.namespace | default "monitoring" }}
+  labels:
+    {{- include "kafka-cluster.labels" . | nindent 4 }}
+    {{ .Values.dashboards.label | default "grafana_dashboard" }}: {{ .Values.dashboards.labelValue | default "1" | quote }}
+data:
+  kafka-connect.json: |
+    {
+      "annotations": { "list": [] },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "links": [],
+      "panels": [
+        {
+          "title": "Worker Count",
+          "type": "stat",
+          "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+          "targets": [{
+            "expr": "kafka_connect_worker_metrics_connector_count",
+            "legendFormat": "Workers"
+          }],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "steps": [
+                  { "color": "red", "value": null },
+                  { "color": "green", "value": 1 }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "title": "Connectors Running",
+          "type": "stat",
+          "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+          "targets": [{
+            "expr": "kafka_connect_worker_metrics_connector_startup_success_total",
+            "legendFormat": "Running"
+          }],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "steps": [
+                  { "color": "red", "value": null },
+                  { "color": "green", "value": 1 }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "title": "Connectors Failed",
+          "type": "stat",
+          "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+          "targets": [{
+            "expr": "kafka_connect_worker_metrics_connector_startup_failure_total",
+            "legendFormat": "Failed"
+          }],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "red", "value": 1 }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "title": "Connectors Paused",
+          "type": "stat",
+          "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+          "targets": [{
+            "expr": "kafka_connect_worker_metrics_connector_paused_task_count",
+            "legendFormat": "Paused"
+          }],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "orange", "value": 1 },
+                  { "color": "red", "value": 5 }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "title": "Source Records In/s",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+          "targets": [{
+            "expr": "rate(kafka_connect_source_task_metrics_source_record_poll_total[5m])",
+            "legendFormat": "{{ "{{" }}connector{{ "}}" }} records/s"
+          }]
+        },
+        {
+          "title": "Sink Records Out/s",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+          "targets": [{
+            "expr": "rate(kafka_connect_sink_task_metrics_sink_record_send_total[5m])",
+            "legendFormat": "{{ "{{" }}connector{{ "}}" }} records/s"
+          }]
+        },
+        {
+          "title": "Task Error Rate",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+          "targets": [{
+            "expr": "rate(kafka_connect_task_metrics_total_errors_logged_total[5m])",
+            "legendFormat": "{{ "{{" }}connector{{ "}}" }} errors/s"
+          }]
+        },
+        {
+          "title": "Task Commit Latency p99",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+          "targets": [{
+            "expr": "kafka_connect_worker_metrics_task_batch_duration_avg",
+            "legendFormat": "{{ "{{" }}connector{{ "}}" }} avg ms"
+          }],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "ms"
+            }
+          }
+        },
+        {
+          "title": "JVM Heap Used %",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
+          "targets": [{
+            "expr": "jvm_memory_bytes_used{area=\"heap\"} / jvm_memory_bytes_max{area=\"heap\"}",
+            "legendFormat": "{{ "{{" }}kubernetes_pod_name{{ "}}" }}"
+          }],
+          "fieldConfig": {
+            "defaults": {
+              "min": 0, "max": 1,
+              "unit": "percentunit",
+              "thresholds": {
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "orange", "value": 0.7 },
+                  { "color": "red", "value": 0.85 }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "title": "Worker Rebalance Rate",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
+          "targets": [{
+            "expr": "rate(kafka_connect_worker_rebalance_metrics_rebalance_total[5m])",
+            "legendFormat": "rebalances/s"
+          }]
+        }
+      ],
+      "schemaVersion": 39,
+      "tags": ["kafka", "connect", "strimzi", "{{ $clusterName }}"],
+      "templating": { "list": [] },
+      "time": { "from": "now-1h", "to": "now" },
+      "title": "Kafka Connect — {{ $clusterName }}",
+      "uid": "kafka-connect-overview"
+    }
+{{- end }}

--- a/charts/kafka-cluster/templates/kafka-connect-logging.yaml
+++ b/charts/kafka-cluster/templates/kafka-connect-logging.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.kafkaConnect.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kafka-cluster.clusterName" . }}-connect-logging
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kafka-cluster.labels" . | nindent 4 }}
+data:
+  log4j2.properties: |-
+    name = Config
+    
+    appender.console.type = Console
+    appender.console.name = STDOUT
+    appender.console.layout.type = PatternLayout
+    appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+    
+    rootLogger.level = INFO
+    rootLogger.appenderRef.console.ref = STDOUT
+    
+    logger.reflections.name = org.reflections
+    logger.reflections.level = ERROR
+{{- end }}

--- a/charts/kafka-cluster/templates/kafka-connect.yaml
+++ b/charts/kafka-cluster/templates/kafka-connect.yaml
@@ -10,14 +10,17 @@ metadata:
     helm.sh/resource-policy: keep
     strimzi.io/use-connector-resources: "true"
 spec:
+  {{- if .Values.kafkaConnect.image }}
+  image: {{ .Values.kafkaConnect.image }}
+  {{- end }}
   version: {{ .Values.kafkaConnect.version | default .Values.kafkaVersion }}
   replicas: {{ .Values.kafkaConnect.replicas }}
   bootstrapServers: {{ if .Values.kafkaConnect.tls.enabled }}{{ include "kafka-cluster.bootstrapServersTLS" . }}{{ else }}{{ include "kafka-cluster.bootstrapServers" . }}{{ end }}
   authentication:
     type: scram-sha-512
-    username: kates-connect
+    username: {{ .Values.kafkaConnect.authentication.username | default "kates-connect" }}
     passwordSecret:
-      secretName: kates-connect
+      secretName: {{ .Values.kafkaConnect.authentication.secretName | default .Values.kafkaConnect.authentication.username | default "kates-connect" }}
       password: password
   {{- if .Values.kafkaConnect.tls.enabled }}
   tls:
@@ -25,9 +28,9 @@ spec:
       {{- toYaml .Values.kafkaConnect.tls.trustedCertificates | nindent 6 }}
   {{- end }}
   groupId: {{ .Values.kafkaConnect.groupId | default "kates-connect-cluster" }}
-  offsetStorageTopic: kates-connect-offsets
-  configStorageTopic: kates-connect-configs
-  statusStorageTopic: kates-connect-status
+  offsetStorageTopic: {{ .Values.kafkaConnect.internalTopics.offsetsName | default (printf "%s-offsets" .Values.kafkaConnect.groupId) }}
+  configStorageTopic: {{ .Values.kafkaConnect.internalTopics.configsName | default (printf "%s-configs" .Values.kafkaConnect.groupId) }}
+  statusStorageTopic: {{ .Values.kafkaConnect.internalTopics.statusName | default (printf "%s-status" .Values.kafkaConnect.groupId) }}
   config:
     offset.storage.replication.factor: {{ .Values.kafkaConnect.config.replicationFactor | default 3 }}
     config.storage.replication.factor: {{ .Values.kafkaConnect.config.replicationFactor | default 3 }}
@@ -36,6 +39,13 @@ spec:
     value.converter: {{ .Values.kafkaConnect.config.valueConverter | default "org.apache.kafka.connect.json.JsonConverter" }}
     key.converter.schemas.enable: {{ .Values.kafkaConnect.config.keyConverterSchemasEnable | default true }}
     value.converter.schemas.enable: {{ .Values.kafkaConnect.config.valueConverterSchemasEnable | default true }}
+    {{- if .Values.kafkaConnect.schemaRegistry.enabled }}
+    schema.registry.url: {{ printf "http://%s.%s.svc.%s:%d%s" .Values.kafkaConnect.schemaRegistry.serviceName (include "kafka-cluster.namespace" .) (include "kafka-cluster.clusterDomain" .) (.Values.kafkaConnect.schemaRegistry.port | int) .Values.kafkaConnect.schemaRegistry.path }}
+    {{- end }}
+    {{- if and .Values.kafkaConnect.externalConfiguration .Values.kafkaConnect.externalConfiguration.volumes }}
+    config.providers: file
+    config.providers.file.class: org.apache.kafka.common.config.provider.FileConfigProvider
+    {{- end }}
     {{- range $key, $value := .Values.kafkaConnect.extraConfig }}
     {{ $key }}: {{ $value | toJson }}
     {{- end }}
@@ -49,7 +59,7 @@ spec:
   rack:
     topologyKey: {{ .Values.kafkaConnect.rack.topologyKey }}
   {{- end }}
-  {{- if .Values.kafkaConnect.build }}
+  {{- if and .Values.kafkaConnect.build .Values.kafkaConnect.build.output }}
   build:
     {{- toYaml .Values.kafkaConnect.build | nindent 4 }}
   {{- end }}
@@ -57,17 +67,38 @@ spec:
     type: jmxPrometheusExporter
     valueFrom:
       configMapKeyRef:
-        name: kafka-metrics
-        key: kafka-metrics-config.yml
+        name: {{ .Values.kafkaConnect.metricsConfig.configMapName | default "kafka-metrics" }}
+        key: {{ .Values.kafkaConnect.metricsConfig.configMapKey | default "kafka-metrics-config.yml" }}
+  {{- if .Values.kafkaConnect.tracing.enabled }}
+  tracing:
+    type: {{ .Values.kafkaConnect.tracing.type | default "opentelemetry" }}
+  {{- end }}
 
   readinessProbe:
     {{- toYaml .Values.kafkaConnect.readinessProbe | nindent 4 }}
   livenessProbe:
     {{- toYaml .Values.kafkaConnect.livenessProbe | nindent 4 }}
   template:
+    {{- if .Values.kafkaConnect.podDisruptionBudget }}
+    podDisruptionBudget:
+      {{- toYaml .Values.kafkaConnect.podDisruptionBudget | nindent 6 }}
+    {{- end }}
     pod:
+      {{- if .Values.kafkaConnect.template.pod.metadata }}
+      metadata:
+        {{- with .Values.kafkaConnect.template.pod.metadata.labels }}
+        labels:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.kafkaConnect.template.pod.metadata.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- end }}
       securityContext:
-        {{- include "kafka-cluster.podSecurityContext" . | nindent 8 }}
+        fsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
       {{- if .Values.kafkaConnect.topologySpreadConstraints.enabled }}
       topologySpreadConstraints:
         - maxSkew: {{ .Values.kafkaConnect.topologySpreadConstraints.maxSkew }}
@@ -92,7 +123,41 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.kafkaConnect.priorityClassName }}
+      priorityClassName: {{ .Values.kafkaConnect.priorityClassName }}
+      {{- end }}
+      {{- with .Values.kafkaConnect.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if and .Values.kafkaConnect.externalConfiguration .Values.kafkaConnect.externalConfiguration.volumes }}
+      volumes:
+        {{- range .Values.kafkaConnect.externalConfiguration.volumes }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName }}
+        {{- end }}
+      {{- end }}
     connectContainer:
+      {{- if and .Values.kafkaConnect.externalConfiguration .Values.kafkaConnect.externalConfiguration.volumes }}
+      volumeMounts:
+        {{- range .Values.kafkaConnect.externalConfiguration.volumes }}
+        - name: {{ .name }}
+          mountPath: /mnt/{{ .name }}
+          readOnly: true
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.kafkaConnect.env (and .Values.kafkaConnect.externalConfiguration .Values.kafkaConnect.externalConfiguration.env) }}
+      env:
+        {{- with .Values.kafkaConnect.env }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.kafkaConnect.externalConfiguration }}
+        {{- with .Values.kafkaConnect.externalConfiguration.env }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
       securityContext:
         {{- include "kafka-cluster.containerSecurityContext" . | nindent 8 }}
 {{- end }}

--- a/charts/kafka-cluster/templates/networkpolicies.yaml
+++ b/charts/kafka-cluster/templates/networkpolicies.yaml
@@ -323,7 +323,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: kates-connect
+      strimzi.io/name: {{ $clusterName }}-connect
   policyTypes:
     - Ingress
     - Egress
@@ -336,6 +336,13 @@ spec:
         - port: 9404
           protocol: TCP
     - from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: kates
+        - podSelector:
+            matchLabels:
+              strimzi.io/kind: cluster-operator
         {{- range .Values.networkPolicies.allowedClientNamespaces }}
         - namespaceSelector:
             matchLabels:
@@ -352,6 +359,29 @@ spec:
       ports:
         - port: 9092
           protocol: TCP
+    # Egress to Apicurio Schema Registry (same namespace)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: apicurio-registry
+      ports:
+        - port: 8080
+          protocol: TCP
+    # Egress to external databases (cross-namespace)
+    {{- range (default (list) .Values.kafkaConnect.databaseEgress) }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .namespace }}
+          {{- with .podSelector }}
+          podSelector:
+            matchLabels:
+              {{- toYaml . | nindent 14 }}
+          {{- end }}
+      ports:
+        - port: {{ .port | default 5432 }}
+          protocol: TCP
+    {{- end }}
     - to: []
       ports:
         - port: 443
@@ -475,4 +505,38 @@ spec:
       ports:
         - port: 443
           protocol: TCP
+{{- if and .Values.kafkaConnect.enabled .Values.kafkaConnect.databaseEgress }}
+{{- range .Values.kafkaConnect.databaseEgress }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-kafka-connect-ingress
+  namespace: {{ .namespace }}
+  labels:
+    {{- include "kafka-cluster.labels" $ | nindent 4 }}
+spec:
+  podSelector:
+    {{- with .podSelector }}
+    matchLabels:
+      {{- toYaml . | nindent 6 }}
+    {{- else }}
+    matchLabels: {}
+    {{- end }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $namespace }}
+          podSelector:
+            matchLabels:
+              strimzi.io/name: {{ $clusterName }}-connect
+      ports:
+        - port: {{ .port | default 5432 }}
+          protocol: TCP
+{{- end }}
+{{- end }}
+
 {{- end }}

--- a/charts/kafka-cluster/templates/podmonitor-connect.yaml
+++ b/charts/kafka-cluster/templates/podmonitor-connect.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.kafkaConnect.enabled .Values.podMonitors.enabled }}
+{{- $clusterName := include "kafka-cluster.clusterName" . -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ $clusterName }}-connect
+  namespace: {{ include "kafka-cluster.namespace" . }}
+  labels:
+    {{- include "kafka-cluster.labels" . | nindent 4 }}
+    {{- with .Values.podMonitors.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      strimzi.io/name: {{ $clusterName }}-connect
+  podMetricsEndpoints:
+    - port: tcp-prometheus
+      path: /metrics
+{{- end }}

--- a/charts/kafka-cluster/templates/rbac.yaml
+++ b/charts/kafka-cluster/templates/rbac.yaml
@@ -26,6 +26,7 @@ rules:
       - kafkanodepools
       - kafkausers
       - kafkaconnects
+      - kafkaconnectors
       - kafkarebalances
     verbs: ["get", "list", "watch"]
   - apiGroups: ["kafka.strimzi.io"]

--- a/charts/kafka-cluster/values-prod.yaml
+++ b/charts/kafka-cluster/values-prod.yaml
@@ -88,3 +88,35 @@ networkPolicies:
 podSecurityPolicy:
   enabled: true
   action: Enforce
+
+kafkaConnect:
+  enabled: true
+  replicas: 3
+  resources:
+    requests:
+      memory: 1Gi
+      cpu: 500m
+    limits:
+      memory: 2Gi
+      cpu: 2000m
+  podDisruptionBudget:
+    maxUnavailable: 1
+  topologySpreadConstraints:
+    enabled: true
+    maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: DoNotSchedule
+  podAntiAffinity:
+    enabled: true
+    topologyKey: kubernetes.io/hostname
+  schemaRegistry:
+    enabled: true
+  databaseEgress:
+    - namespace: database
+      port: 5432
+      podSelector:
+        app.kubernetes.io/name: postgresql
+  externalConfiguration:
+    volumes:
+      - name: pg-credentials
+        secretName: connect-pg-credentials

--- a/charts/kafka-cluster/values-staging.yaml
+++ b/charts/kafka-cluster/values-staging.yaml
@@ -69,3 +69,51 @@ dashboards:
   kraftDashboard: true
   cruiseControlDashboard: true
   connectDashboard: true
+
+kafkaConnect:
+  enabled: true
+  replicas: 2
+  config:
+    keyConverter: io.apicurio.registry.utils.converter.AvroConverter
+    valueConverter: io.apicurio.registry.utils.converter.AvroConverter
+    keyConverterSchemasEnable: false
+    valueConverterSchemasEnable: false
+  schemaRegistry:
+    enabled: true
+  databaseEgress:
+    - namespace: database
+      port: 5432
+      podSelector:
+        app.kubernetes.io/name: postgresql
+  externalConfiguration:
+    volumes:
+      - name: pg-credentials
+        secretName: connect-pg-credentials
+  build:
+    output:
+      type: docker
+      image: ghcr.io/bmscomp/kates-connect:latest
+      pushSecret: ghcr-credentials
+    plugins:
+      - name: debezium-postgres
+        artifacts:
+          - type: maven
+            group: io.debezium
+            artifact: debezium-connector-postgres
+            version: 2.7.3.Final
+  connectors:
+    - name: cdc-orders
+      class: io.debezium.connector.postgresql.PostgresConnector
+      tasksMax: 1
+      config:
+        database.hostname: postgresql.database.svc
+        database.port: "5432"
+        database.user: debezium
+        database.password: "${file:/opt/kafka/external-configuration/pg-credentials/password}"
+        database.dbname: orders
+        topic.prefix: cdc.orders
+        schema.include.list: public
+        plugin.name: pgoutput
+        slot.name: debezium_orders
+        heartbeat.interval.ms: "10000"
+        snapshot.mode: initial

--- a/charts/kafka-cluster/values.schema.json
+++ b/charts/kafka-cluster/values.schema.json
@@ -272,6 +272,43 @@
             "timeoutSeconds": { "type": "integer", "minimum": 1 }
           }
         },
+        "externalConfiguration": {
+          "type": "object",
+          "properties": {
+            "volumes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["name", "secretName"],
+                "properties": {
+                  "name": { "type": "string", "minLength": 1 },
+                  "secretName": { "type": "string", "minLength": 1 }
+                }
+              }
+            }
+          }
+        },
+        "databaseEgress": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["namespace"],
+            "properties": {
+              "namespace": { "type": "string", "minLength": 1 },
+              "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+              "podSelector": { "type": "object" }
+            }
+          }
+        },
+        "schemaRegistry": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "serviceName": { "type": "string" },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "path": { "type": "string" }
+          }
+        },
         "connectors": {
           "type": "array",
           "items": {

--- a/charts/kafka-cluster/values.yaml
+++ b/charts/kafka-cluster/values.yaml
@@ -41,9 +41,7 @@ kafka:
       tls: true
       authentication:
         type: scram-sha-512
-      configuration:
-        bootstrap:
-          nodePort: null
+      configuration: {}
 
   authorization:
     type: simple
@@ -281,6 +279,21 @@ topics:
         retention.ms: "-1"
         min.insync.replicas: "2"
         cleanup.policy: compact
+    # CDC Debezium internal topics
+    - name: cdc-schema-history
+      partitions: 1
+      replicas: 3
+      config:
+        cleanup.policy: compact
+        retention.ms: "-1"
+        min.insync.replicas: "2"
+    - name: cdc-heartbeat
+      partitions: 1
+      replicas: 3
+      config:
+        cleanup.policy: delete
+        retention.ms: "86400000"
+        min.insync.replicas: "2"
 
 users:
   # -- Enable managed user provisioning
@@ -383,6 +396,18 @@ users:
             operations: ["Read", "Write", "Create", "Describe"]
             host: "*"
           - resource:
+              type: transactionalId
+              name: "connect-cluster-"
+              patternType: prefix
+            operations: ["Write", "Describe"]
+            host: "*"
+          - resource:
+              type: topic
+              name: "cdc"
+              patternType: prefix
+            operations: ["Read", "Write", "Create", "Describe"]
+            host: "*"
+          - resource:
               type: group
               name: "kates-connect"
               patternType: prefix
@@ -445,13 +470,30 @@ tieredStorage:
 
 kafkaConnect:
   enabled: false
-  replicas: 1
+  replicas: 3
   version: ""
+  image: "kates-connect:local"
   groupId: kates-connect-cluster
 
+  topologySpreadConstraints:
+    enabled: true
+    maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: DoNotSchedule
+
+  authentication:
+    username: kates-connect
+    secretName: ""
+
+  podDisruptionBudget:
+    maxUnavailable: 1
+
+  internalTopics:
+    prefix: ""  # defaults to groupId
+
   jvmOptions:
-    -Xms: 256m
-    -Xmx: 512m
+    -Xms: 1024m
+    -Xmx: 1024m
     gcLoggingEnabled: true
     javaSystemProperties: []
     # - name: com.sun.management.jmxremote
@@ -459,11 +501,32 @@ kafkaConnect:
 
   resources:
     requests:
-      memory: 512Mi
-      cpu: 200m
-    limits:
-      memory: 1Gi
+      memory: 2Gi
       cpu: 1000m
+    limits:
+      memory: 4Gi
+      cpu: 4000m
+
+  # Schema registry integration (Apicurio — open source, no Confluent)
+  schemaRegistry:
+    enabled: false
+    # Service name of the Apicurio Registry in the same namespace
+    serviceName: apicurio-apicurio-registry
+    port: 80
+    # Compatibility API path
+    path: /apis/ccompat/v7
+
+  externalConfiguration:
+    volumes:
+      - name: pg-credentials
+        secretName: connect-pg-credentials
+    env: []
+
+  databaseEgress: []
+    # - namespace: database
+    #   port: 5432
+    #   podSelector:
+    #     app.kubernetes.io/name: postgresql
 
   config:
     replicationFactor: 3
@@ -473,26 +536,34 @@ kafkaConnect:
     keyConverterSchemasEnable: true
     valueConverterSchemasEnable: true
   # Arbitrary extra Kafka Connect config (merged into spec.config)
-  extraConfig: {}
-    # producer.acks: "all"
-    # consumer.auto.offset.reset: earliest
-    # schema.registry.url: http://apicurio-registry:8080/apis/ccompat/v7
+  extraConfig:
+    producer.acks: "all"
+    producer.enable.idempotence: "true"
+    consumer.auto.offset.reset: "earliest"
+    exactly.once.source.support: "enabled"
+    # schema.registry.url is auto-computed when kafkaConnect.schemaRegistry.enabled=true
+    # FQDN: http://apicurio-apicurio-registry.<namespace>.svc.<clusterDomain>:80/apis/ccompat/v7
 
   logging:
-    type: inline
-    loggers:
-      connect.root.logger.level: INFO
-      # log4j.logger.org.apache.kafka.connect: DEBUG
+    type: external
+    valueFrom:
+      configMapKeyRef:
+        name: krafter-connect-logging
+        key: log4j2.properties
       # log4j.logger.org.apache.kafka.connect.runtime.WorkerSourceTask: TRACE
 
+  tracing:
+    enabled: true
+    type: opentelemetry
+
   tls:
-    enabled: false
-    # trustedCertificates:
-    #   - secretName: krafter-cluster-ca-cert
-    #     certificate: ca.crt
+    enabled: true
+    trustedCertificates:
+      - secretName: krafter-cluster-ca-cert
+        certificate: ca.crt
 
   rack:
-    enabled: false
+    enabled: true
     topologyKey: topology.kubernetes.io/zone
 
   tolerations: []
@@ -502,44 +573,54 @@ kafkaConnect:
     topologyKey: topology.kubernetes.io/zone
     whenUnsatisfiable: ScheduleAnyway
   podAntiAffinity:
-    enabled: false
+    enabled: true
     topologyKey: kubernetes.io/hostname
+
+  priorityClassName: "system-cluster-critical"
+  imagePullSecrets: []
+  env: []
 
   readinessProbe:
     initialDelaySeconds: 60
-    timeoutSeconds: 5
+    timeoutSeconds: 30
   livenessProbe:
     initialDelaySeconds: 60
-    timeoutSeconds: 5
+    timeoutSeconds: 30
 
-
+  # Strimzi native build (disabled — using pre-built image instead).
+  # Enable this if you don't have a pre-built image and want Strimzi to build one.
   build: {}
-    # output:
-    #   type: docker
-    #   image: my-registry/my-connect:latest
-    #   pushSecret: my-registry-credentials
-    # plugins:
-    #   - name: debezium-postgres
-    #     artifacts:
-    #       - type: maven
-    #         group: io.debezium
-    #         artifact: debezium-connector-postgres
-    #         version: 2.5.0.Final
+
+  metricsConfig:
+    configMapName: kafka-metrics
+    configMapKey: kafka-metrics-config.yml
+
+  template:
+    pod:
+      metadata: {}
 
   connectors: []
-    # - name: my-source-connector
+    # - name: cdc-orders
     #   class: io.debezium.connector.postgresql.PostgresConnector
     #   tasksMax: 1
+    #   state: running  # running, paused, or stopped
     #   autoRestart:
     #     enabled: true
-    #     maxRestarts: 5
+    #     maxRestarts: 10
     #   config:
-    #     database.hostname: postgres.default.svc
+    #     database.hostname: postgresql.database.svc
     #     database.port: "5432"
-    #     database.user: replicator
-    #     database.password: "${file:/opt/kafka/external-configuration/pg-credentials/password}"
-    #     database.dbname: mydb
-    #     topic.prefix: cdc
+    #     database.user: "${file:/mnt/pg-credentials/username}"
+    #     database.password: "${file:/mnt/pg-credentials/password}"
+    #     database.dbname: orders
+    #     topic.prefix: cdc.orders
+    #     schema.include.list: public
+    #     plugin.name: pgoutput
+    #     slot.name: debezium_orders
+    #     heartbeat.interval.ms: "10000"
+    #     snapshot.mode: initial
+    #     decimal.handling.mode: double
+    #     tombstones.on.delete: true
 
 crdUpgrade:
   enabled: true
@@ -553,7 +634,7 @@ dashboards:
   brokerDashboard: true
   kraftDashboard: true
   cruiseControlDashboard: true
-  connectDashboard: false
+  connectDashboard: true
 
 podSecurityPolicy:
   enabled: false

--- a/charts/kates/templates/rbac.yaml
+++ b/charts/kates/templates/rbac.yaml
@@ -23,7 +23,7 @@ rules:
     resources: ["networkpolicies"]
     verbs: ["get", "list"]
   - apiGroups: ["kafka.strimzi.io"]
-    resources: ["kafkas", "kafkanodepools", "kafkatopics", "kafkausers", "kafkaconnects", "kafkamirrormaker2s", "kafkarebalances"]
+    resources: ["kafkas", "kafkanodepools", "kafkatopics", "kafkausers", "kafkaconnects", "kafkaconnectors", "kafkamirrormaker2s", "kafkarebalances"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["monitoring.coreos.com"]
     resources: ["podmonitors", "prometheusrules"]

--- a/cli/cmd/clean.go
+++ b/cli/cmd/clean.go
@@ -32,6 +32,7 @@ var (
 	cleanTopology      string
 	cleanNamespace     string
 	cleanKafkaNS       string
+	cleanDbNS          string
 	cleanAppNS         string
 	cleanChaosNS       string
 	cleanMonitoringNS  string
@@ -43,6 +44,7 @@ func init() {
 	cleanCmd.Flags().StringVar(&cleanTopology, "topology", "", "Topology to clean: 'isolated' or 'single'. If empty, cleans both.")
 	cleanCmd.Flags().StringVar(&cleanNamespace, "namespace", "kates-stack", "Target namespace when topology is 'single'")
 	cleanCmd.Flags().StringVar(&cleanKafkaNS, "kafka-ns", "kafka", "Namespace for Kafka when topology is 'isolated'")
+	cleanCmd.Flags().StringVar(&cleanDbNS, "db-ns", "database", "Namespace for PostgreSQL Database when topology is 'isolated'")
 	cleanCmd.Flags().StringVar(&cleanAppNS, "app-ns", "kates", "Namespace for Kates Backend when topology is 'isolated'")
 	cleanCmd.Flags().StringVar(&cleanChaosNS, "chaos-ns", "litmus", "Namespace for Chaos Engine when topology is 'isolated'")
 	cleanCmd.Flags().StringVar(&cleanMonitoringNS, "monitoring-ns", "monitoring", "Namespace for monitoring components when topology is 'isolated'")
@@ -209,6 +211,7 @@ func runClean(cmd *cobra.Command, args []string) error {
 			helmRelease{"jaeger", cleanNamespace},
 			helmRelease{"krafter", cleanNamespace},
 			helmRelease{"monitoring", cleanNamespace},
+			helmRelease{"postgresql", cleanNamespace},
 		)
 		managedNamespaces = append(managedNamespaces, cleanNamespace)
 		strimziNS = append(strimziNS, cleanNamespace)
@@ -224,9 +227,10 @@ func runClean(cmd *cobra.Command, args []string) error {
 			helmRelease{"jaeger", cleanMonitoringNS},
 			helmRelease{"krafter", cleanKafkaNS},
 			helmRelease{"monitoring", cleanMonitoringNS},
+			helmRelease{"postgresql", cleanDbNS},
 		)
 		managedNamespaces = append(managedNamespaces,
-			cleanKafkaNS, cleanAppNS, cleanChaosNS, cleanMonitoringNS,
+			cleanKafkaNS, cleanAppNS, cleanChaosNS, cleanMonitoringNS, cleanDbNS,
 		)
 		strimziNS = append(strimziNS, cleanKafkaNS)
 	}

--- a/cli/cmd/connect.go
+++ b/cli/cmd/connect.go
@@ -1,0 +1,274 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var connectNamespace string
+var connectFollow bool
+
+var kafkaConnectCmd = &cobra.Command{
+	Use:   "connect",
+	Short: "Manage Kafka Connect (via Strimzi CRDs)",
+}
+
+var connectStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show Connect cluster status",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		argsCmd := []string{"get", "kafkaconnect", "-n", connectNamespace}
+		if outputMode == "json" {
+			argsCmd = append(argsCmd, "-o", "json")
+		}
+		out, err := exec.CommandContext(context.Background(), "kubectl", argsCmd...).Output()
+		if err != nil {
+			return fmt.Errorf("failed to get kafkaconnect: %w", err)
+		}
+		fmt.Print(string(out))
+		return nil
+	},
+}
+
+var connectConnectorsCmd = &cobra.Command{
+	Use:   "connectors",
+	Short: "List all KafkaConnector CRs",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		argsCmd := []string{"get", "kafkaconnector", "-n", connectNamespace}
+		if outputMode == "json" {
+			argsCmd = append(argsCmd, "-o", "json")
+		}
+		out, err := exec.CommandContext(context.Background(), "kubectl", argsCmd...).Output()
+		if err != nil {
+			return fmt.Errorf("failed to get kafkaconnector: %w", err)
+		}
+		fmt.Print(string(out))
+		return nil
+	},
+}
+
+var connectConnectorCmd = &cobra.Command{
+	Use:   "connector [name]",
+	Short: "Describe a connector",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		argsCmd := []string{"get", "kafkaconnector", args[0], "-n", connectNamespace}
+		if outputMode == "json" {
+			argsCmd = append(argsCmd, "-o", "json")
+		} else {
+			argsCmd = append(argsCmd, "-o", "yaml") 
+		}
+		out, err := exec.CommandContext(context.Background(), "kubectl", argsCmd...).Output()
+		if err != nil {
+			return fmt.Errorf("failed to describe connector %s: %w", args[0], err)
+		}
+		fmt.Print(string(out))
+		return nil
+	},
+}
+
+var connectTasksCmd = &cobra.Command{
+	Use:   "tasks [name]",
+	Short: "Show task-level status for a connector",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out, err := exec.CommandContext(context.Background(), "kubectl", "get", "kafkaconnector", args[0], "-n", connectNamespace, "-o", "jsonpath={.status.connectorStatus.tasks}").Output()
+		if err != nil {
+			return fmt.Errorf("failed to get tasks for connector %s: %w", args[0], err)
+		}
+		if string(out) == "" {
+			fmt.Println("No tasks found or connector status unavailable.")
+			return nil
+		}
+		fmt.Println(string(out))
+		return nil
+	},
+}
+
+var connectRestartCmd = &cobra.Command{
+	Use:   "restart [name]",
+	Short: "Restart a connector",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out, err := exec.CommandContext(context.Background(), "kubectl", "annotate", "kafkaconnector", args[0], "-n", connectNamespace, "strimzi.io/restart=true", "--overwrite").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to restart connector %s: %s", args[0], string(out))
+		}
+		fmt.Printf("Connector %s restart triggered.\n", args[0])
+		return nil
+	},
+}
+
+var connectPauseCmd = &cobra.Command{
+	Use:   "pause [name]",
+	Short: "Pause a connector",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out, err := exec.CommandContext(context.Background(), "kubectl", "patch", "kafkaconnector", args[0], "-n", connectNamespace, "--type=merge", "-p", `{"spec":{"state":"paused"}}`).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to pause connector %s: %s", args[0], string(out))
+		}
+		fmt.Printf("Connector %s paused.\n", args[0])
+		return nil
+	},
+}
+
+var connectResumeCmd = &cobra.Command{
+	Use:   "resume [name]",
+	Short: "Resume a connector",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out, err := exec.CommandContext(context.Background(), "kubectl", "patch", "kafkaconnector", args[0], "-n", connectNamespace, "--type=merge", "-p", `{"spec":{"state":"running"}}`).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to resume connector %s: %s", args[0], string(out))
+		}
+		fmt.Printf("Connector %s resumed.\n", args[0])
+		return nil
+	},
+}
+
+var connectPluginsCmd = &cobra.Command{
+	Use:   "plugins",
+	Short: "List installed connector plugins",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out, err := exec.CommandContext(context.Background(), "kubectl", "get", "kafkaconnect", "-n", connectNamespace, "-o", "jsonpath={.items[0].status.connectorPlugins}").Output()
+		if err != nil {
+			return fmt.Errorf("failed to get plugins (ensure a KafkaConnect cluster is running): %w", err)
+		}
+		if string(out) == "" {
+			fmt.Println("No plugins found or status unavailable.")
+			return nil
+		}
+		
+		if outputMode == "json" {
+			fmt.Println(string(out))
+		} else {
+			// Basic formatting for non-json output
+			fmt.Println("Installed Connector Plugins:")
+			fmt.Println(string(out))
+		}
+		return nil
+	},
+}
+
+var connectLogsCmd = &cobra.Command{
+	Use:   "logs",
+	Short: "Tail Kafka Connect worker logs",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		connectArgs := []string{"logs", "-l", "strimzi.io/kind=KafkaConnect", "-n", connectNamespace, "--tail=100"}
+		if connectFollow {
+			connectArgs = append(connectArgs, "-f")
+		}
+		c := exec.CommandContext(context.Background(), "kubectl", connectArgs...)
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
+		return c.Run()
+	},
+}
+
+var connectRestartTaskCmd = &cobra.Command{
+	Use:   "restart-task [connector] [taskId]",
+	Short: "Restart a specific connector task",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		annotation := fmt.Sprintf("strimzi.io/restart-task=%s", args[1])
+		out, err := exec.CommandContext(context.Background(), "kubectl", "annotate", "kafkaconnector", args[0], "-n", connectNamespace, annotation, "--overwrite").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to restart task %s on connector %s: %s", args[1], args[0], string(out))
+		}
+		fmt.Printf("Task %s on connector %s restart triggered.\n", args[1], args[0])
+		return nil
+	},
+}
+
+var connectConfigCmd = &cobra.Command{
+	Use:   "config [name]",
+	Short: "Show connector configuration",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		format := "jsonpath={.spec.config}"
+		if outputMode == "json" {
+			format = "-o=json"
+		} else if outputMode == "yaml" {
+			format = "-o=yaml"
+		}
+		cmdArgs := []string{"get", "kafkaconnector", args[0], "-n", connectNamespace}
+		if strings.HasPrefix(format, "jsonpath") {
+			cmdArgs = append(cmdArgs, "-o", format)
+		} else {
+			cmdArgs = append(cmdArgs, format)
+		}
+		out, err := exec.CommandContext(context.Background(), "kubectl", cmdArgs...).Output()
+		if err != nil {
+			return fmt.Errorf("failed to get config for connector %s: %w", args[0], err)
+		}
+		fmt.Println(string(out))
+		return nil
+	},
+}
+
+var connectDeleteCmd = &cobra.Command{
+	Use:   "delete [name]",
+	Short: "Delete a connector",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out, err := exec.CommandContext(context.Background(), "kubectl", "delete", "kafkaconnector", args[0], "-n", connectNamespace).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to delete connector %s: %s", args[0], string(out))
+		}
+		fmt.Printf("Connector %s deleted.\n", args[0])
+		return nil
+	},
+}
+
+var connectScaleCmd = &cobra.Command{
+	Use:   "scale [replicas]",
+	Short: "Scale Kafka Connect workers",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		patch := fmt.Sprintf(`{"spec":{"replicas":%s}}`, args[0])
+		// Find the KafkaConnect resource name
+		nameOut, err := exec.CommandContext(context.Background(), "kubectl", "get", "kafkaconnect", "-n", connectNamespace, "-o", "jsonpath={.items[0].metadata.name}").Output()
+		if err != nil {
+			return fmt.Errorf("failed to find KafkaConnect resource: %w", err)
+		}
+		name := strings.TrimSpace(string(nameOut))
+		if name == "" {
+			return fmt.Errorf("no KafkaConnect resource found in namespace %s", connectNamespace)
+		}
+		out, patchErr := exec.CommandContext(context.Background(), "kubectl", "patch", "kafkaconnect", name, "-n", connectNamespace, "--type=merge", "-p", patch).CombinedOutput()
+		if patchErr != nil {
+			return fmt.Errorf("failed to scale connect: %s", string(out))
+		}
+		fmt.Printf("Kafka Connect %s scaled to %s replicas.\n", name, args[0])
+		return nil
+	},
+}
+
+func init() {
+	defaultNS := "kafka"
+	if envNS := os.Getenv("KATES_KAFKA_NS"); envNS != "" {
+		defaultNS = envNS
+	}
+	kafkaConnectCmd.PersistentFlags().StringVarP(&connectNamespace, "namespace", "n", defaultNS, "Namespace where Kafka Connect is deployed")
+
+	kafkaConnectCmd.AddCommand(connectStatusCmd)
+	kafkaConnectCmd.AddCommand(connectConnectorsCmd)
+	kafkaConnectCmd.AddCommand(connectConnectorCmd)
+	kafkaConnectCmd.AddCommand(connectTasksCmd)
+	kafkaConnectCmd.AddCommand(connectRestartCmd)
+	kafkaConnectCmd.AddCommand(connectPauseCmd)
+	kafkaConnectCmd.AddCommand(connectResumeCmd)
+	kafkaConnectCmd.AddCommand(connectPluginsCmd)
+	connectLogsCmd.Flags().BoolVarP(&connectFollow, "follow", "f", false, "Stream logs continuously")
+	kafkaConnectCmd.AddCommand(connectLogsCmd)
+	kafkaConnectCmd.AddCommand(connectRestartTaskCmd)
+	kafkaConnectCmd.AddCommand(connectConfigCmd)
+	kafkaConnectCmd.AddCommand(connectDeleteCmd)
+	kafkaConnectCmd.AddCommand(connectScaleCmd)
+}

--- a/cli/cmd/connect_wait.go
+++ b/cli/cmd/connect_wait.go
@@ -1,0 +1,517 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// ── Bubble Tea: Kafka Connect ──────────────────────────────────────────────
+
+type connectStatusMsg struct {
+	crReady    bool
+	podRunning int
+	podTotal   int
+	pending    []string
+	err        error
+}
+
+func pollConnectStatus(ctx context.Context, namespace string) tea.Cmd {
+	return func() tea.Msg {
+		var s connectStatusMsg
+
+		// 1. CR condition
+		condOut, _ := exec.CommandContext(ctx,
+			"kubectl", "get", "kafkaconnect", "-n", namespace,
+			"--no-headers",
+			"-o", `custom-columns=READY:.status.conditions[?(@.type=="Ready")].status`,
+		).Output()
+		s.crReady = strings.Contains(string(condOut), "True")
+
+		// 2. Pod counts
+		s.podRunning, s.podTotal, s.pending = countPodsByLabel(ctx, namespace,
+			"strimzi.io/name=krafter-connect-connect")
+
+		return s
+	}
+}
+
+type connectWaitModel struct {
+	ctx       context.Context
+	namespace string
+	timeout   time.Duration
+	start     time.Time
+
+	podRunning int
+	podTotal   int
+	pending    []string
+	crReady    bool
+	err        error
+	done       bool
+}
+
+func (m connectWaitModel) Init() tea.Cmd {
+	m.start = time.Now()
+	return tea.Batch(
+		pollConnectStatus(m.ctx, m.namespace),
+		tea.Tick(6*time.Second, func(t time.Time) tea.Msg { return tickMsg(t) }),
+	)
+}
+
+func (m connectWaitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if msg.String() == "ctrl+c" {
+			m.err = fmt.Errorf("user aborted")
+			return m, tea.Quit
+		}
+	case connectStatusMsg:
+		m.podRunning = msg.podRunning
+		m.podTotal = msg.podTotal
+		m.pending = msg.pending
+		m.crReady = msg.crReady
+
+		allPodsUp := m.podTotal > 0 && m.podRunning == m.podTotal
+		if m.crReady && allPodsUp {
+			m.done = true
+			return m, tea.Quit
+		}
+
+		elapsed := int(time.Since(m.start).Seconds())
+		if elapsed >= int(m.timeout.Seconds()) {
+			m.err = fmt.Errorf("%s kafka connect not ready after %s (pods:%d/%d)",
+				red("✖"), m.timeout, m.podRunning, m.podTotal)
+			return m, tea.Quit
+		}
+
+	case tickMsg:
+		elapsed := int(time.Since(m.start).Seconds())
+		if elapsed >= int(m.timeout.Seconds()) {
+			m.err = fmt.Errorf("%s kafka connect not ready after %s (pods:%d/%d)",
+				red("✖"), m.timeout, m.podRunning, m.podTotal)
+			return m, tea.Quit
+		}
+		return m, tea.Batch(
+			pollConnectStatus(m.ctx, m.namespace),
+			tea.Tick(6*time.Second, func(t time.Time) tea.Msg { return tickMsg(t) }),
+		)
+	}
+	return m, nil
+}
+
+func (m connectWaitModel) View() string {
+	var b strings.Builder
+
+	elapsed := int(time.Since(m.start).Seconds())
+	totalSecs := int(m.timeout.Seconds())
+	if elapsed > totalSecs {
+		elapsed = totalSecs
+	}
+
+	failed := m.err != nil
+
+	b.WriteString(fmt.Sprintf("\n    %s\n", boxTop(fmt.Sprintf(" Kafka Connect  %s ", bold(fmt.Sprintf("(%s timeout)", fmtRemaining(m.timeout)))), 58)))
+
+	workerStatus := podPhaseLabel(m.podRunning, m.podTotal)
+	workerCount := fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", m.podRunning, m.podTotal))
+	if m.done {
+		workerStatus = blue("✔ running")
+		workerCount = blue(workerCount)
+	}
+	b.WriteString(fmt.Sprintf("    %s\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
+		dim("Workers     "),
+		renderProgressBar(m.podRunning, m.podTotal, 15, failed),
+		workerCount, workerStatus), 58)))
+
+	b.WriteString(fmt.Sprintf("    %s\n", boxRow(fmt.Sprintf(" %s  [%s]  %s / %s",
+		dim("Timeout     "),
+		renderProgressBar(elapsed, totalSecs, 15, failed),
+		fmtElapsed(elapsed), fmtElapsed(totalSecs)), 58)))
+
+	crIcon := red("⏳ waiting")
+	if m.crReady || m.done {
+		crIcon = blue("✔ Ready=True")
+	}
+	b.WriteString(fmt.Sprintf("    %s\n", boxRow(fmt.Sprintf(" %s  %s",
+		dim("CR status   "), crIcon), 58)))
+
+	b.WriteString(fmt.Sprintf("    %s\n", boxBottom(58)))
+
+	if m.done {
+		b.WriteString(fmt.Sprintf("    %s Kafka Connect ready  %s %s\n",
+			green("✔"), dim("elapsed"), bold(fmtElapsed(elapsed))))
+	} else {
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+func waitConnectReady(ctx context.Context, namespace string, timeout time.Duration) error {
+	m := connectWaitModel{
+		ctx:       ctx,
+		namespace: namespace,
+		timeout:   timeout,
+		start:     time.Now(),
+	}
+
+	p := tea.NewProgram(m)
+	finalModel, err := p.Run()
+	if err != nil {
+		return err
+	}
+
+	fm := finalModel.(connectWaitModel)
+	if fm.err != nil {
+		return fm.err
+	}
+
+	return nil
+}
+
+// ── Bubble Tea: Kafka Connectors ───────────────────────────────────────────
+
+type connectorStat struct {
+	name  string
+	ready bool
+}
+
+type connectorsStatusMsg struct {
+	connectors []connectorStat
+	total      int
+	ready      int
+	err        error
+}
+
+func pollConnectors(ctx context.Context, namespace string) tea.Cmd {
+	return func() tea.Msg {
+		var msg connectorsStatusMsg
+		out, _ := exec.CommandContext(ctx,
+			"kubectl", "get", "kafkaconnector",
+			"-n", namespace,
+			"--no-headers",
+			"-o", `custom-columns=NAME:.metadata.name,READY:.status.conditions[?(@.type=="Ready")].status`,
+		).Output()
+
+		for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+			if line == "" {
+				continue
+			}
+			fields := strings.Fields(line)
+			if len(fields) < 1 {
+				continue
+			}
+			msg.total++
+			isReady := len(fields) >= 2 && fields[1] == "True"
+			if isReady {
+				msg.ready++
+			}
+			msg.connectors = append(msg.connectors, connectorStat{name: fields[0], ready: isReady})
+		}
+
+		sort.Slice(msg.connectors, func(i, j int) bool {
+			return msg.connectors[i].name < msg.connectors[j].name
+		})
+
+		return msg
+	}
+}
+
+type connectorWaitModel struct {
+	ctx       context.Context
+	namespace string
+	timeout   time.Duration
+	start     time.Time
+
+	connectors []connectorStat
+	total      int
+	ready      int
+	err        error
+	done       bool
+	isTimeout  bool
+}
+
+func (m connectorWaitModel) Init() tea.Cmd {
+	m.start = time.Now()
+	return tea.Batch(
+		pollConnectors(m.ctx, m.namespace),
+		tea.Tick(6*time.Second, func(t time.Time) tea.Msg { return tickMsg(t) }),
+	)
+}
+
+func (m connectorWaitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if msg.String() == "ctrl+c" {
+			m.err = fmt.Errorf("user aborted")
+			return m, tea.Quit
+		}
+	case connectorsStatusMsg:
+		m.connectors = msg.connectors
+		m.total = msg.total
+		m.ready = msg.ready
+
+		elapsed := int(time.Since(m.start).Seconds())
+
+		if m.total > 0 && m.ready == m.total {
+			m.done = true
+			return m, tea.Quit
+		}
+
+		if elapsed >= int(m.timeout.Seconds()) {
+			m.isTimeout = true
+			m.done = true
+			return m, tea.Quit
+		}
+
+	case tickMsg:
+		elapsed := int(time.Since(m.start).Seconds())
+		if elapsed >= int(m.timeout.Seconds()) {
+			m.isTimeout = true
+			m.done = true
+			return m, tea.Quit
+		}
+		return m, tea.Batch(
+			pollConnectors(m.ctx, m.namespace),
+			tea.Tick(6*time.Second, func(t time.Time) tea.Msg { return tickMsg(t) }),
+		)
+	}
+	return m, nil
+}
+
+func (m connectorWaitModel) View() string {
+	var b strings.Builder
+
+	elapsed := int(time.Since(m.start).Seconds())
+	totalSecs := int(m.timeout.Seconds())
+	if elapsed > totalSecs {
+		elapsed = totalSecs
+	}
+
+	failed := m.err != nil || m.isTimeout
+
+	b.WriteString(fmt.Sprintf("\n    %s\n", boxTop(fmt.Sprintf(" Kafka Connectors  %s ", bold(fmt.Sprintf("(%s timeout)", fmtRemaining(m.timeout)))), 58)))
+
+	b.WriteString(m.renderConnectors(failed))
+
+	b.WriteString(fmt.Sprintf("    %s\n", boxRow(fmt.Sprintf(" %s  [%s]  %s / %s",
+		dim(fmt.Sprintf("%-12s", "Timeout")),
+		renderProgressBar(elapsed, totalSecs, 15, failed),
+		fmtElapsed(elapsed), fmtElapsed(totalSecs)), 58)))
+
+	b.WriteString(fmt.Sprintf("    %s\n", boxBottom(58)))
+
+	if m.done && !m.isTimeout {
+		b.WriteString(fmt.Sprintf("    %s All %d connectors ready  %s %s\n",
+			green("✔"), m.total, dim("elapsed"), bold(fmtElapsed(elapsed))))
+	} else {
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+func (m connectorWaitModel) renderConnectors(finalFailed bool) string {
+	var b strings.Builder
+	if len(m.connectors) == 0 {
+		b.WriteString(fmt.Sprintf("    %s\n", boxRow(fmt.Sprintf(" %s", dim("Waiting for KafkaConnectors to appear...")), 58)))
+		return b.String()
+	}
+	for _, c := range m.connectors {
+		namePadded := fmt.Sprintf("%-12s", c.name)
+		if len(c.name) > 12 {
+			namePadded = c.name[:9] + "..."
+		}
+
+		statusStr := red("pending")
+		progress := 0
+		if c.ready {
+			statusStr = blue("ready")
+			progress = 1
+		} else if finalFailed {
+			statusStr = red("failed")
+			if m.isTimeout {
+				statusStr = red("timed out")
+			}
+		}
+
+		b.WriteString(fmt.Sprintf("    %s\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
+			dim(namePadded),
+			renderProgressBar(progress, 1, 15, finalFailed && !c.ready),
+			fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", progress, 1)),
+			statusStr), 58)))
+	}
+	return b.String()
+}
+
+func waitConnectorReady(ctx context.Context, namespace string, timeout time.Duration) error {
+	m := connectorWaitModel{
+		ctx:       ctx,
+		namespace: namespace,
+		timeout:   timeout,
+		start:     time.Now(),
+	}
+
+	p := tea.NewProgram(m)
+	finalModel, err := p.Run()
+	if err != nil {
+		return err
+	}
+
+	fm := finalModel.(connectorWaitModel)
+	if fm.err != nil {
+		return fm.err
+	}
+
+	if fm.isTimeout {
+		return fmt.Errorf("connectors not all ready after %s (%d/%d ready)", timeout, fm.ready, fm.total)
+	}
+
+	return nil
+}
+
+// ── Bubble Tea: PostgreSQL ─────────────────────────────────────────────────
+
+type pgStatusMsg struct {
+	podRunning int
+	podTotal   int
+	pending    []string
+	err        error
+}
+
+func pollPostgresStatus(ctx context.Context, namespace string) tea.Cmd {
+	return func() tea.Msg {
+		var s pgStatusMsg
+		s.podRunning, s.podTotal, s.pending = countPodsByLabel(ctx, namespace,
+			"app.kubernetes.io/name=postgresql")
+		return s
+	}
+}
+
+type pgWaitModel struct {
+	ctx       context.Context
+	namespace string
+	timeout   time.Duration
+	start     time.Time
+
+	podRunning int
+	podTotal   int
+	pending    []string
+	err        error
+	done       bool
+}
+
+func (m pgWaitModel) Init() tea.Cmd {
+	m.start = time.Now()
+	return tea.Batch(
+		pollPostgresStatus(m.ctx, m.namespace),
+		tea.Tick(6*time.Second, func(t time.Time) tea.Msg { return tickMsg(t) }),
+	)
+}
+
+func (m pgWaitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if msg.String() == "ctrl+c" {
+			m.err = fmt.Errorf("user aborted")
+			return m, tea.Quit
+		}
+	case pgStatusMsg:
+		m.podRunning = msg.podRunning
+		m.podTotal = msg.podTotal
+		m.pending = msg.pending
+
+		if m.podTotal > 0 && m.podRunning == m.podTotal {
+			m.done = true
+			return m, tea.Quit
+		}
+
+		elapsed := int(time.Since(m.start).Seconds())
+		if elapsed >= int(m.timeout.Seconds()) {
+			m.err = fmt.Errorf("%s postgresql not ready after %s (pods:%d/%d)",
+				red("✖"), m.timeout, m.podRunning, m.podTotal)
+			return m, tea.Quit
+		}
+
+	case tickMsg:
+		elapsed := int(time.Since(m.start).Seconds())
+		if elapsed >= int(m.timeout.Seconds()) {
+			m.err = fmt.Errorf("%s postgresql not ready after %s (pods:%d/%d)",
+				red("✖"), m.timeout, m.podRunning, m.podTotal)
+			return m, tea.Quit
+		}
+		return m, tea.Batch(
+			pollPostgresStatus(m.ctx, m.namespace),
+			tea.Tick(6*time.Second, func(t time.Time) tea.Msg { return tickMsg(t) }),
+		)
+	}
+	return m, nil
+}
+
+func (m pgWaitModel) View() string {
+	var b strings.Builder
+
+	elapsed := int(time.Since(m.start).Seconds())
+	totalSecs := int(m.timeout.Seconds())
+	if elapsed > totalSecs {
+		elapsed = totalSecs
+	}
+
+	failed := m.err != nil
+
+	b.WriteString(fmt.Sprintf("\n    %s\n", boxTop(fmt.Sprintf(" PostgreSQL  %s ", bold(fmt.Sprintf("(%s timeout)", fmtRemaining(m.timeout)))), 58)))
+
+	podStatus := podPhaseLabel(m.podRunning, m.podTotal)
+	podCount := fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", m.podRunning, m.podTotal))
+	if m.done {
+		podStatus = blue("✔ running")
+		podCount = blue(podCount)
+	}
+	b.WriteString(fmt.Sprintf("    %s\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
+		dim("Pods        "),
+		renderProgressBar(m.podRunning, m.podTotal, 15, failed),
+		podCount, podStatus), 58)))
+
+	b.WriteString(fmt.Sprintf("    %s\n", boxRow(fmt.Sprintf(" %s  [%s]  %s / %s",
+		dim("Timeout     "),
+		renderProgressBar(elapsed, totalSecs, 15, failed),
+		fmtElapsed(elapsed), fmtElapsed(totalSecs)), 58)))
+
+	b.WriteString(fmt.Sprintf("    %s\n", boxBottom(58)))
+
+	if m.done {
+		b.WriteString(fmt.Sprintf("    %s PostgreSQL ready  %s %s\n",
+			green("✔"), dim("elapsed"), bold(fmtElapsed(elapsed))))
+	} else {
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+func waitPostgresReady(ctx context.Context, namespace string, timeout time.Duration) error {
+	m := pgWaitModel{
+		ctx:       ctx,
+		namespace: namespace,
+		timeout:   timeout,
+		start:     time.Now(),
+	}
+
+	p := tea.NewProgram(m)
+	finalModel, err := p.Run()
+	if err != nil {
+		return err
+	}
+
+	fm := finalModel.(pgWaitModel)
+	if fm.err != nil {
+		return fm.err
+	}
+
+	return nil
+}

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -44,16 +43,19 @@ var (
 	deployTopology           string
 	deployNamespace          string
 	deployKafkaNS            string
+	deployDbNS               string
 	deployAppNS              string
 	deployChaosNS            string
 	deployMonitoringNS       string
 	deployWithSchemaRegistry string
+	deployHA                 bool
 	deployWithChaos          bool
 	deployWithMonitoring     bool
 	deployWithCertManager    bool
 	deployWithKyverno        bool
 	deployWithSecretManager  bool
 	deployWithStrimzi        bool
+	deployWithKafkaConnect   bool
 	deployInteractive        bool
 	deployVerbose            bool
 	deployPortForward        bool
@@ -63,18 +65,21 @@ func init() {
 	deployCmd.Flags().StringVar(&deployTopology, "topology", "isolated", "Deployment topology: 'isolated' (separate namespaces) or 'single' (one namespace)")
 	deployCmd.Flags().StringVar(&deployNamespace, "namespace", "kates-stack", "Target namespace when topology is 'single'")
 	deployCmd.Flags().StringVar(&deployKafkaNS, "kafka-ns", "kafka", "Namespace for Kafka when topology is 'isolated'")
+	deployCmd.Flags().StringVar(&deployDbNS, "db-ns", "database", "Namespace for PostgreSQL Database when topology is 'isolated'")
 	deployCmd.Flags().StringVar(&deployAppNS, "app-ns", "kates", "Namespace for Kates Backend when topology is 'isolated'")
 	deployCmd.Flags().StringVar(&deployChaosNS, "chaos-ns", "litmus", "Namespace for Chaos Engine when topology is 'isolated'")
 	deployCmd.Flags().StringVar(&deployMonitoringNS, "monitoring-ns", "monitoring", "Namespace for monitoring components (Jaeger) when topology is 'isolated'")
 	
 	// Component flags
 	deployCmd.Flags().StringVar(&deployWithSchemaRegistry, "with-schema-registry", "none", "Schema Registry to deploy: 'none', 'apicurio', or 'confluent'")
+	deployCmd.Flags().BoolVar(&deployHA, "ha", false, "Enable High Availability (Multi-AZ)")
 	deployCmd.Flags().BoolVar(&deployWithChaos, "with-chaos", true, "Deploy LitmusChaos engine")
 	deployCmd.Flags().BoolVar(&deployWithMonitoring, "with-monitoring", true, "Deploy monitoring components (Prometheus/Grafana/Jaeger)")
 	deployCmd.Flags().BoolVar(&deployWithCertManager, "with-cert-manager", true, "Deploy Cert-Manager for TLS certificate management")
 	deployCmd.Flags().BoolVar(&deployWithKyverno, "with-kyverno", false, "Deploy Kyverno for cluster policy enforcement")
 	deployCmd.Flags().BoolVar(&deployWithSecretManager, "with-secret-manager", false, "Deploy Secret Manager (e.g., External Secrets Operator)")
 	deployCmd.Flags().BoolVar(&deployWithStrimzi, "with-strimzi", true, "Deploy Strimzi Operator")
+	deployCmd.Flags().BoolVar(&deployWithKafkaConnect, "with-kafka-connect", false, "Deploy Kafka Connect with PostgreSQL CDC (Debezium)")
 	deployCmd.Flags().BoolVarP(&deployInteractive, "interactive", "i", false, "Use interactive UI to configure deployment")
 	deployCmd.Flags().BoolVar(&deployVerbose, "verbose", false, "Show every kubectl/helm command as it runs")
 	deployCmd.Flags().BoolVarP(&deployPortForward, "port-forward", "P", false, "After deploy, start port-forwards for all services and keep running until Ctrl+C")
@@ -109,11 +114,17 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 					).
 					Value(&deployWithSchemaRegistry),
 
+				huh.NewConfirm().
+					Title("Enable High Availability (Multi-AZ)?").
+					Description("Sets replicas=3, min.insync.replicas=2, and enables Topology Spread Constraints").
+					Value(&deployHA),
+
 				huh.NewMultiSelect[string]().
 					Title("Select Additional Components").
 					Description("Use space to toggle, enter to confirm").
 					Options(
 						huh.NewOption("🦊 Strimzi Operator", "strimzi").Selected(deployWithStrimzi),
+						huh.NewOption("🔗 Kafka Connect + PostgreSQL (CDC)", "kafka-connect").Selected(deployWithKafkaConnect),
 						huh.NewOption("🧪 Litmus Chaos Engine", "chaos").Selected(deployWithChaos),
 						huh.NewOption("📊 Monitoring (Grafana + Prometheus)", "monitoring").Selected(deployWithMonitoring),
 						huh.NewOption("🔐 Cert-Manager (TLS)", "cert-manager").Selected(deployWithCertManager),
@@ -128,6 +139,10 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 					Title("Kafka Namespace").
 					Description("Namespace for Strimzi operator and Kafka cluster").
 					Value(&deployKafkaNS),
+				huh.NewInput().
+					Title("Database Namespace").
+					Description("Namespace for PostgreSQL CDC database").
+					Value(&deployDbNS),
 				huh.NewInput().
 					Title("Kates App Namespace").
 					Description("Namespace for the Kates backend service").
@@ -157,6 +172,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		for _, c := range components {
 			switch c {
 			case "strimzi": deployWithStrimzi = true
+			case "kafka-connect": deployWithKafkaConnect = true
 			case "chaos": deployWithChaos = true
 			case "monitoring": deployWithMonitoring = true
 			case "cert-manager": deployWithCertManager = true
@@ -171,6 +187,9 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		PrintPhaseItem(fmt.Sprintf("All components → %s", deployNamespace))
 	} else {
 		PrintPhaseItem(fmt.Sprintf("Kafka        → %s", deployKafkaNS))
+		if deployWithKafkaConnect {
+			PrintPhaseItem(fmt.Sprintf("Database     → %s", deployDbNS))
+		}
 		PrintPhaseItem(fmt.Sprintf("Kates App    → %s", deployAppNS))
 		if deployWithMonitoring {
 			PrintPhaseItem(fmt.Sprintf("Monitoring   → %s", deployMonitoringNS))
@@ -182,6 +201,9 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	PrintPhaseHeader(2, "Component Selection")
 	if deployWithStrimzi {
 		PrintPhaseSuccess("Strimzi Operator")
+	}
+	if deployWithKafkaConnect {
+		PrintPhaseSuccess("Kafka Connect + PostgreSQL (CDC)")
 	}
 	if deployWithSchemaRegistry != "none" {
 		PrintPhaseSuccess(fmt.Sprintf("Schema Registry: %s", deployWithSchemaRegistry))
@@ -314,11 +336,16 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 kind: Namespace
 metadata:
   name: strimzi-operator`)
-			err := runHelmFn(gCtx, "upgrade", "--install", "strimzi-operator", "oci://quay.io/strimzi-helm/strimzi-kafka-operator", "--version", "1.0.0", "-n", "strimzi-operator", "--set", "watchAnyNamespace=true", "--set", "replicas=1", "--timeout", "5m", "--wait")
+			err := runHelmFn(gCtx, "upgrade", "--install", "strimzi-operator", "oci://quay.io/strimzi-helm/strimzi-kafka-operator", "--version", "1.0.0", "-n", "strimzi-operator", 
+				"--set", "watchAnyNamespace=true", 
+				"--set", "replicas=1", 
+				"--set", "resources.limits.memory=768Mi", 
+				"--set", "resources.requests.memory=768Mi", 
+				"--set", "leaderElection.enabled=false",
+				"--set", "operationTimeoutMs=900000",
+				"--timeout", "5m")
 			if err != nil { return err }
-			
-			fmt.Println("    - Waiting for Strimzi CRDs to be established...")
-			return runExecFn(gCtx, "kubectl", "wait", "--for=condition=Established", "crd", "kafkas.kafka.strimzi.io", "--timeout=60s")
+			return nil
 		})
 	}
 	
@@ -482,6 +509,14 @@ spec:
 		output.Error(fmt.Sprintf("Failed during Group A (Operators) deployments: %v", err))
 		return err
 	}
+
+	// ── Strimzi readiness (sequential — Bubble Tea needs exclusive terminal) ──
+	if deployWithStrimzi && !isTesting {
+		if err := waitStrimziReady(ctx, "strimzi-operator", 5*time.Minute); err != nil {
+			output.Error(fmt.Sprintf("Strimzi operator readiness failed: %v", err))
+			return err
+		}
+	}
 	
 	// Bust Kubernetes Discovery Cache so Helm knows about the newly created CRDs
 	fmt.Println("    - Refreshing API server schema cache...")
@@ -517,6 +552,43 @@ spec:
 	}
 
 	
+	if deployWithKafkaConnect {
+		g2.Go(func() error {
+			dbNS := deployDbNS
+			if isHelmReleaseDeployedFn(g2Ctx, "postgresql", dbNS) {
+				fmt.Println("⏭️  PostgreSQL already deployed. Skipping.")
+				return nil
+			}
+			fmt.Printf("\n📦 Deploying PostgreSQL CDC Database (Namespace: %s)...\n", dbNS)
+
+			runExecStdinFn(g2Ctx, "kubectl", []string{"apply", "-f", "-"}, fmt.Sprintf(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s`, dbNS))
+
+			runHelmFn(g2Ctx, "repo", "add", "bitnami", "https://charts.bitnami.com/bitnami")
+			runHelmFn(g2Ctx, "repo", "update", "bitnami")
+
+			if err := runHelmFn(g2Ctx, "upgrade", "--install", "postgresql", "bitnami/postgresql",
+				"-n", dbNS, "--create-namespace",
+				"--set", "auth.postgresPassword=postgres",
+				"--set", "auth.username=debezium",
+				"--set", "auth.password=debezium",
+				"--set", "auth.database=orders",
+				"--set", "primary.extendedConfiguration=wal_level = logical\nmax_wal_senders = 10\nmax_replication_slots = 10",
+				"--timeout", "5m", "--wait"); err != nil {
+				return err
+			}
+
+			if !isTesting {
+				if err := waitPostgresReady(g2Ctx, dbNS, 5*time.Minute); err != nil {
+					fmt.Printf("    %s PostgreSQL not ready: %v\n", amber("⚠"), err)
+				}
+			}
+			return nil
+		})
+	}
+
 	// Deploy Kafka
 	g2.Go(func() error {
 		if !isHelmReleaseDeployedFn(g2Ctx, "krafter", kafkaNS) {
@@ -530,16 +602,53 @@ spec:
 			if clusterDomain == "" {
 				clusterDomain = "cluster.local"
 			}
-			kafkaArgs := []string{
-				"upgrade", "--install", "krafter", "charts/kafka-cluster",
-				"-n", kafkaNS, "--create-namespace",
+			kafkaArgs := []string{"upgrade", "--install", "krafter", "charts/kafka-cluster", "-n", kafkaNS, "--create-namespace"}
+
+			kafkaArgs = append(kafkaArgs,
 				"-f", valuesFile,
-				"--set", "global.clusterDomain=" + clusterDomain,
+				"--set", "global.clusterDomain="+clusterDomain,
 				"--timeout", "10m",
-			}
+			)
 			if isKind {
 				kafkaArgs = append(kafkaArgs, "-f", "charts/kafka-cluster/values-kind.yaml")
 			}
+
+			if deployHA {
+				kafkaArgs = append(kafkaArgs,
+					"--set", "kafka.replicas=3",
+					"--set", "kafka.config.default\\.replication\\.factor=3",
+					"--set", "kafka.config.min\\.insync\\.replicas=2",
+					"--set", "zookeeper.replicas=3",
+					"--set", "kafkaConnect.replicas=3",
+				)
+			} else {
+				kafkaArgs = append(kafkaArgs,
+					"--set", "kafka.replicas=1",
+					"--set", "kafka.config.default\\.replication\\.factor=1",
+					"--set", "kafka.config.min\\.insync\\.replicas=1",
+					"--set", "zookeeper.replicas=1",
+					"--set", "kafkaConnect.replicas=1",
+				)
+			}
+
+			// (Values files are already appended above so these overrides take precedence)
+			
+			if deployWithKafkaConnect {
+				registryFQDN := fmt.Sprintf("http://apicurio-apicurio-registry.%s.svc.%s:80/apis/ccompat/v7",
+					kafkaNS, clusterDomain)
+
+				kafkaArgs = append(kafkaArgs,
+					"--set", "kafkaConnect.enabled=true",
+					"--set", "kafkaConnect.schemaRegistry.enabled=true",
+					"--set", "kafkaConnect.databaseEgress[0].namespace="+deployDbNS,
+					"--set", "kafkaConnect.databaseEgress[0].port=5432",
+					"--set", "kafkaConnect.databaseEgress[0].podSelector.app\\.kubernetes\\.io/name=postgresql",
+					"--set", "kafkaConnect.externalConfiguration.volumes[0].name=pg-credentials",
+					"--set", "kafkaConnect.externalConfiguration.volumes[0].secretName=connect-pg-credentials",
+					"--set", "kafkaConnect.extraConfig.schema\\.registry\\.url="+registryFQDN,
+				)
+			}
+			
 			if err := runHelmFn(g2Ctx, kafkaArgs...); err != nil {
 				return err
 			}
@@ -548,16 +657,13 @@ spec:
 		}
 
 
-		if isTesting {
-			fmt.Println("⚡ Running in test mode, skipping Kafka readiness polling and manifest waits.")
-			return nil
-		}
+		if !isTesting {
 
 		// Live progress poller — shows broker/controller/EO counts every 6s.
 		// waitKafkaReady already confirms Ready=True on the Kafka CR, which
 		// Strimzi only sets after the Entity Operator is also healthy.
 		// No separate EO wait needed.
-		if err := waitKafkaReady(g2Ctx, kafkaNS, 12*time.Minute); err != nil {
+		if err := waitKafkaReady(g2Ctx, kafkaNS, 15*time.Minute); err != nil {
 			return fmt.Errorf("kafka readiness failed: %w", err)
 		}
 
@@ -570,7 +676,7 @@ spec:
 		// time to establish its admin Kafka connection before it can process
 		// KafkaUser resources.
 		fmt.Println("    - Waiting for Entity Operator to start...")
-		eoDeadline := time.Now().Add(3 * time.Minute)
+		eoDeadline := time.Now().Add(5 * time.Minute)
 		for time.Now().Before(eoDeadline) {
 			eoOut, _ := exec.CommandContext(g2Ctx,
 				"kubectl", "get", "pods", "-n", kafkaNS,
@@ -590,166 +696,82 @@ spec:
 		}
 
 		// ── Poll KafkaUsers with progress ─────────────────────────────────
-		userTimeout := 5 * time.Minute
-		userDeadline := time.Now().Add(userTimeout)
-		start := time.Now()
-
-		fmt.Printf("\n    %s\n", boxTop(fmt.Sprintf(" Kafka Users  %s ", bold(fmt.Sprintf("(%s timeout)", fmtRemaining(userTimeout)))), 58))
-
-		lastPrintedUserLines := 0
-
-		for {
-			out, _ := exec.CommandContext(g2Ctx,
-				"kubectl", "get", "kafkauser",
-				"-n", kafkaNS,
-				"--no-headers",
-				"-o", "custom-columns=NAME:.metadata.name,READY:.status.conditions[0].status",
-			).Output()
-
-			type userStat struct {
-				name  string
-				ready bool
-			}
-			var users []userStat
-			total, ready := 0, 0
-			for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-				if line == "" {
-					continue
-				}
-				fields := strings.Fields(line)
-				if len(fields) < 1 {
-					continue
-				}
-				total++
-				isReady := len(fields) >= 2 && fields[1] == "True"
-				if isReady {
-					ready++
-				}
-				users = append(users, userStat{name: fields[0], ready: isReady})
-			}
-			
-			sort.Slice(users, func(i, j int) bool {
-				return users[i].name < users[j].name
-			})
-
-			elapsed := time.Since(start)
-			remaining := time.Until(userDeadline)
-			if remaining < 0 {
-				remaining = 0
-			}
-
-			isTimedOut := time.Now().After(userDeadline)
-			isCancelled := g2Ctx.Err() != nil
-			failed := isTimedOut || isCancelled
-
-			if lastPrintedUserLines > 0 {
-				fmt.Printf("\033[%dA", lastPrintedUserLines)
-			}
-			
-			renderUsers := func(finalFailed bool) int {
-				lines := 0
-				if len(users) == 0 {
-					fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s", dim("Waiting for KafkaUsers to be applied...")), 58))
-					lines++
-					return lines
-				}
-				for _, u := range users {
-					namePadded := fmt.Sprintf("%-12s", u.name)
-					if len(u.name) > 12 {
-						namePadded = u.name[:9] + "..."
-					}
-					
-					statusStr := red("pending")
-					progress := 0
-					if u.ready {
-						statusStr = blue("ready")
-						progress = 1
-					} else if finalFailed {
-						statusStr = red("failed")
-						if isTimedOut {
-							statusStr = red("timed out")
-						}
-					}
-					
-					fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
-						dim(namePadded),
-						renderProgressBar(progress, 1, 15, finalFailed && !u.ready),
-						fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", progress, 1)),
-						statusStr), 58))
-					lines++
-				}
-				return lines
-			}
-
-			elapsedSecs := int(elapsed.Seconds())
-			totalSecs := int(userTimeout.Seconds())
-
-			if total > 0 && ready == total {
-				// Final success UI
-				renderUsers(false)
-				fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s / %s",
-					dim(fmt.Sprintf("%-12s", "Timeout")),
-					renderProgressBar(elapsedSecs, totalSecs, 15, false),
-					blue(fmtElapsed(elapsedSecs)), blue(fmtElapsed(totalSecs))), 58))
-				fmt.Printf("    %s\033[K\n", boxBottom(58))
-				fmt.Printf("    %s All %d KafkaUser credentials ready  %s %s\033[K\n\n",
-					green("✔"), total, dim("elapsed"), bold(fmtElapsed(elapsedSecs)))
-				break
-			}
-
-			if isTimedOut {
-				// Show final failed state
-				renderUsers(true)
-				fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s / %s",
-					dim(fmt.Sprintf("%-12s", "Timeout")),
-					renderProgressBar(totalSecs, totalSecs, 15, true),
-					red(fmtElapsed(totalSecs)), red(fmtElapsed(totalSecs))), 58))
-				fmt.Printf("    %s\033[K\n", boxBottom(58))
-				break
-			}
-
-			// Render active progress
-			lines := renderUsers(failed)
-			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s / %s",
-				dim(fmt.Sprintf("%-12s", "Timeout")),
-				renderProgressBar(elapsedSecs, totalSecs, 15, failed),
-				fmtElapsed(elapsedSecs), fmtElapsed(totalSecs)), 58))
-			lines++
-			fmt.Printf("    %s\033[K\n", boxBottom(58))
-			lines++
-
-			if lastPrintedUserLines > lines {
-				for i := lines; i < lastPrintedUserLines; i++ {
-					fmt.Printf("\033[K\n")
-				}
-				fmt.Printf("\033[%dA", lastPrintedUserLines-lines)
-			}
-			lastPrintedUserLines = lines
-
-			select {
-			case <-g2Ctx.Done():
-				return g2Ctx.Err()
-			case <-time.After(6 * time.Second):
-			}
-		}
-
-		// Final check — if we exhausted the deadline
-		checkOut, _ := exec.CommandContext(g2Ctx,
-			"kubectl", "get", "kafkauser", "-n", kafkaNS,
-			"--no-headers",
-			"-o", "custom-columns=NAME:.metadata.name,READY:.status.conditions[0].status",
-		).Output()
-		allReady := true
-		for _, line := range strings.Split(strings.TrimSpace(string(checkOut)), "\n") {
-			fields := strings.Fields(line)
-			if len(fields) < 2 || fields[1] != "True" {
-				allReady = false
-				break
-			}
+		allReady, err := waitKafkaUsersReady(g2Ctx, kafkaNS, 8*time.Minute)
+		if err != nil {
+			return err
 		}
 		if !allReady {
 			fmt.Printf("    %s KafkaUsers not all ready after 5m — downstream deploys will retry secret lookup\n", amber("⚠"))
 		}
+		} // end !isTesting
+
+		if deployWithKafkaConnect {
+			fmt.Println("    - Creating PostgreSQL credentials secret for Kafka Connect...")
+			pgSecretYaml := fmt.Sprintf(`apiVersion: v1
+kind: Secret
+metadata:
+  name: connect-pg-credentials
+  namespace: %s
+type: Opaque
+stringData:
+  password: debezium
+  username: debezium`, kafkaNS)
+			runExecStdinFn(g2Ctx, "kubectl", []string{"apply", "-f", "-"}, pgSecretYaml)
+			
+			if !isTesting {
+				if err := waitConnectReady(g2Ctx, kafkaNS, 15*time.Minute); err != nil {
+					fmt.Printf("    %s Kafka Connect not ready: %v\n", amber("⚠"), err)
+				}
+			}
+
+			checkOut, checkErr := exec.CommandContext(g2Ctx, "kubectl", "get", "kafkaconnector", "debezium-postgres-source", "-n", kafkaNS, "--no-headers").CombinedOutput()
+			if checkErr != nil || strings.Contains(string(checkOut), "not found") {
+				fmt.Println("    - Deploying Debezium PostgreSQL CDC connector...")
+				connectorYaml := fmt.Sprintf(`apiVersion: kafka.strimzi.io/v1
+kind: KafkaConnector
+metadata:
+  name: debezium-postgres-source
+  namespace: %s
+  labels:
+    strimzi.io/cluster: krafter-connect
+spec:
+  class: io.debezium.connector.postgresql.PostgresConnector
+  tasksMax: 1
+  autoRestart:
+    enabled: true
+    maxRestarts: 10
+  config:
+    database.hostname: postgresql.database.svc
+    database.port: "5432"
+    database.user: debezium
+    database.password: "${file:/mnt/pg-credentials/password}"
+    database.dbname: katesdb
+    topic.prefix: cdc
+    schema.include.list: public
+    plugin.name: pgoutput
+    slot.name: debezium_kates
+    heartbeat.interval.ms: "10000"
+    snapshot.mode: initial
+    decimal.handling.mode: double
+    tombstones.on.delete: "true"
+    schema.history.internal.kafka.bootstrap.servers: krafter-kafka-bootstrap.%s.svc:9092
+    schema.history.internal.kafka.topic: cdc-schema-history`, kafkaNS, kafkaNS)
+				if err := runExecStdinFn(g2Ctx, "kubectl", []string{"apply", "-f", "-"}, connectorYaml); err != nil {
+					fmt.Printf("    %s Failed to deploy Debezium connector: %v\n", amber("⚠"), err)
+				} else {
+					fmt.Printf("    %s Debezium PostgreSQL CDC connector deployed\n", green("✔"))
+				}
+			} else {
+				fmt.Printf("    %s Debezium connector already exists — skipping\n", green("✔"))
+			}
+
+			if !isTesting {
+				if err := waitConnectorReady(g2Ctx, kafkaNS, 10*time.Minute); err != nil {
+					fmt.Printf("    %s Connectors not all ready: %v\n", amber("⚠"), err)
+				}
+			}
+		}
+		
 		return nil
 	})
 
@@ -859,6 +881,10 @@ data:
 		entries = append(entries, DeploySummaryEntry{Icon: "🛡️", Name: "Kyverno", Release: "kyverno", Namespace: "kyverno", Group: "A"})
 	}
 	entries = append(entries, DeploySummaryEntry{Icon: "📨", Name: "Kafka (krafter)", Release: "krafter", Namespace: kafkaNS, Group: "B"})
+	if deployWithKafkaConnect {
+		entries = append(entries, DeploySummaryEntry{Icon: "🐘", Name: "PostgreSQL (CDC)", Release: "postgresql", Namespace: "database", Group: "B"})
+		entries = append(entries, DeploySummaryEntry{Icon: "🔗", Name: "Kafka Connect", Release: "krafter", Namespace: kafkaNS, Group: "B"})
+	}
 	if deployWithMonitoring {
 		entries = append(entries, DeploySummaryEntry{Icon: "📊", Name: "Monitoring Stack", Release: "monitoring", Namespace: jaegerNS, Group: "B"})
 	}

--- a/cli/cmd/deploy_test.go
+++ b/cli/cmd/deploy_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -37,13 +38,17 @@ func TestDeployCommand_SingleTopology(t *testing.T) {
 	deployWithCertManager = false
 	deployWithKyverno = false
 	deployWithStrimzi = false
+	deployWithKafkaConnect = false
 
 	var executedCommands []string
+	var mu sync.Mutex
 	
 	// Mock functions
 	runExecFn = func(ctx context.Context, name string, args ...string) error {
 		cmdStr := name + " " + strings.Join(args, " ")
+		mu.Lock()
 		executedCommands = append(executedCommands, cmdStr)
+		mu.Unlock()
 		return nil
 	}
 	runExecStdinFn = func(ctx context.Context, name string, args []string, stdinData string) error {
@@ -51,7 +56,9 @@ func TestDeployCommand_SingleTopology(t *testing.T) {
 	}
 	runHelmFn = func(ctx context.Context, args ...string) error {
 		cmdStr := "helm " + strings.Join(args, " ")
+		mu.Lock()
 		executedCommands = append(executedCommands, cmdStr)
+		mu.Unlock()
 		return nil
 	}
 	isHelmReleaseDeployedFn = func(ctx context.Context, release, namespace string) bool {
@@ -107,12 +114,16 @@ func TestDeployCommand_IsolatedTopology(t *testing.T) {
 	deployWithCertManager = false
 	deployWithKyverno = false
 	deployWithStrimzi = false
+	deployWithKafkaConnect = true
 
 	var executedCommands []string
+	var mu sync.Mutex
 	
 	runExecFn = func(ctx context.Context, name string, args ...string) error {
 		cmdStr := name + " " + strings.Join(args, " ")
+		mu.Lock()
 		executedCommands = append(executedCommands, cmdStr)
+		mu.Unlock()
 		return nil
 	}
 	runExecStdinFn = func(ctx context.Context, name string, args []string, stdinData string) error {
@@ -120,7 +131,9 @@ func TestDeployCommand_IsolatedTopology(t *testing.T) {
 	}
 	runHelmFn = func(ctx context.Context, args ...string) error {
 		cmdStr := "helm " + strings.Join(args, " ")
+		mu.Lock()
 		executedCommands = append(executedCommands, cmdStr)
+		mu.Unlock()
 		return nil
 	}
 	isHelmReleaseDeployedFn = func(ctx context.Context, release, namespace string) bool {
@@ -133,13 +146,16 @@ func TestDeployCommand_IsolatedTopology(t *testing.T) {
 		t.Fatalf("runDeploy failed: %v", err)
 	}
 
-	foundKafka, foundKates, foundChaos, foundSchema := false, false, false, false
+	foundKafka, foundKates, foundChaos, foundSchema, foundPostgres := false, false, false, false, false
 	
 	for _, cmd := range executedCommands {
 		if strings.Contains(cmd, "helm upgrade --install krafter") {
 			foundKafka = true
 			if !strings.Contains(cmd, "-n kafka-sys") {
 				t.Errorf("Expected Kafka to be deployed in kafka-sys namespace, got: %s", cmd)
+			}
+			if !strings.Contains(cmd, "kafkaConnect.enabled=true") {
+				t.Errorf("Expected Kafka Connect to be enabled, got: %s", cmd)
 			}
 		}
 		if strings.Contains(cmd, "helm upgrade --install kates") {
@@ -160,10 +176,16 @@ func TestDeployCommand_IsolatedTopology(t *testing.T) {
 				t.Errorf("Expected Apicurio to be deployed in kafka-sys namespace, got: %s", cmd)
 			}
 		}
+		if strings.Contains(cmd, "helm upgrade --install postgresql bitnami/postgresql") {
+			foundPostgres = true
+			if !strings.Contains(cmd, "-n database") {
+				t.Errorf("Expected Postgres to be deployed in database namespace, got: %s", cmd)
+			}
+		}
 	}
 	
-	if !foundKafka || !foundKates || !foundChaos || !foundSchema {
-		t.Errorf("Missing expected commands. Kafka: %v, Kates: %v, Chaos: %v, Schema: %v", foundKafka, foundKates, foundChaos, foundSchema)
+	if !foundKafka || !foundKates || !foundChaos || !foundSchema || !foundPostgres {
+		t.Errorf("Missing expected commands. Kafka: %v, Kates: %v, Chaos: %v, Schema: %v, Postgres: %v", foundKafka, foundKates, foundChaos, foundSchema, foundPostgres)
 	}
 }
 
@@ -176,12 +198,16 @@ func TestDeployCommand_Idempotency(t *testing.T) {
 	deployWithCertManager = true
 	deployWithKyverno = true
 	deployWithStrimzi = true
+	deployWithKafkaConnect = false
 
 	var executedCommands []string
+	var mu sync.Mutex
 	
 	runExecFn = func(ctx context.Context, name string, args ...string) error {
 		cmdStr := name + " " + strings.Join(args, " ")
+		mu.Lock()
 		executedCommands = append(executedCommands, cmdStr)
+		mu.Unlock()
 		return nil
 	}
 	runExecStdinFn = func(ctx context.Context, name string, args []string, stdinData string) error {
@@ -189,7 +215,9 @@ func TestDeployCommand_Idempotency(t *testing.T) {
 	}
 	runHelmFn = func(ctx context.Context, args ...string) error {
 		cmdStr := "helm " + strings.Join(args, " ")
+		mu.Lock()
 		executedCommands = append(executedCommands, cmdStr)
+		mu.Unlock()
 		return nil
 	}
 	isHelmReleaseDeployedFn = func(ctx context.Context, release, namespace string) bool {
@@ -209,6 +237,216 @@ func TestDeployCommand_Idempotency(t *testing.T) {
 	for _, cmd := range executedCommands {
 		if strings.Contains(cmd, "helm upgrade") {
 			t.Errorf("Expected no helm upgrade commands to run due to idempotency, got: %s", cmd)
+		}
+	}
+}
+
+func TestDeployCommand_KafkaConnectParameters(t *testing.T) {
+	// Save and restore global flags
+	defer func() {
+		deployTopology = "isolated"
+		deployNamespace = "kates-stack"
+		deployKafkaNS = "kafka"
+		deployDbNS = "database"
+		deployAppNS = "kates"
+		deployChaosNS = "litmus"
+		deployWithSchemaRegistry = "none"
+		deployWithChaos = false
+		deployWithMonitoring = false
+		deployWithCertManager = false
+		deployWithKyverno = false
+		deployWithStrimzi = false
+		deployWithKafkaConnect = false
+	}()
+
+	deployTopology = "isolated"
+	deployKafkaNS = "kafka"
+	deployDbNS = "database"
+	deployAppNS = "kates"
+	deployChaosNS = "litmus"
+	deployWithSchemaRegistry = "none"
+	deployWithChaos = false
+	deployWithMonitoring = false
+	deployWithCertManager = false
+	deployWithKyverno = false
+	deployWithStrimzi = false
+	deployWithKafkaConnect = true
+
+	var executedCommands []string
+	var stdinCommands []string
+	var mu sync.Mutex
+
+	runExecFn = func(ctx context.Context, name string, args ...string) error {
+		cmdStr := name + " " + strings.Join(args, " ")
+		mu.Lock()
+		executedCommands = append(executedCommands, cmdStr)
+		mu.Unlock()
+		return nil
+	}
+	runExecStdinFn = func(ctx context.Context, name string, args []string, stdinData string) error {
+		cmdStr := name + " " + strings.Join(args, " ")
+		mu.Lock()
+		stdinCommands = append(stdinCommands, cmdStr+"|"+stdinData)
+		mu.Unlock()
+		return nil
+	}
+	runHelmFn = func(ctx context.Context, args ...string) error {
+		cmdStr := "helm " + strings.Join(args, " ")
+		mu.Lock()
+		executedCommands = append(executedCommands, cmdStr)
+		mu.Unlock()
+		return nil
+	}
+	isHelmReleaseDeployedFn = func(ctx context.Context, release, namespace string) bool {
+		return false
+	}
+
+	defaultExecutor = &MockExecutor{}
+
+	_ = deployCmd.Flags().Set("topology", deployTopology)
+	err := runDeploy(deployCmd, []string{})
+	if err != nil {
+		t.Fatalf("runDeploy failed: %v", err)
+	}
+
+	// 1. Verify Kafka helm command includes ALL connect-specific sets
+	foundKafkaConnect := false
+	for _, cmd := range executedCommands {
+		if !strings.Contains(cmd, "helm upgrade --install krafter") {
+			continue
+		}
+		foundKafkaConnect = true
+
+		connectSets := []string{
+			"kafkaConnect.enabled=true",
+			"kafkaConnect.schemaRegistry.enabled=true",
+			"kafkaConnect.databaseEgress[0].namespace=database",
+			"kafkaConnect.externalConfiguration.volumes[0].name=pg-credentials",
+		}
+		for _, expected := range connectSets {
+			if !strings.Contains(cmd, expected) {
+				t.Errorf("Expected Kafka helm command to include %q, got: %s", expected, cmd)
+			}
+		}
+	}
+	if !foundKafkaConnect {
+		t.Error("Kafka deployment command (krafter) was not executed")
+	}
+
+	// 2. Verify PostgreSQL is deployed with the correct namespace (database)
+	foundPostgres := false
+	for _, cmd := range executedCommands {
+		if strings.Contains(cmd, "helm upgrade --install postgresql bitnami/postgresql") {
+			foundPostgres = true
+			if !strings.Contains(cmd, "-n database") {
+				t.Errorf("Expected PostgreSQL to be deployed in 'database' namespace, got: %s", cmd)
+			}
+		}
+	}
+	if !foundPostgres {
+		t.Error("PostgreSQL deployment command was not executed")
+	}
+
+	// 3. Verify the connect-pg-credentials Secret creation kubectl command is invoked
+	foundPgSecret := false
+	for _, cmd := range stdinCommands {
+		if strings.Contains(cmd, "kubectl") && strings.Contains(cmd, "connect-pg-credentials") {
+			foundPgSecret = true
+		}
+	}
+	if !foundPgSecret {
+		t.Error("connect-pg-credentials Secret creation command was not invoked")
+	}
+}
+
+func TestDeployCommand_KafkaConnectIdempotent(t *testing.T) {
+	// Save and restore global flags
+	defer func() {
+		deployTopology = "isolated"
+		deployNamespace = "kates-stack"
+		deployKafkaNS = "kafka"
+		deployDbNS = "database"
+		deployAppNS = "kates"
+		deployChaosNS = "litmus"
+		deployWithSchemaRegistry = "none"
+		deployWithChaos = false
+		deployWithMonitoring = false
+		deployWithCertManager = false
+		deployWithKyverno = false
+		deployWithStrimzi = false
+		deployWithKafkaConnect = false
+	}()
+
+	deployTopology = "isolated"
+	deployKafkaNS = "kafka"
+	deployDbNS = "database"
+	deployAppNS = "kates"
+	deployChaosNS = "litmus"
+	deployWithSchemaRegistry = "none"
+	deployWithChaos = false
+	deployWithMonitoring = false
+	deployWithCertManager = false
+	deployWithKyverno = false
+	deployWithStrimzi = false
+	deployWithKafkaConnect = true
+
+	var executedCommands []string
+	var stdinCommands []string
+	var mu sync.Mutex
+
+	runExecFn = func(ctx context.Context, name string, args ...string) error {
+		cmdStr := name + " " + strings.Join(args, " ")
+		mu.Lock()
+		executedCommands = append(executedCommands, cmdStr)
+		mu.Unlock()
+		return nil
+	}
+	runExecStdinFn = func(ctx context.Context, name string, args []string, stdinData string) error {
+		cmdStr := name + " " + strings.Join(args, " ")
+		mu.Lock()
+		stdinCommands = append(stdinCommands, cmdStr+"|"+stdinData)
+		mu.Unlock()
+		return nil
+	}
+	runHelmFn = func(ctx context.Context, args ...string) error {
+		cmdStr := "helm " + strings.Join(args, " ")
+		mu.Lock()
+		executedCommands = append(executedCommands, cmdStr)
+		mu.Unlock()
+		return nil
+	}
+	isHelmReleaseDeployedFn = func(ctx context.Context, release, namespace string) bool {
+		// All releases are already deployed
+		return true
+	}
+
+	defaultExecutor = &MockExecutor{}
+
+	_ = deployCmd.Flags().Set("topology", deployTopology)
+	err := runDeploy(deployCmd, []string{})
+	if err != nil {
+		t.Fatalf("runDeploy failed: %v", err)
+	}
+
+	// When everything is already deployed, no helm upgrade should be called
+	for _, cmd := range executedCommands {
+		if strings.Contains(cmd, "helm upgrade") {
+			t.Errorf("Expected no helm upgrade commands due to idempotency, got: %s", cmd)
+		}
+	}
+
+	// Specifically, PostgreSQL should NOT be deployed
+	for _, cmd := range executedCommands {
+		if strings.Contains(cmd, "helm upgrade --install postgresql") {
+			t.Error("PostgreSQL should not be redeployed when already deployed (idempotency)")
+		}
+	}
+
+	// The connect-pg-credentials secret should still be created (it's applied idempotently via kubectl apply)
+	// but no helm upgrade for kafka/postgresql should run
+	for _, cmd := range executedCommands {
+		if strings.Contains(cmd, "helm upgrade --install krafter") {
+			t.Error("Kafka chart should not be redeployed when already deployed (idempotency)")
 		}
 	}
 }

--- a/cli/cmd/deploy_view.go
+++ b/cli/cmd/deploy_view.go
@@ -67,12 +67,18 @@ func RenderDeployDashboard(ctx context.Context, entries []DeploySummaryEntry, el
 	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(clrCyan)
 	sepLine := lipgloss.NewStyle().Foreground(clrDim).Render(strings.Repeat("─", 58))
 
+	colHdrName := lipgloss.NewStyle().Width(26).Render("COMPONENT")
+	colHdrNs := lipgloss.NewStyle().Width(18).Render("NAMESPACE")
+	colHdrStat := lipgloss.NewStyle().Render("STATUS")
+	colHeaders := lipgloss.NewStyle().Bold(true).Foreground(clrDim).Render(fmt.Sprintf("  %s%s%s", colHdrName, colHdrNs, colHdrStat))
+
 	for _, g := range []string{"A", "B", "C"} {
 		if len(groups[g]) == 0 {
 			continue
 		}
 		fmt.Println()
 		fmt.Println(headerStyle.Render(fmt.Sprintf("  Group %s — %s", g, groupNames[g])))
+		fmt.Println(colHeaders)
 		fmt.Println("  " + sepLine)
 		for _, e := range groups[g] {
 			status := getComponentStatus(ctx, e.Release, e.Namespace)
@@ -104,34 +110,24 @@ func getComponentStatus(ctx context.Context, release, namespace string) string {
 }
 
 func printRow(icon, name, namespace, status string) {
-	// Total combined visual width for icon + name + namespace before the status column starts.
-	// This ensures the status column perfectly aligns for all rows.
-	const targetWidth = 44
+	const nameWidth = 26
+	const nsWidth = 18
 
-	raw := icon + " " + name
-	visualLen := runewidth.StringWidth(raw)
-	
-	// Minimum padding between name and namespace
-	padLen := 26 - visualLen
-	if padLen < 1 {
-		padLen = 1
+	nameStr := icon + " " + name
+	nsStr := namespace
+
+	// Pad based on actual visual width so emoji don't throw off alignment
+	namePad := nameWidth - runewidth.StringWidth(nameStr)
+	if namePad < 1 {
+		namePad = 1
 	}
-	pad := strings.Repeat(" ", padLen)
-
-	nameCol := lipgloss.NewStyle().Bold(true).Foreground(clrText).Render(raw) + pad
-	
-	// Calculate the actual visual width consumed so far
-	consumedWidth := visualLen + padLen
-	
-	// How much space is left for the namespace column padding
-	nsVisualLen := runewidth.StringWidth(namespace)
-	nsPadLen := targetWidth - consumedWidth - nsVisualLen
-	if nsPadLen < 1 {
-		nsPadLen = 1
+	nsPad := nsWidth - runewidth.StringWidth(nsStr)
+	if nsPad < 1 {
+		nsPad = 1
 	}
-	nsPad := strings.Repeat(" ", nsPadLen)
 
-	nsCol := lipgloss.NewStyle().Foreground(clrDim).Render(namespace) + nsPad
+	nameCol := lipgloss.NewStyle().Bold(true).Foreground(clrText).Render(nameStr) + strings.Repeat(" ", namePad)
+	nsCol := lipgloss.NewStyle().Foreground(clrDim).Render(nsStr) + strings.Repeat(" ", nsPad)
 
 	// Status column
 	var statusStr string

--- a/cli/cmd/kafka.go
+++ b/cli/cmd/kafka.go
@@ -671,6 +671,7 @@ func init() {
 	kafkaCmd.AddCommand(kafkaAlterTopicCmd)
 	kafkaCmd.AddCommand(kafkaDeleteTopicCmd)
 	kafkaCmd.AddCommand(kafkaTuiCmd)
+	kafkaCmd.AddCommand(kafkaConnectCmd)
 	rootCmd.AddCommand(kafkaCmd)
 
 	registerKafkaCompletions()

--- a/cli/cmd/kafka_wait.go
+++ b/cli/cmd/kafka_wait.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"os/exec"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/mattn/go-runewidth"
 )
 
@@ -38,12 +40,6 @@ type kafkaPodStatus struct {
 	pendingPods   []string // names of Pending pods, for diagnostics
 }
 
-// countPodsByLabel queries pods matching the given label selector and counts
-// how many are fully Ready (all containers passing readiness probes) vs total.
-//
-// We check the pod-level Ready condition (True only when ALL containers are
-// ready) rather than just the pod phase, because a broker in phase "Running"
-// with 0/1 containers ready is NOT serving traffic.
 func countPodsByLabel(ctx context.Context, namespace, selector string) (running, total int, pending []string) {
 	out, _ := exec.CommandContext(ctx,
 		"kubectl", "get", "pods",
@@ -65,10 +61,9 @@ func countPodsByLabel(ctx context.Context, namespace, selector string) (running,
 		readyCond := ""
 		phase := ""
 		if len(fields) >= 3 {
-			readyCond = fields[1] // "True" or "False" or "<none>"
+			readyCond = fields[1]
 			phase = fields[2]
 		} else {
-			// Only 2 fields — Ready condition might be missing
 			phase = fields[1]
 		}
 
@@ -78,15 +73,12 @@ func countPodsByLabel(ctx context.Context, namespace, selector string) (running,
 		} else if phase == "Pending" || phase == "ContainerCreating" {
 			pending = append(pending, name)
 		} else {
-			// Running but not ready (e.g., 0/1) — still counts as pending
 			pending = append(pending, name)
 		}
 	}
 	return
 }
 
-// pollKafkaPods returns broker and controller pod counts using Strimzi's own
-// role labels (strimzi.io/broker-role and strimzi.io/controller-role).
 func pollKafkaPods(ctx context.Context, namespace string) kafkaPodStatus {
 	var s kafkaPodStatus
 
@@ -102,15 +94,12 @@ func pollKafkaPods(ctx context.Context, namespace string) kafkaPodStatus {
 	return s
 }
 
-// ── Progress Bar & Display Helpers ──────────────────────────────────────────
-
 var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
 func stripANSI(s string) string {
 	return ansiRe.ReplaceAllString(s, "")
 }
 
-// boxTop returns the top border of a box.
 func boxTop(title string, insideWidth int) string {
 	visibleLen := runewidth.StringWidth(stripANSI(title))
 	dashes := insideWidth - visibleLen - 1
@@ -120,12 +109,10 @@ func boxTop(title string, insideWidth int) string {
 	return dim("╭─") + title + dim(strings.Repeat("─", dashes) + "╮")
 }
 
-// boxBottom returns the bottom border of a box.
 func boxBottom(insideWidth int) string {
 	return dim("╰" + strings.Repeat("─", insideWidth) + "╯")
 }
 
-// boxRow pads the content to insideWidth and wraps it in left and right borders.
 func boxRow(content string, insideWidth int) string {
 	visibleLen := runewidth.StringWidth(stripANSI(content))
 	if visibleLen < insideWidth {
@@ -139,9 +126,6 @@ const (
 	charUnfilled = "▱"
 )
 
-// renderProgressBar returns a customizable width Unicode block bar with adaptive colors:
-//   - When not failed, filled blocks are in blue, empty blocks in dim gray.
-//   - When failed, the entire bar is shown in red.
 func renderProgressBar(running, total int, width int, failed bool) string {
 	if total <= 0 {
 		if failed {
@@ -165,17 +149,14 @@ func renderProgressBar(running, total int, width int, failed bool) string {
 	return blue(strings.Repeat(charFilled, filled)) + dim(strings.Repeat(charUnfilled, width-filled))
 }
 
-// colorProgressBar is a backward-compatible wrapper for renderProgressBar.
 func colorProgressBar(running, total int) string {
 	return renderProgressBar(running, total, 15, false)
 }
 
-// fmtElapsed formats seconds as "0:00".
 func fmtElapsed(secs int) string {
 	return fmt.Sprintf("%d:%02d", secs/60, secs%60)
 }
 
-// fmtRemaining formats a duration as "7m54s" trimming sub-seconds.
 func fmtRemaining(d time.Duration) string {
 	d = d.Round(time.Second)
 	if d <= 0 {
@@ -189,7 +170,6 @@ func fmtRemaining(d time.Duration) string {
 	return fmt.Sprintf("%dm%02ds", m, s)
 }
 
-// podPhaseLabel returns a colored phase badge.
 func podPhaseLabel(running, total int) string {
 	if total == 0 {
 		return red("⏳ waiting")
@@ -201,199 +181,422 @@ func podPhaseLabel(running, total int) string {
 	return red(fmt.Sprintf("✖ %d pending", pending))
 }
 
-// waitKafkaReady polls the Kafka CR condition AND actual pod phases every 6 s.
-//
-// It declares success only when ALL three conditions hold simultaneously:
-//   - kafka/krafter has condition Ready=True         (Strimzi agrees)
-//   - every broker pod is Running (and at least one exists)
-//   - every controller pod is Running (and at least one exists)
-func waitKafkaReady(ctx context.Context, namespace string, timeout time.Duration) error {
-	deadline := time.Now().Add(timeout)
-	poll := 6 * time.Second
-	elapsed := 0
-	totalSecs := int(timeout.Seconds())
+// ── Bubble Tea Implementation ──────────────────────────────────────────────
 
-	fmt.Printf("\n    %s\n", boxTop(fmt.Sprintf(" Kafka Cluster  %s ", bold(fmt.Sprintf("(%s timeout)", fmtRemaining(timeout)))), 58))
+type statusMsg struct {
+	crReady  bool
+	eoReady  bool
+	pods     kafkaPodStatus
+	pvcError bool
+	err      error
+}
 
-	lastPrintedLines := 0
+type tickMsg time.Time
 
-	for {
-		// ── 1. Kafka CR condition ──────────────────────────────────────────────
+func pollKafkaStatus(ctx context.Context, namespace string, elapsed int) tea.Cmd {
+	return func() tea.Msg {
+		var s statusMsg
+		// 1. CR condition
 		condOut, _ := exec.CommandContext(ctx,
 			"kubectl", "get", "kafka/krafter", "-n", namespace,
 			"-o", `jsonpath={range .status.conditions[*]}{.type}={.status} {end}`,
 		).Output()
-		crReady := strings.Contains(string(condOut), "Ready=True")
+		s.crReady = strings.Contains(string(condOut), "Ready=True")
 
-		// ── 2. Pod counts ──────────────────────────────────────────────────────
-		pods := pollKafkaPods(ctx, namespace)
+		// 2. Pod counts
+		s.pods = pollKafkaPods(ctx, namespace)
 
-		// ── 3. Entity Operator ─────────────────────────────────────────────────
+		// 3. Entity Operator
 		eoOut, _ := exec.CommandContext(ctx,
 			"kubectl", "get", "pods", "-n", namespace,
 			"-l", "app.kubernetes.io/name=entity-operator",
 			"--no-headers",
 			"-o", "custom-columns=PHASE:.status.phase",
 		).Output()
-		eoReady := strings.Contains(string(eoOut), "Running")
-		eoIcon := red("⏳")
-		if eoReady {
-			eoIcon = blue("✔")
-		}
+		s.eoReady = strings.Contains(string(eoOut), "Running")
 
-		// ── 4. Evaluate ────────────────────────────────────────────────────────
-		allBrokersUp := pods.brokerTotal > 0 && pods.brokerRunning == pods.brokerTotal
-		allCtrlUp := pods.ctrlTotal > 0 && pods.ctrlRunning == pods.ctrlTotal
-
-		isTimedOut := time.Now().After(deadline)
-		isCancelled := ctx.Err() != nil
-		failed := isTimedOut || isCancelled
-
-		if lastPrintedLines > 0 {
-			fmt.Printf("\033[%dA", lastPrintedLines)
-		}
-
-		if crReady && allBrokersUp && allCtrlUp {
-			// Final success block
-			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
-				dim("Brokers     "),
-				renderProgressBar(pods.brokerRunning, pods.brokerTotal, 15, false),
-				blue(fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", pods.brokerRunning, pods.brokerTotal))),
-				blue("✔ running")), 58))
-			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
-				dim("Controllers "),
-				renderProgressBar(pods.ctrlRunning, pods.ctrlTotal, 15, false),
-				blue(fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", pods.ctrlRunning, pods.ctrlTotal))),
-				blue("✔ running")), 58))
-			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s / %s",
-				dim("Timeout     "),
-				renderProgressBar(elapsed, totalSecs, 15, false),
-				blue(fmtElapsed(elapsed)), blue(fmtElapsed(totalSecs))), 58))
-			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  %s", dim("Entity Op   "), eoIcon), 58))
-			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  %s", dim("CR status   "), blue("✔ Ready=True")), 58))
-			fmt.Printf("    %s\033[K\n", boxBottom(58))
-			fmt.Printf("    %s Kafka ready  %s %s\033[K\n\n",
-				green("✔"), dim("elapsed"), bold(fmtElapsed(elapsed)))
-			return nil
-		}
-
-		// ── 5. Progress block ──────────────────────────────────────────────────
-		remaining := time.Until(deadline)
-		if remaining < 0 {
-			remaining = 0
-		}
-		
-		lines := 0
-		fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
-			dim("Brokers     "),
-			renderProgressBar(pods.brokerRunning, pods.brokerTotal, 15, failed),
-			fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", pods.brokerRunning, pods.brokerTotal)),
-			podPhaseLabel(pods.brokerRunning, pods.brokerTotal)), 58))
-		lines++
-		fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
-			dim("Controllers "),
-			renderProgressBar(pods.ctrlRunning, pods.ctrlTotal, 15, failed),
-			fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", pods.ctrlRunning, pods.ctrlTotal)),
-			podPhaseLabel(pods.ctrlRunning, pods.ctrlTotal)), 58))
-		lines++
-		fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s / %s",
-			dim("Timeout     "),
-			renderProgressBar(elapsed, totalSecs, 15, failed),
-			fmtElapsed(elapsed), fmtElapsed(totalSecs)), 58))
-		lines++
-		fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  %s",
-			dim("Entity Op   "), eoIcon), 58))
-		lines++
-
-		// ── 6. Pending pods hint (after 30 s) ────────────────────────────
-		if elapsed >= 30 && len(pods.pendingPods) > 0 {
-			fmt.Printf("    %s\033[K\n", boxRow("", 58))
-			lines++
-			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s", amber(fmt.Sprintf("⚠  %d pod(s) Pending — diagnose with:", len(pods.pendingPods)))), 58))
-			lines++
-			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf("    %s", dim(fmt.Sprintf("kubectl describe pod %s -n %s", pods.pendingPods[0], namespace))), 58))
-			lines++
-		}
-
-		// Always print the bottom border of the box
-		fmt.Printf("    %s\033[K\n", boxBottom(58))
-		lines++
-		
-		// Clear any leftover lines from a previous taller frame
-		if lastPrintedLines > lines {
-			for i := lines; i < lastPrintedLines; i++ {
-				fmt.Printf("\033[K\n")
-			}
-			fmt.Printf("\033[%dA", lastPrintedLines-lines)
-		}
-
-		// ── 6b. Early exit on unrecoverable storage errors ────────────────────
-		if elapsed > 30 && len(pods.pendingPods) > 0 {
+		// 4. PVC Error
+		if elapsed > 30 && len(s.pods.pendingPods) > 0 {
 			evOut, _ := exec.CommandContext(ctx,
 				"kubectl", "get", "events", "-n", namespace,
 				"--field-selector=reason=FailedScheduling",
 				"--no-headers", "-o", "custom-columns=MSG:.message",
 			).Output()
 			if strings.Contains(string(evOut), "unbound immediate PersistentVolumeClaims") {
-				fmt.Printf("\033[%dA", lines) // Re-render in place
-				fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
-					dim("Brokers     "),
-					renderProgressBar(pods.brokerRunning, pods.brokerTotal, 15, true),
-					red(fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", pods.brokerRunning, pods.brokerTotal))),
-					red("✖ failed")), 58))
-				fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
-					dim("Controllers "),
-					renderProgressBar(pods.ctrlRunning, pods.ctrlTotal, 15, true),
-					red(fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", pods.ctrlRunning, pods.ctrlTotal))),
-					red("✖ failed")), 58))
-				fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s / %s",
-					dim("Timeout     "),
-					renderProgressBar(elapsed, totalSecs, 15, true),
-					red(fmtElapsed(elapsed)), red(fmtElapsed(totalSecs))), 58))
-				fmt.Printf("    %s\033[K\n", boxBottom(58))
-				return fmt.Errorf(
-					"pods stuck Pending: PVCs unbound (StorageClass likely using Immediate mode — check kind_storage.go)\n" +
-					"Fix: kubectl delete pvc -n %s --all && kubectl delete kafka/krafter -n %s --ignore-not-found",
-					namespace, namespace,
-				)
+				s.pvcError = true
 			}
 		}
 
-		// ── 7. Timeout ─────────────────────────────────────────────────────────
-		if time.Now().After(deadline) {
-			fmt.Printf("\033[%dA", lines) // Re-render in place
-			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
-				dim("Brokers     "),
-				renderProgressBar(pods.brokerRunning, pods.brokerTotal, 15, true),
-				red(fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", pods.brokerRunning, pods.brokerTotal))),
-				red("✖ timed out")), 58))
-			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
-				dim("Controllers "),
-				renderProgressBar(pods.ctrlRunning, pods.ctrlTotal, 15, true),
-				red(fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", pods.ctrlRunning, pods.ctrlTotal))),
-				red("✖ timed out")), 58))
-			fmt.Printf("    %s\033[K\n", boxRow(fmt.Sprintf(" %s  [%s]  %s / %s",
-				dim("Timeout     "),
-				renderProgressBar(totalSecs, totalSecs, 15, true),
-				red(fmtElapsed(totalSecs)), red(fmtElapsed(totalSecs))), 58))
-			fmt.Printf("    %s\033[K\n", boxBottom(58))
-			return fmt.Errorf("%s kafka not ready after %s (brokers:%d/%d controllers:%d/%d pending:%d)",
-				red("✖"),
-				timeout,
-				pods.brokerRunning, pods.brokerTotal,
-				pods.ctrlRunning, pods.ctrlTotal,
-				len(pods.pendingPods))
-		}
-
-		lastPrintedLines = lines
-
-		// ── 8. Wait ────────────────────────────────────────────────────────────
-		select {
-		case <-ctx.Done():
-			fmt.Printf("    %s\n", dim("╰──────────────────────────────────────────────────────────╯"))
-			return ctx.Err()
-		case <-time.After(poll):
-			elapsed += int(poll.Seconds())
-		}
+		return s
 	}
+}
+
+type kafkaWaitModel struct {
+	ctx       context.Context
+	namespace string
+	timeout   time.Duration
+	start     time.Time
+	
+	pods      kafkaPodStatus
+	crReady   bool
+	eoReady   bool
+	pvcError  bool
+	err       error
+	done      bool
+}
+
+func (m kafkaWaitModel) Init() tea.Cmd {
+	m.start = time.Now()
+	return tea.Batch(
+		pollKafkaStatus(m.ctx, m.namespace, 0),
+		tea.Tick(6*time.Second, func(t time.Time) tea.Msg { return tickMsg(t) }),
+	)
+}
+
+func (m kafkaWaitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if msg.String() == "ctrl+c" {
+			m.err = fmt.Errorf("user aborted")
+			return m, tea.Quit
+		}
+	case statusMsg:
+		m.pods = msg.pods
+		m.crReady = msg.crReady
+		m.eoReady = msg.eoReady
+		
+		elapsed := int(time.Since(m.start).Seconds())
+		
+		if msg.pvcError {
+			m.pvcError = true
+			m.err = fmt.Errorf(
+				"pods stuck Pending: PVCs unbound (StorageClass likely using Immediate mode — check kind_storage.go)\n" +
+				"Fix: kubectl delete pvc -n %s --all && kubectl delete kafka/krafter -n %s --ignore-not-found",
+				m.namespace, m.namespace,
+			)
+			return m, tea.Quit
+		}
+
+		allBrokersUp := m.pods.brokerTotal > 0 && m.pods.brokerRunning == m.pods.brokerTotal
+		allCtrlUp := m.pods.ctrlTotal > 0 && m.pods.ctrlRunning == m.pods.ctrlTotal
+
+		if m.crReady && allBrokersUp && allCtrlUp {
+			m.done = true
+			return m, tea.Quit
+		}
+		
+		if elapsed >= int(m.timeout.Seconds()) {
+			m.err = fmt.Errorf("%s kafka not ready after %s (brokers:%d/%d controllers:%d/%d pending:%d)",
+				red("✖"),
+				m.timeout,
+				m.pods.brokerRunning, m.pods.brokerTotal,
+				m.pods.ctrlRunning, m.pods.ctrlTotal,
+				len(m.pods.pendingPods))
+			return m, tea.Quit
+		}
+
+	case tickMsg:
+		elapsed := int(time.Since(m.start).Seconds())
+		if elapsed >= int(m.timeout.Seconds()) {
+			m.err = fmt.Errorf("%s kafka not ready after %s (brokers:%d/%d controllers:%d/%d pending:%d)",
+				red("✖"),
+				m.timeout,
+				m.pods.brokerRunning, m.pods.brokerTotal,
+				m.pods.ctrlRunning, m.pods.ctrlTotal,
+				len(m.pods.pendingPods))
+			return m, tea.Quit
+		}
+		return m, tea.Batch(
+			pollKafkaStatus(m.ctx, m.namespace, elapsed),
+			tea.Tick(6*time.Second, func(t time.Time) tea.Msg { return tickMsg(t) }),
+		)
+	}
+	return m, nil
+}
+
+func (m kafkaWaitModel) View() string {
+	var b strings.Builder
+
+	elapsed := int(time.Since(m.start).Seconds())
+	totalSecs := int(m.timeout.Seconds())
+	if elapsed > totalSecs {
+		elapsed = totalSecs
+	}
+
+	failed := m.err != nil
+
+	b.WriteString(fmt.Sprintf("\n    %s\n", boxTop(fmt.Sprintf(" Kafka Cluster  %s ", bold(fmt.Sprintf("(%s timeout)", fmtRemaining(m.timeout)))), 58)))
+
+	brokerStatus := podPhaseLabel(m.pods.brokerRunning, m.pods.brokerTotal)
+	brokerCount := fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", m.pods.brokerRunning, m.pods.brokerTotal))
+	if m.done {
+		brokerStatus = blue("✔ running")
+		brokerCount = blue(brokerCount)
+	}
+	b.WriteString(fmt.Sprintf("    %s\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
+		dim("Brokers     "),
+		renderProgressBar(m.pods.brokerRunning, m.pods.brokerTotal, 15, failed),
+		brokerCount, brokerStatus), 58)))
+
+	ctrlStatus := podPhaseLabel(m.pods.ctrlRunning, m.pods.ctrlTotal)
+	ctrlCount := fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", m.pods.ctrlRunning, m.pods.ctrlTotal))
+	if m.done {
+		ctrlStatus = blue("✔ running")
+		ctrlCount = blue(ctrlCount)
+	}
+	b.WriteString(fmt.Sprintf("    %s\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
+		dim("Controllers "),
+		renderProgressBar(m.pods.ctrlRunning, m.pods.ctrlTotal, 15, failed),
+		ctrlCount, ctrlStatus), 58)))
+
+	b.WriteString(fmt.Sprintf("    %s\n", boxRow(fmt.Sprintf(" %s  [%s]  %s / %s",
+		dim("Timeout     "),
+		renderProgressBar(elapsed, totalSecs, 15, failed),
+		fmtElapsed(elapsed), fmtElapsed(totalSecs)), 58)))
+
+	eoIcon := red("⏳")
+	if m.eoReady || m.done {
+		eoIcon = blue("✔")
+	}
+	b.WriteString(fmt.Sprintf("    %s\n", boxRow(fmt.Sprintf(" %s  %s",
+		dim("Entity Op   "), eoIcon), 58)))
+
+	if m.done {
+		b.WriteString(fmt.Sprintf("    %s\n", boxRow(fmt.Sprintf(" %s  %s", dim("CR status   "), blue("✔ Ready=True")), 58)))
+	} else if elapsed >= 30 && len(m.pods.pendingPods) > 0 {
+		b.WriteString(fmt.Sprintf("    %s\n", boxRow(fmt.Sprintf(" %s", amber(fmt.Sprintf("⚠  %d pod(s) Pending", len(m.pods.pendingPods)))), 58)))
+	} else {
+		b.WriteString(fmt.Sprintf("    %s\n", boxRow(fmt.Sprintf(" %s  %s", dim("CR status   "), red("⏳ waiting")), 58)))
+	}
+
+	b.WriteString(fmt.Sprintf("    %s\n", boxBottom(58)))
+
+	if m.done {
+		b.WriteString(fmt.Sprintf("    %s Kafka ready  %s %s\n",
+			green("✔"), dim("elapsed"), bold(fmtElapsed(elapsed))))
+	} else {
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+func waitKafkaReady(ctx context.Context, namespace string, timeout time.Duration) error {
+	m := kafkaWaitModel{
+		ctx:       ctx,
+		namespace: namespace,
+		timeout:   timeout,
+		start:     time.Now(),
+	}
+	
+	p := tea.NewProgram(m)
+	finalModel, err := p.Run()
+	if err != nil {
+		return err
+	}
+	
+	fm := finalModel.(kafkaWaitModel)
+	if fm.err != nil {
+		return fm.err
+	}
+	
+	return nil
+}
+
+// ── Bubble Tea Implementation for Kafka Users ─────────────────────────────
+
+type userStat struct {
+	name  string
+	ready bool
+}
+
+type usersStatusMsg struct {
+	users []userStat
+	total int
+	ready int
+	err   error
+}
+
+func pollKafkaUsers(ctx context.Context, namespace string) tea.Cmd {
+	return func() tea.Msg {
+		var msg usersStatusMsg
+		out, _ := exec.CommandContext(ctx,
+			"kubectl", "get", "kafkauser",
+			"-n", namespace,
+			"--no-headers",
+			"-o", "custom-columns=NAME:.metadata.name,READY:.status.conditions[0].status",
+		).Output()
+
+		for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+			if line == "" {
+				continue
+			}
+			fields := strings.Fields(line)
+			if len(fields) < 1 {
+				continue
+			}
+			msg.total++
+			isReady := len(fields) >= 2 && fields[1] == "True"
+			if isReady {
+				msg.ready++
+			}
+			msg.users = append(msg.users, userStat{name: fields[0], ready: isReady})
+		}
+		
+		sort.Slice(msg.users, func(i, j int) bool {
+			return msg.users[i].name < msg.users[j].name
+		})
+
+		return msg
+	}
+}
+
+type kafkaUsersModel struct {
+	ctx       context.Context
+	namespace string
+	timeout   time.Duration
+	start     time.Time
+
+	users   []userStat
+	total   int
+	ready   int
+	err     error
+	done      bool
+	isTimeout bool
+}
+
+func (m kafkaUsersModel) Init() tea.Cmd {
+	m.start = time.Now()
+	return tea.Batch(
+		pollKafkaUsers(m.ctx, m.namespace),
+		tea.Tick(6*time.Second, func(t time.Time) tea.Msg { return tickMsg(t) }),
+	)
+}
+
+func (m kafkaUsersModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if msg.String() == "ctrl+c" {
+			m.err = fmt.Errorf("user aborted")
+			return m, tea.Quit
+		}
+	case usersStatusMsg:
+		m.users = msg.users
+		m.total = msg.total
+		m.ready = msg.ready
+		
+		elapsed := int(time.Since(m.start).Seconds())
+		
+		if m.total > 0 && m.ready == m.total {
+			m.done = true
+			return m, tea.Quit
+		}
+		
+		if elapsed >= int(m.timeout.Seconds()) {
+			m.isTimeout = true
+			m.done = true
+			return m, tea.Quit
+		}
+
+	case tickMsg:
+		elapsed := int(time.Since(m.start).Seconds())
+		if elapsed >= int(m.timeout.Seconds()) {
+			m.isTimeout = true
+			m.done = true
+			return m, tea.Quit
+		}
+		return m, tea.Batch(
+			pollKafkaUsers(m.ctx, m.namespace),
+			tea.Tick(6*time.Second, func(t time.Time) tea.Msg { return tickMsg(t) }),
+		)
+	}
+	return m, nil
+}
+
+func (m kafkaUsersModel) View() string {
+	var b strings.Builder
+
+	elapsed := int(time.Since(m.start).Seconds())
+	totalSecs := int(m.timeout.Seconds())
+	if elapsed > totalSecs {
+		elapsed = totalSecs
+	}
+
+	failed := m.err != nil || m.isTimeout
+
+	b.WriteString(fmt.Sprintf("\n    %s\n", boxTop(fmt.Sprintf(" Kafka Users  %s ", bold(fmt.Sprintf("(%s timeout)", fmtRemaining(m.timeout)))), 58)))
+
+	b.WriteString(m.renderUsers(failed))
+
+	b.WriteString(fmt.Sprintf("    %s\n", boxRow(fmt.Sprintf(" %s  [%s]  %s / %s",
+		dim(fmt.Sprintf("%-12s", "Timeout")),
+		renderProgressBar(elapsed, totalSecs, 15, failed),
+		fmtElapsed(elapsed), fmtElapsed(totalSecs)), 58)))
+
+	b.WriteString(fmt.Sprintf("    %s\n", boxBottom(58)))
+
+	if m.done && !m.isTimeout {
+		b.WriteString(fmt.Sprintf("    %s All %d KafkaUser credentials ready  %s %s\n",
+			green("✔"), m.total, dim("elapsed"), bold(fmtElapsed(elapsed))))
+	} else {
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+func (m kafkaUsersModel) renderUsers(finalFailed bool) string {
+	var b strings.Builder
+	if len(m.users) == 0 {
+		b.WriteString(fmt.Sprintf("    %s\n", boxRow(fmt.Sprintf(" %s", dim("Waiting for KafkaUsers to be applied...")), 58)))
+		return b.String()
+	}
+	for _, u := range m.users {
+		namePadded := fmt.Sprintf("%-12s", u.name)
+		if len(u.name) > 12 {
+			namePadded = u.name[:9] + "..."
+		}
+		
+		statusStr := red("pending")
+		progress := 0
+		if u.ready {
+			statusStr = blue("ready")
+			progress = 1
+		} else if finalFailed {
+			statusStr = red("failed")
+			if m.isTimeout {
+				statusStr = red("timed out")
+			}
+		}
+		
+		b.WriteString(fmt.Sprintf("    %s\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
+			dim(namePadded),
+			renderProgressBar(progress, 1, 15, finalFailed && !u.ready),
+			fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", progress, 1)),
+			statusStr), 58)))
+	}
+	return b.String()
+}
+
+func waitKafkaUsersReady(ctx context.Context, namespace string, timeout time.Duration) (bool, error) {
+	m := kafkaUsersModel{
+		ctx:       ctx,
+		namespace: namespace,
+		timeout:   timeout,
+		start:     time.Now(),
+	}
+	
+	p := tea.NewProgram(m)
+	finalModel, err := p.Run()
+	if err != nil {
+		return false, err
+	}
+	
+	fm := finalModel.(kafkaUsersModel)
+	if fm.err != nil {
+		return false, fm.err
+	}
+	
+	// Return true if all users are ready, false if timed out
+	return fm.total > 0 && fm.ready == fm.total, nil
 }

--- a/cli/cmd/strimzi_wait.go
+++ b/cli/cmd/strimzi_wait.go
@@ -1,0 +1,173 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// ── Bubble Tea: Strimzi Operator ───────────────────────────────────────────
+
+type strimziStatusMsg struct {
+	podRunning int
+	podTotal   int
+	pending    []string
+	crdReady   bool
+	err        error
+}
+
+func pollStrimziStatus(ctx context.Context, namespace string) tea.Cmd {
+	return func() tea.Msg {
+		var s strimziStatusMsg
+
+		// 1. Operator pod
+		s.podRunning, s.podTotal, s.pending = countPodsByLabel(ctx, namespace,
+			"name=strimzi-cluster-operator")
+
+		// 2. CRD established
+		crdOut, _ := exec.CommandContext(ctx,
+			"kubectl", "get", "crd", "kafkas.kafka.strimzi.io",
+			"-o", `jsonpath={.status.conditions[?(@.type=="Established")].status}`,
+		).Output()
+		s.crdReady = strings.TrimSpace(string(crdOut)) == "True"
+
+		return s
+	}
+}
+
+type strimziWaitModel struct {
+	ctx       context.Context
+	namespace string
+	timeout   time.Duration
+	start     time.Time
+
+	podRunning int
+	podTotal   int
+	pending    []string
+	crdReady   bool
+	err        error
+	done       bool
+}
+
+func (m strimziWaitModel) Init() tea.Cmd {
+	m.start = time.Now()
+	return tea.Batch(
+		pollStrimziStatus(m.ctx, m.namespace),
+		tea.Tick(6*time.Second, func(t time.Time) tea.Msg { return tickMsg(t) }),
+	)
+}
+
+func (m strimziWaitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if msg.String() == "ctrl+c" {
+			m.err = fmt.Errorf("user aborted")
+			return m, tea.Quit
+		}
+	case strimziStatusMsg:
+		m.podRunning = msg.podRunning
+		m.podTotal = msg.podTotal
+		m.pending = msg.pending
+		m.crdReady = msg.crdReady
+
+		allPodsUp := m.podTotal > 0 && m.podRunning == m.podTotal
+		if allPodsUp && m.crdReady {
+			m.done = true
+			return m, tea.Quit
+		}
+
+		elapsed := int(time.Since(m.start).Seconds())
+		if elapsed >= int(m.timeout.Seconds()) {
+			m.err = fmt.Errorf("%s strimzi operator not ready after %s (pods:%d/%d crd:%v)",
+				red("✖"), m.timeout, m.podRunning, m.podTotal, m.crdReady)
+			return m, tea.Quit
+		}
+
+	case tickMsg:
+		elapsed := int(time.Since(m.start).Seconds())
+		if elapsed >= int(m.timeout.Seconds()) {
+			m.err = fmt.Errorf("%s strimzi operator not ready after %s (pods:%d/%d crd:%v)",
+				red("✖"), m.timeout, m.podRunning, m.podTotal, m.crdReady)
+			return m, tea.Quit
+		}
+		return m, tea.Batch(
+			pollStrimziStatus(m.ctx, m.namespace),
+			tea.Tick(6*time.Second, func(t time.Time) tea.Msg { return tickMsg(t) }),
+		)
+	}
+	return m, nil
+}
+
+func (m strimziWaitModel) View() string {
+	var b strings.Builder
+
+	elapsed := int(time.Since(m.start).Seconds())
+	totalSecs := int(m.timeout.Seconds())
+	if elapsed > totalSecs {
+		elapsed = totalSecs
+	}
+
+	failed := m.err != nil
+
+	b.WriteString(fmt.Sprintf("\n    %s\n", boxTop(fmt.Sprintf(" Strimzi Operator  %s ", bold(fmt.Sprintf("(%s timeout)", fmtRemaining(m.timeout)))), 58)))
+
+	opStatus := podPhaseLabel(m.podRunning, m.podTotal)
+	opCount := fmt.Sprintf("%-5s", fmt.Sprintf("%d/%d", m.podRunning, m.podTotal))
+	if m.done {
+		opStatus = blue("✔ running")
+		opCount = blue(opCount)
+	}
+	b.WriteString(fmt.Sprintf("    %s\n", boxRow(fmt.Sprintf(" %s  [%s]  %s  %s",
+		dim("Operator    "),
+		renderProgressBar(m.podRunning, m.podTotal, 15, failed),
+		opCount, opStatus), 58)))
+
+	b.WriteString(fmt.Sprintf("    %s\n", boxRow(fmt.Sprintf(" %s  [%s]  %s / %s",
+		dim("Timeout     "),
+		renderProgressBar(elapsed, totalSecs, 15, failed),
+		fmtElapsed(elapsed), fmtElapsed(totalSecs)), 58)))
+
+	crdIcon := red("⏳ waiting")
+	if m.crdReady || m.done {
+		crdIcon = blue("✔ Established")
+	}
+	b.WriteString(fmt.Sprintf("    %s\n", boxRow(fmt.Sprintf(" %s  %s",
+		dim("CRDs        "), crdIcon), 58)))
+
+	b.WriteString(fmt.Sprintf("    %s\n", boxBottom(58)))
+
+	if m.done {
+		b.WriteString(fmt.Sprintf("    %s Strimzi Operator ready  %s %s\n",
+			green("✔"), dim("elapsed"), bold(fmtElapsed(elapsed))))
+	} else {
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+func waitStrimziReady(ctx context.Context, namespace string, timeout time.Duration) error {
+	m := strimziWaitModel{
+		ctx:       ctx,
+		namespace: namespace,
+		timeout:   timeout,
+		start:     time.Now(),
+	}
+
+	p := tea.NewProgram(m)
+	finalModel, err := p.Run()
+	if err != nil {
+		return err
+	}
+
+	fm := finalModel.(strimziWaitModel)
+	if fm.err != nil {
+		return fm.err
+	}
+
+	return nil
+}

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -74,7 +74,7 @@ func runUpgrade() error {
 
 	// ── 5. Display plan ──────────────────────────────────────────────────────
 	fmt.Println()
-	fmt.Println("    ╭─ Kates Upgrade ──────────────────────────────────────────╮")
+	fmt.Println("    ╭─ Kates Upgrade ────────────────────────────────────────────────────────────╮")
 	upgradeRow("Source", srcDir)
 	upgradeRow("Branch", gitBranch+gitDirty)
 	upgradeRow("Commit", gitCommit)
@@ -85,7 +85,7 @@ func runUpgrade() error {
 	if oldVersion != "" {
 		upgradeRow("Current", oldVersion)
 	}
-	fmt.Println("    ╰──────────────────────────────────────────────────────────╯")
+	fmt.Println("    ╰────────────────────────────────────────────────────────────────────────────╯")
 	fmt.Println()
 
 	if upgradeDryRun {
@@ -132,13 +132,13 @@ func runUpgrade() error {
 	newVersion := captureInstalledVersion(installPath)
 
 	fmt.Println()
-	fmt.Println("    ╭─ Upgrade Complete ───────────────────────────────────────╮")
+	fmt.Println("    ╭─ Upgrade Complete ─────────────────────────────────────────────────────────╮")
 	if oldVersion != "" {
 		upgradeRow("Previous", oldVersion)
 	}
 	upgradeRow("Installed", newVersion)
 	upgradeRow("Elapsed", time.Since(start).Round(time.Millisecond).String())
-	fmt.Println("    ╰──────────────────────────────────────────────────────────╯")
+	fmt.Println("    ╰────────────────────────────────────────────────────────────────────────────╯")
 	fmt.Println()
 
 	return nil
@@ -311,7 +311,13 @@ func execOutput(dir, name string, args ...string) (string, error) {
 }
 
 func upgradeRow(label, value string) {
-	fmt.Printf("    │  %-12s %s\n", label, value)
+	content := fmt.Sprintf("  %-12s %s", label, value)
+	pad := 76 - len(content)
+	if pad < 0 {
+		content = content[:73] + "..."
+		pad = 0
+	}
+	fmt.Printf("    │%s%s│\n", content, strings.Repeat(" ", pad))
 }
 
 func humanSize(bytes int64) string {

--- a/cli/pkg/detect/analyzer.go
+++ b/cli/pkg/detect/analyzer.go
@@ -2,6 +2,7 @@ package detect
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -271,6 +272,64 @@ func (a *Analyzer) calculateVerdict(report *DetectReport) {
 	}
 	addCheck("TLS certificate validity", certPass, certDetail)
 
+	// Ecosystem / CDC Checks
+	if report.Ecosystem.KafkaConnect.Installed {
+
+		// Connect JVM health check
+		if report.Ecosystem.KafkaConnect.HeapXmx != "" && report.Ecosystem.KafkaConnect.MemLimitMi > 0 {
+			heapMi := parseHeapMi(report.Ecosystem.KafkaConnect.HeapXmx)
+			limitMi := report.Ecosystem.KafkaConnect.MemLimitMi
+			ratio := float64(heapMi) / float64(limitMi) * 100
+			if ratio > 75 {
+				addCheck("Connect JVM heap ratio", false, fmt.Sprintf("%.0f%% of limit — risks OOMKill, reduce -Xmx", ratio))
+			} else if ratio > 50 {
+				v.Warns++
+				addCheck("Connect JVM heap ratio", true, fmt.Sprintf("%.0f%% of limit — limited off-heap space", ratio))
+			} else {
+				addCheck("Connect JVM heap ratio", true, fmt.Sprintf("%.0f%% of limit — healthy", ratio))
+			}
+		}
+
+		if !report.Ecosystem.KafkaConnect.TLSEnabled {
+			v.Warns++
+			addCheck("Connect TLS", true, "disabled — traffic is plaintext")
+		}
+
+		if !report.Ecosystem.KafkaConnect.PDBConfigured {
+			v.Warns++
+			addCheck("Connect PDB", true, "not configured — upgrades may cause downtime")
+		}
+
+		if !report.Ecosystem.SchemaRegistry.Installed {
+			v.Warns++
+			addCheck("Schema Registry for CDC", true, "warning: not found (Debezium Avro requires it)")
+		} else {
+			addCheck("Schema Registry for CDC", report.Ecosystem.SchemaRegistry.Available, "available")
+		}
+
+		if report.Ecosystem.Database.Installed {
+			addCheck("Database CDC source", report.Ecosystem.Database.Accessible, "available in "+report.Ecosystem.Database.Namespace)
+		} else {
+			v.Warns++
+			addCheck("Database CDC source", true, "warning: PostgreSQL not detected in cluster")
+		}
+	}
+
 	v.Compatible = v.Fails == 0
 	report.Verdict = v
+}
+
+// parseHeapMi converts a JVM heap string like "768m" or "2g" to MiB.
+func parseHeapMi(heap string) int {
+	heap = strings.TrimSpace(strings.ToLower(heap))
+	if strings.HasSuffix(heap, "m") {
+		v, _ := strconv.Atoi(strings.TrimSuffix(heap, "m"))
+		return v
+	}
+	if strings.HasSuffix(heap, "g") {
+		v, _ := strconv.Atoi(strings.TrimSuffix(heap, "g"))
+		return v * 1024
+	}
+	v, _ := strconv.Atoi(heap)
+	return v
 }

--- a/cli/pkg/detect/collector.go
+++ b/cli/pkg/detect/collector.go
@@ -111,6 +111,10 @@ func (c *Collector) Collect(ctx context.Context) (*DetectReport, error) {
 		report.Workload = c.getWorkloadPressure()
 		return nil
 	})
+	g.Go(func() error {
+		report.Ecosystem = c.getEcosystemStatus()
+		return nil
+	})
 
 	err := g.Wait()
 	if err != nil {
@@ -602,7 +606,7 @@ func (c *Collector) getStrimziStatus() StrimziInfo {
 			}
 
 			// Fetch logs
-			logs, _ := c.exec.Exec("kubectl", "logs", "-n", info.Namespace, pod.Metadata.Name, "--tail=100")
+			logs, _ := c.exec.Exec("kubectl", "logs", "-n", info.Namespace, pod.Metadata.Name, "--tail=100", "--since=15m")
 			var warningLogs []string
 			for _, line := range strings.Split(logs, "\n") {
 				lineLower := strings.ToLower(line)
@@ -632,6 +636,218 @@ func (c *Collector) getStrimziStatus() StrimziInfo {
 		}
 	} else {
 		info.Health.Status = "Unhealthy"
+	}
+
+	return info
+}
+
+func (c *Collector) getEcosystemStatus() EcosystemInfo {
+	info := EcosystemInfo{}
+
+	// Kafka Connect Status
+	kcOut, _ := c.exec.Exec("kubectl", "get", "kafkaconnect", "-A", "-o", "json")
+	var kcData struct {
+		Items []struct {
+			Metadata struct {
+				Name      string `json:"name"`
+				Namespace string `json:"namespace"`
+			} `json:"metadata"`
+			Spec struct {
+				Replicas int    `json:"replicas"`
+				Image    string `json:"image"`
+				Build    *struct {
+					Output struct {
+						Image string `json:"image"`
+						Type  string `json:"type"`
+					} `json:"output"`
+				} `json:"build"`
+				Rack *struct {
+					TopologyKey string `json:"topologyKey"`
+				} `json:"rack"`
+				Tracing *struct {
+					Type string `json:"type"`
+				} `json:"tracing"`
+				JVMOptions *struct {
+					Xms string `json:"-Xms"`
+					Xmx string `json:"-Xmx"`
+				} `json:"jvmOptions"`
+				Resources *struct {
+					Requests *struct {
+						CPU    string `json:"cpu"`
+						Memory string `json:"memory"`
+					} `json:"requests"`
+					Limits *struct {
+						CPU    string `json:"cpu"`
+						Memory string `json:"memory"`
+					} `json:"limits"`
+				} `json:"resources"`
+				TLS *struct {
+					TrustedCertificates []struct {
+						SecretName string `json:"secretName"`
+					} `json:"trustedCertificates"`
+				} `json:"tls"`
+				Template *struct {
+					PDB *struct {
+						MaxUnavailable int `json:"maxUnavailable"`
+					} `json:"podDisruptionBudget"`
+				} `json:"template"`
+			} `json:"spec"`
+			Status struct {
+				Conditions []struct {
+					Type   string `json:"type"`
+					Status string `json:"status"`
+				} `json:"conditions"`
+				LabelSelector    string `json:"labelSelector"`
+				ConnectorPlugins []struct {
+					Class   string `json:"class"`
+					Type    string `json:"type"`
+					Version string `json:"version"`
+				} `json:"connectorPlugins"`
+			} `json:"status"`
+		} `json:"items"`
+	}
+
+	if json.Unmarshal([]byte(kcOut), &kcData) == nil && len(kcData.Items) > 0 {
+		kc := kcData.Items[0]
+		info.KafkaConnect.Installed = true
+		info.KafkaConnect.Name = kc.Metadata.Name
+		info.KafkaConnect.Namespace = kc.Metadata.Namespace
+		info.KafkaConnect.TotalReplicas = kc.Spec.Replicas
+		info.KafkaConnect.Image = kc.Spec.Image
+
+		// Build status
+		if kc.Spec.Build != nil {
+			info.KafkaConnect.HasBuild = true
+		}
+
+		// Rack awareness
+		if kc.Spec.Rack != nil {
+			info.KafkaConnect.RackAware = true
+		}
+
+		// Tracing
+		if kc.Spec.Tracing != nil {
+			info.KafkaConnect.TracingEnabled = true
+		}
+
+		// JVM options
+		if kc.Spec.JVMOptions != nil {
+			info.KafkaConnect.HeapXms = kc.Spec.JVMOptions.Xms
+			info.KafkaConnect.HeapXmx = kc.Spec.JVMOptions.Xmx
+		}
+
+		// Resource limits/requests
+		if kc.Spec.Resources != nil {
+			if kc.Spec.Resources.Limits != nil {
+				info.KafkaConnect.MemLimitMi = parseResourceToMi(kc.Spec.Resources.Limits.Memory)
+				info.KafkaConnect.CPULimitM = parseResourceToCPUMilli(kc.Spec.Resources.Limits.CPU)
+			}
+			if kc.Spec.Resources.Requests != nil {
+				info.KafkaConnect.CPURequestM = parseResourceToCPUMilli(kc.Spec.Resources.Requests.CPU)
+			}
+		}
+
+		// TLS
+		if kc.Spec.TLS != nil {
+			info.KafkaConnect.TLSEnabled = true
+		}
+
+		// PDB
+		if kc.Spec.Template != nil && kc.Spec.Template.PDB != nil {
+			info.KafkaConnect.PDBConfigured = true
+		}
+
+		// Installed plugins from status
+		for _, p := range kc.Status.ConnectorPlugins {
+			info.KafkaConnect.Plugins = append(info.KafkaConnect.Plugins, p.Class)
+		}
+
+		// Check deployment for ready replicas
+		depOut, _ := c.exec.Exec("kubectl", "get", "deployment", fmt.Sprintf("%s-connect", info.KafkaConnect.Name), "-n", info.KafkaConnect.Namespace, "-o", "jsonpath={.status.readyReplicas}")
+		if depOut != "" {
+			info.KafkaConnect.ReadyReplicas, _ = strconv.Atoi(depOut)
+		}
+
+		// Connectors
+		kctorOut, _ := c.exec.Exec("kubectl", "get", "kafkaconnectors", "-n", info.KafkaConnect.Namespace, "-o", "json")
+		var kctorData struct {
+			Items []struct {
+				Metadata struct {
+					Name string `json:"name"`
+				} `json:"metadata"`
+				Spec struct {
+					Class    string `json:"class"`
+					TasksMax int    `json:"tasksMax"`
+				} `json:"spec"`
+				Status struct {
+					Conditions []struct {
+						Type   string `json:"type"`
+						Status string `json:"status"`
+					} `json:"conditions"`
+				} `json:"status"`
+			} `json:"items"`
+		}
+		if json.Unmarshal([]byte(kctorOut), &kctorData) == nil {
+			for _, kctor := range kctorData.Items {
+				status := "Unknown"
+				for _, cond := range kctor.Status.Conditions {
+					if cond.Type == "Ready" {
+						if cond.Status == "True" {
+							status = "Ready"
+						} else {
+							status = "NotReady"
+						}
+					}
+				}
+				info.KafkaConnect.Connectors = append(info.KafkaConnect.Connectors, ConnectorStatus{
+					Name:     kctor.Metadata.Name,
+					Class:    kctor.Spec.Class,
+					TasksMax: kctor.Spec.TasksMax,
+					Status:   status,
+				})
+			}
+		}
+	}
+
+	// Schema Registry Status
+	srOut, _ := c.exec.Exec("kubectl", "get", "deployment", "-A", "-l", "app.kubernetes.io/name=apicurio-registry", "-o", "json")
+	var srData struct {
+		Items []struct {
+			Metadata struct {
+				Name      string `json:"name"`
+				Namespace string `json:"namespace"`
+			} `json:"metadata"`
+			Status struct {
+				ReadyReplicas int `json:"readyReplicas"`
+			} `json:"status"`
+		} `json:"items"`
+	}
+	if json.Unmarshal([]byte(srOut), &srData) == nil && len(srData.Items) > 0 {
+		info.SchemaRegistry.Installed = true
+		info.SchemaRegistry.Name = srData.Items[0].Metadata.Name
+		info.SchemaRegistry.Namespace = srData.Items[0].Metadata.Namespace
+		info.SchemaRegistry.Available = srData.Items[0].Status.ReadyReplicas > 0
+	}
+
+	// Database CDC Status
+	dbOut, _ := c.exec.Exec("kubectl", "get", "statefulset,deployment", "-A", "-l", "app.kubernetes.io/name=postgresql", "-o", "json")
+	var dbData struct {
+		Items []struct {
+			Metadata struct {
+				Name      string `json:"name"`
+				Namespace string `json:"namespace"`
+			} `json:"metadata"`
+			Status struct {
+				ReadyReplicas int `json:"readyReplicas"`
+			} `json:"status"`
+		} `json:"items"`
+	}
+	if json.Unmarshal([]byte(dbOut), &dbData) == nil && len(dbData.Items) > 0 {
+		info.Database.Installed = true
+		info.Database.Name = dbData.Items[0].Metadata.Name
+		info.Database.Namespace = dbData.Items[0].Metadata.Namespace
+		info.Database.Port = 5432
+		info.Database.Accessible = dbData.Items[0].Status.ReadyReplicas > 0
 	}
 
 	return info
@@ -2022,4 +2238,37 @@ func (c *Collector) getSecurityAudit(adm AdmissionInfo) SecurityAudit {
 	}
 
 	return audit
+}
+
+// parseResourceToMi converts a Kubernetes memory resource string (e.g. "1Gi", "512Mi", "2G") to MiB.
+func parseResourceToMi(mem string) int {
+	mem = strings.TrimSpace(mem)
+	if strings.HasSuffix(mem, "Gi") {
+		v, _ := strconv.Atoi(strings.TrimSuffix(mem, "Gi"))
+		return v * 1024
+	}
+	if strings.HasSuffix(mem, "Mi") {
+		v, _ := strconv.Atoi(strings.TrimSuffix(mem, "Mi"))
+		return v
+	}
+	if strings.HasSuffix(mem, "G") {
+		v, _ := strconv.Atoi(strings.TrimSuffix(mem, "G"))
+		return v * 1000 // G = 10^9 bytes ≈ 953 MiB, but close enough
+	}
+	if strings.HasSuffix(mem, "M") {
+		v, _ := strconv.Atoi(strings.TrimSuffix(mem, "M"))
+		return v
+	}
+	return 0
+}
+
+// parseResourceToCPUMilli converts a Kubernetes CPU resource string (e.g. "1", "500m", "2000m") to millicores.
+func parseResourceToCPUMilli(cpu string) int {
+	cpu = strings.TrimSpace(cpu)
+	if strings.HasSuffix(cpu, "m") {
+		v, _ := strconv.Atoi(strings.TrimSuffix(cpu, "m"))
+		return v
+	}
+	v, _ := strconv.Atoi(cpu)
+	return v * 1000
 }

--- a/cli/pkg/detect/renderer_markdown.go
+++ b/cli/pkg/detect/renderer_markdown.go
@@ -127,6 +127,47 @@ func RenderMarkdown(report *DetectReport, w io.Writer) {
 		p("")
 	}
 
+	// Ecosystem & CDC
+	p("## Kafka Connect & CDC Ecosystem")
+	p("")
+	if report.Ecosystem.KafkaConnect.Installed {
+		p("- **Kafka Connect:** %s (in `%s`)", report.Ecosystem.KafkaConnect.Name, report.Ecosystem.KafkaConnect.Namespace)
+		p("- **Image:** `%s`", report.Ecosystem.KafkaConnect.Image)
+		p("- **Workers:** %d/%d ready", report.Ecosystem.KafkaConnect.ReadyReplicas, report.Ecosystem.KafkaConnect.TotalReplicas)
+		
+		if len(report.Ecosystem.KafkaConnect.Connectors) > 0 {
+			p("")
+			p("| Connector Name | Class | Tasks Max | Status |")
+			p("|----------------|-------|-----------|--------|")
+			for _, c := range report.Ecosystem.KafkaConnect.Connectors {
+				p("| %s | %s | %d | %s |", c.Name, c.Class, c.TasksMax, c.Status)
+			}
+		}
+	} else {
+		p("- **Kafka Connect:** ❌ Not installed")
+	}
+
+	if report.Ecosystem.SchemaRegistry.Installed {
+		if report.Ecosystem.SchemaRegistry.Available {
+			p("- **Schema Registry:** ✅ Available (`%s` in `%s`)", report.Ecosystem.SchemaRegistry.Name, report.Ecosystem.SchemaRegistry.Namespace)
+		} else {
+			p("- **Schema Registry:** ⚠️ Deployed but NOT READY (`%s`)", report.Ecosystem.SchemaRegistry.Name)
+		}
+	} else {
+		p("- **Schema Registry:** ❌ Not installed")
+	}
+
+	if report.Ecosystem.Database.Installed {
+		if report.Ecosystem.Database.Accessible {
+			p("- **Database CDC Source:** ✅ Accessible (`%s` in `%s`, port %d)", report.Ecosystem.Database.Name, report.Ecosystem.Database.Namespace, report.Ecosystem.Database.Port)
+		} else {
+			p("- **Database CDC Source:** ⚠️ Deployed but NOT READY (`%s`)", report.Ecosystem.Database.Name)
+		}
+	} else {
+		p("- **Database CDC Source:** ❌ Not detected")
+	}
+	p("")
+
 	// Admission
 	p("## Admission Controllers & Security")
 	p("")

--- a/cli/pkg/detect/renderer_tui.go
+++ b/cli/pkg/detect/renderer_tui.go
@@ -249,6 +249,90 @@ func RenderTUI(report *DetectReport) {
 		}
 	}
 
+	output.Header("Kafka Connect & CDC Ecosystem")
+	if report.Ecosystem.KafkaConnect.Installed {
+		output.KeyValue("Kafka Connect:", fmt.Sprintf("%s (in %s)", report.Ecosystem.KafkaConnect.Name, report.Ecosystem.KafkaConnect.Namespace))
+		output.KeyValue("Image:", report.Ecosystem.KafkaConnect.Image)
+		output.KeyValue("Workers:", fmt.Sprintf("%d/%d ready", report.Ecosystem.KafkaConnect.ReadyReplicas, report.Ecosystem.KafkaConnect.TotalReplicas))
+
+		// JVM health display
+		if report.Ecosystem.KafkaConnect.HeapXmx != "" {
+			heapMi := parseHeapMi(report.Ecosystem.KafkaConnect.HeapXmx)
+			limitMi := report.Ecosystem.KafkaConnect.MemLimitMi
+			if limitMi > 0 {
+				ratio := float64(heapMi) / float64(limitMi) * 100
+				output.KeyValue("JVM Heap:", fmt.Sprintf("-Xms=%s -Xmx=%s (%.0f%% of %dMi limit)",
+					report.Ecosystem.KafkaConnect.HeapXms,
+					report.Ecosystem.KafkaConnect.HeapXmx,
+					ratio, limitMi))
+				if ratio > 75 {
+					output.Error("JVM heap dangerously high — risks OOMKill. Run: kates detect --generate-values")
+				} else if ratio > 50 {
+					output.Warn("JVM heap > 50% of limit — limited off-heap space")
+				} else {
+					output.Success("JVM heap ratio: healthy")
+				}
+			} else {
+				output.KeyValue("JVM Heap:", fmt.Sprintf("-Xms=%s -Xmx=%s",
+					report.Ecosystem.KafkaConnect.HeapXms,
+					report.Ecosystem.KafkaConnect.HeapXmx))
+			}
+		}
+		if !report.Ecosystem.KafkaConnect.TLSEnabled {
+			output.Warn("TLS: disabled — Connect ↔ Kafka traffic is plaintext")
+		}
+		if !report.Ecosystem.KafkaConnect.PDBConfigured {
+			output.Warn("PDB: not configured — rolling upgrades may cause downtime")
+		}
+
+		if len(report.Ecosystem.KafkaConnect.Plugins) > 0 {
+			output.Success(fmt.Sprintf("Plugins: %d installed", len(report.Ecosystem.KafkaConnect.Plugins)))
+		}
+		if report.Ecosystem.KafkaConnect.TracingEnabled {
+			output.Success("Tracing: OpenTelemetry enabled")
+		}
+		if report.Ecosystem.KafkaConnect.RackAware {
+			output.Success("Rack awareness: enabled")
+		}
+		if report.Ecosystem.KafkaConnect.HasBuild {
+			output.Success("Strimzi Build: configured")
+		}
+
+		if len(report.Ecosystem.KafkaConnect.Connectors) > 0 {
+			output.Success(fmt.Sprintf("Connectors: %d detected", len(report.Ecosystem.KafkaConnect.Connectors)))
+			cHeaders := []string{"NAME", "CLASS", "TASKS MAX", "STATUS"}
+			var cRows [][]string
+			for _, c := range report.Ecosystem.KafkaConnect.Connectors {
+				cRows = append(cRows, []string{c.Name, c.Class, strconv.Itoa(c.TasksMax), c.Status})
+			}
+			output.Table(cHeaders, cRows)
+		} else {
+			output.Hint("Connectors: none deployed")
+		}
+	} else {
+		output.Warn("Kafka Connect: not installed")
+	}
+
+	if report.Ecosystem.SchemaRegistry.Installed {
+		if report.Ecosystem.SchemaRegistry.Available {
+			output.Success(fmt.Sprintf("Schema Registry: available (%s in %s)", report.Ecosystem.SchemaRegistry.Name, report.Ecosystem.SchemaRegistry.Namespace))
+		} else {
+			output.Error(fmt.Sprintf("Schema Registry: deployed but NOT READY (%s)", report.Ecosystem.SchemaRegistry.Name))
+		}
+	} else {
+		output.Hint("Schema Registry: not installed")
+	}
+
+	if report.Ecosystem.Database.Installed {
+		if report.Ecosystem.Database.Accessible {
+			output.Success(fmt.Sprintf("Database (CDC Source): accessible (%s in %s, port %d)", report.Ecosystem.Database.Name, report.Ecosystem.Database.Namespace, report.Ecosystem.Database.Port))
+		} else {
+			output.Error(fmt.Sprintf("Database (CDC Source): deployed but NOT READY (%s)", report.Ecosystem.Database.Name))
+		}
+	} else {
+		output.Hint("Database (CDC Source): not detected")
+	}
+
 	output.Header("Monitoring Stack")
 	if report.Monitoring.PodMonitorCRD {
 		output.Success("PodMonitor CRD: present")

--- a/cli/pkg/detect/types.go
+++ b/cli/pkg/detect/types.go
@@ -98,6 +98,55 @@ type MonitoringInfo struct {
 	ReleaseLabel      string
 }
 
+type EcosystemInfo struct {
+	KafkaConnect   KafkaConnectStatus
+	SchemaRegistry SchemaRegistryStatus
+	Database       DatabaseCDCStatus
+}
+
+type KafkaConnectStatus struct {
+	Installed      bool
+	Name           string
+	Namespace      string
+	ReadyReplicas  int
+	TotalReplicas  int
+	Image          string
+	Connectors     []ConnectorStatus
+	Plugins        []string
+	HasBuild       bool
+	TracingEnabled bool
+	RackAware      bool
+	HeapXms        string
+	HeapXmx        string
+	MemLimitMi     int
+	CPURequestM    int
+	CPULimitM      int
+	TLSEnabled     bool
+	PDBConfigured  bool
+}
+
+type ConnectorStatus struct {
+	Name   string
+	Class  string
+	TasksMax int
+	Status string
+}
+
+type SchemaRegistryStatus struct {
+	Installed bool
+	Name      string
+	Namespace string
+	Available bool
+}
+
+type DatabaseCDCStatus struct {
+	Installed  bool
+	Name       string
+	Namespace  string
+	Port       int
+	Accessible bool
+}
+
 type LatencyResult struct {
 	SourceZone string
 	TargetZone string
@@ -338,6 +387,7 @@ type DetectReport struct {
 	StorageAudit     StorageAudit
 	ExistingKafka    KafkaResources
 	Strimzi          StrimziInfo
+	Ecosystem        EcosystemInfo
 	Monitoring       MonitoringInfo
 	Network          NetworkInfo
 	Admission        AdmissionInfo
@@ -373,7 +423,7 @@ type GeneratedValues struct {
 	KafkaExporter      GenFeature             `yaml:"kafkaExporter"`
 	DrainCleaner       GenFeature             `yaml:"drainCleaner"`
 	Rebalance          GenFeature             `yaml:"rebalance"`
-	KafkaConnect       GenFeature             `yaml:"kafkaConnect"`
+	KafkaConnect       GenKafkaConnect        `yaml:"kafkaConnect"`
 	RBAC               GenFeature             `yaml:"rbac"`
 	EntityOperator     map[string]interface{} `yaml:"entityOperator"`
 	StrimziSubchart    GenStrimziSubchart     `yaml:"strimzi-kafka-operator"`
@@ -511,9 +561,16 @@ type GenUsers struct {
 }
 
 type GenUser struct {
-	Name           string       `yaml:"name"`
-	Authentication GenUserAuth  `yaml:"authentication"`
-	Authorization  *GenUserAuthz `yaml:"authorization,omitempty"`
+	Name           string         `yaml:"name"`
+	Authentication GenUserAuth    `yaml:"authentication"`
+	Quotas         *GenUserQuotas `yaml:"quotas,omitempty"`
+	Authorization  *GenUserAuthz  `yaml:"authorization,omitempty"`
+}
+
+type GenUserQuotas struct {
+	ProducerByteRate  int `yaml:"producerByteRate,omitempty"`
+	ConsumerByteRate  int `yaml:"consumerByteRate,omitempty"`
+	RequestPercentage int `yaml:"requestPercentage,omitempty"`
 }
 
 type GenUserAuth struct {
@@ -539,4 +596,49 @@ type GenAclResource struct {
 type GenFeature struct {
 	Enabled bool `yaml:"enabled"`
 	Create  bool `yaml:"create,omitempty"`
+}
+
+type GenKafkaConnect struct {
+	Enabled         bool                   `yaml:"enabled"`
+	Replicas        int                    `yaml:"replicas"`
+	GroupID         string                 `yaml:"groupId"`
+	JVMOptions      GenJVMOptions          `yaml:"jvmOptions"`
+	Resources       GenResources           `yaml:"resources"`
+	TLS             GenConnectTLS          `yaml:"tls"`
+	Rack            GenConnectRack         `yaml:"rack"`
+	Tracing         GenConnectTracing      `yaml:"tracing"`
+	TopologySpread  GenTopologyConstraints `yaml:"topologySpreadConstraints"`
+	PodAntiAffinity GenAntiAffinity        `yaml:"podAntiAffinity"`
+	PDB             GenConnectPDB          `yaml:"podDisruptionBudget"`
+	Config          GenConnectConfig       `yaml:"config"`
+	ExtraConfig     map[string]string      `yaml:"extraConfig,omitempty"`
+}
+
+type GenJVMOptions struct {
+	Xms string `yaml:"-Xms"`
+	Xmx string `yaml:"-Xmx"`
+}
+
+type GenConnectTLS struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+type GenConnectRack struct {
+	Enabled     bool   `yaml:"enabled"`
+	TopologyKey string `yaml:"topologyKey,omitempty"`
+}
+
+type GenConnectTracing struct {
+	Enabled bool   `yaml:"enabled"`
+	Type    string `yaml:"type,omitempty"`
+}
+
+type GenConnectPDB struct {
+	MaxUnavailable int `yaml:"maxUnavailable"`
+}
+
+type GenConnectConfig struct {
+	ReplicationFactor int    `yaml:"replicationFactor"`
+	KeyConverter      string `yaml:"keyConverter"`
+	ValueConverter    string `yaml:"valueConverter"`
 }

--- a/cli/pkg/detect/valuesgen.go
+++ b/cli/pkg/detect/valuesgen.go
@@ -337,7 +337,7 @@ func (g *ValuesGenerator) Generate() *GeneratedValues {
 		KafkaExporter: GenFeature{Enabled: false},
 		DrainCleaner:  GenFeature{Enabled: false},
 		Rebalance:     GenFeature{Enabled: true},
-		KafkaConnect:  GenFeature{Enabled: false},
+		KafkaConnect:  g.buildKafkaConnect(),
 		RBAC:          GenFeature{Create: true},
 		EntityOperator: map[string]interface{}{
 			"topicOperator": map[string]interface{}{
@@ -398,9 +398,176 @@ func (g *ValuesGenerator) Generate() *GeneratedValues {
 						},
 					},
 				},
+				{
+					Name: "kates-connect",
+					Authentication: GenUserAuth{
+						Type: "scram-sha-512",
+					},
+					Quotas: &GenUserQuotas{
+						ProducerByteRate: 52428800,
+						ConsumerByteRate: 52428800,
+						RequestPercentage: 25,
+					},
+					Authorization: &GenUserAuthz{
+						Type: "simple",
+						Acls: []GenAcl{
+							{
+								Resource: GenAclResource{
+									Type:        "topic",
+									Name:        "kates-connect-",
+									PatternType: "prefix",
+								},
+								Operations: []string{"Read", "Write", "Create", "Describe"},
+							},
+							{
+								Resource: GenAclResource{
+									Type:        "topic",
+									Name:        "kates-",
+									PatternType: "prefix",
+								},
+								Operations: []string{"Read", "Write", "Create", "Describe"},
+							},
+							{
+								Resource: GenAclResource{
+									Type:        "transactionalId",
+									Name:        "connect-cluster-",
+									PatternType: "prefix",
+								},
+								Operations: []string{"Write", "Describe"},
+							},
+							{
+								Resource: GenAclResource{
+									Type:        "topic",
+									Name:        "cdc",
+									PatternType: "prefix",
+								},
+								Operations: []string{"Read", "Write", "Create", "Describe"},
+							},
+							{
+								Resource: GenAclResource{
+									Type:        "group",
+									Name:        "kates-connect",
+									PatternType: "prefix",
+								},
+								Operations: []string{"Read", "Describe"},
+							},
+							{
+								Resource: GenAclResource{
+									Type: "cluster",
+								},
+								Operations: []string{"Describe"},
+							},
+						},
+					},
+				},
 			},
 		},
 		StrimziSubchart: GenStrimziSubchart{},
+	}
+}
+
+func (g *ValuesGenerator) buildKafkaConnect() GenKafkaConnect {
+	zoneScheduling := len(g.Report.Zones) >= 3
+	topologyKey := "topology.kubernetes.io/zone"
+	if !zoneScheduling {
+		topologyKey = "kubernetes.io/hostname"
+	}
+
+	// JVM sizing: memory limit based on cluster capacity
+	// Connect gets ~10% of Kafka memory budget, clamped [2Gi, 8Gi]
+	connectMemGi := float64(g.Cap.KafkaMem) * 0.1
+	if connectMemGi < 2 {
+		connectMemGi = 2
+	}
+	if connectMemGi > 8 {
+		connectMemGi = 8
+	}
+	memLimitMi := int(connectMemGi * 1024)
+	// Heap = 50% of limit (safe ratio for off-heap buffers)
+	heapMi := memLimitMi / 2
+	memRequestMi := memLimitMi * 3 / 4
+
+	// CPU: 10% of Kafka CPU budget, clamped [1000m, 4000m]
+	connectCPU := g.Cap.KafkaCPU / 10
+	if connectCPU < 1000 {
+		connectCPU = 1000
+	}
+	if connectCPU > 4000 {
+		connectCPU = 4000
+	}
+	cpuLimit := connectCPU * 2
+	if cpuLimit > 8000 {
+		cpuLimit = 8000
+	}
+
+	replicas := 3
+	if len(g.Report.Zones) > 0 && len(g.Report.Zones) < 3 {
+		replicas = len(g.Report.Zones)
+	}
+
+	// Auto-enable TLS when Kafka has TLS listener
+	tlsEnabled := false
+	for _, l := range g.Report.ExistingKafka.Health.Listeners {
+		if l.Type == "tls" || l.TLS {
+			tlsEnabled = true
+			break
+		}
+	}
+
+	extraConfig := map[string]string{
+		"producer.acks":               "all",
+		"producer.enable.idempotence": "true",
+		"consumer.auto.offset.reset":  "earliest",
+		"exactly.once.source.support":  "enabled",
+	}
+
+	return GenKafkaConnect{
+		Enabled:  g.Report.Ecosystem.KafkaConnect.Installed,
+		Replicas: replicas,
+		GroupID:  "kates-connect-cluster",
+		JVMOptions: GenJVMOptions{
+			Xms: fmt.Sprintf("%dm", heapMi),
+			Xmx: fmt.Sprintf("%dm", heapMi),
+		},
+		Resources: GenResources{
+			Requests: GenResourceValues{
+				Memory: fmt.Sprintf("%dMi", memRequestMi),
+				CPU:    fmt.Sprintf("%dm", connectCPU),
+			},
+			Limits: GenResourceValues{
+				Memory: fmt.Sprintf("%dMi", memLimitMi),
+				CPU:    fmt.Sprintf("%dm", cpuLimit),
+			},
+		},
+		TLS: GenConnectTLS{
+			Enabled: tlsEnabled,
+		},
+		Rack: GenConnectRack{
+			Enabled:     zoneScheduling,
+			TopologyKey: topologyKey,
+		},
+		Tracing: GenConnectTracing{
+			Enabled: g.Report.Monitoring.PodMonitorCRD,
+			Type:    "opentelemetry",
+		},
+		TopologySpread: GenTopologyConstraints{
+			Enabled:           zoneScheduling,
+			TopologyKey:       topologyKey,
+			WhenUnsatisfiable: "DoNotSchedule",
+		},
+		PodAntiAffinity: GenAntiAffinity{
+			Enabled:     true,
+			TopologyKey: "kubernetes.io/hostname",
+		},
+		PDB: GenConnectPDB{
+			MaxUnavailable: 1,
+		},
+		Config: GenConnectConfig{
+			ReplicationFactor: 3,
+			KeyConverter:      "org.apache.kafka.connect.json.JsonConverter",
+			ValueConverter:    "org.apache.kafka.connect.json.JsonConverter",
+		},
+		ExtraConfig: extraConfig,
 	}
 }
 

--- a/docs/kafka-connect.md
+++ b/docs/kafka-connect.md
@@ -1,0 +1,179 @@
+# Kafka Connect — Enterprise Image
+
+Production-ready Kafka Connect image with pre-installed CDC, Schema Registry,
+and JDBC connectors for enterprise data integration pipelines.
+
+## Quick Start
+
+```bash
+# Pull from GHCR
+docker pull ghcr.io/bmscomp/connect:3.0.2
+
+# Or build locally
+make connect-build
+```
+
+## Image Details
+
+| Property | Value |
+|----------|-------|
+| **Base Image** | `quay.io/strimzi/kafka:1.0.0-kafka-4.2.0` |
+| **Kafka Version** | 4.2.0 |
+| **Strimzi Version** | 1.0.0 |
+| **Architecture** | `linux/amd64`, `linux/arm64` |
+| **License** | Apache 2.0 |
+
+### Registries
+
+| Registry | Image |
+|----------|-------|
+| GitHub Container Registry | `ghcr.io/bmscomp/connect:<version>` |
+| Docker Hub | `bmscomp/connect:<version>` |
+
+### Tag Convention
+
+Tags follow the **Debezium version** bundled in the image:
+
+```
+ghcr.io/bmscomp/connect:3.0.2          # Debezium 3.0.2.Final
+ghcr.io/bmscomp/connect:latest         # latest build from main
+ghcr.io/bmscomp/connect:abc1234        # commit SHA
+```
+
+## Included Plugins
+
+### Debezium CDC Connectors (v3.0.2.Final)
+
+| Connector | Class | Use Case |
+|-----------|-------|----------|
+| PostgreSQL | `io.debezium.connector.postgresql.PostgresConnector` | Logical replication CDC from PostgreSQL |
+| MySQL | `io.debezium.connector.mysql.MySqlConnector` | Binlog-based CDC from MySQL/MariaDB |
+| MongoDB | `io.debezium.connector.mongodb.MongoDbConnector` | Change stream CDC from MongoDB |
+| SQL Server | `io.debezium.connector.sqlserver.SqlServerConnector` | Change Tracking CDC from SQL Server |
+
+### Apicurio Schema Registry (v2.5.11.Final)
+
+| JAR | Purpose |
+|-----|---------|
+| `apicurio-registry-utils-converter` | Kafka Connect converter for Apicurio Registry |
+| `apicurio-registry-serdes-avro-serde` | Avro serialization/deserialization |
+| `apicurio-registry-serdes-jsonschema-serde` | JSON Schema serialization/deserialization |
+| `apicurio-registry-serdes-protobuf-serde` | Protobuf serialization/deserialization |
+
+### Aiven JDBC Connector (v6.12.0)
+
+| Connector | Class | Use Case |
+|-----------|-------|----------|
+| JDBC Source | `io.aiven.connect.jdbc.JdbcSourceConnector` | Poll-based ingestion from SQL databases |
+| JDBC Sink | `io.aiven.connect.jdbc.JdbcSinkConnector` | Write-back to SQL databases |
+
+> **License**: Aiven JDBC connector is licensed under Apache 2.0, unlike the
+> Confluent JDBC connector which uses the Confluent Community License.
+
+### Built-in Connectors (from Kafka)
+
+| Connector | Class | Use Case |
+|-----------|-------|----------|
+| MirrorSource | `o.a.k.connect.mirror.MirrorSourceConnector` | Cross-cluster replication |
+| MirrorCheckpoint | `o.a.k.connect.mirror.MirrorCheckpointConnector` | Consumer offset sync |
+| MirrorHeartbeat | `o.a.k.connect.mirror.MirrorHeartbeatConnector` | Replication health check |
+
+## Usage with Strimzi
+
+### Using the pre-built image (recommended)
+
+```yaml
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaConnect
+metadata:
+  name: my-connect
+spec:
+  version: 4.2.0
+  replicas: 3
+  image: ghcr.io/bmscomp/connect:3.0.2
+  bootstrapServers: my-cluster-kafka-bootstrap:9093
+  tls:
+    trustedCertificates:
+      - secretName: my-cluster-cluster-ca-cert
+        pattern: "*.crt"
+  config:
+    group.id: my-connect-cluster
+    offset.storage.topic: my-connect-offsets
+    config.storage.topic: my-connect-configs
+    status.storage.topic: my-connect-status
+    config.storage.replication.factor: 3
+    offset.storage.replication.factor: 3
+    status.storage.replication.factor: 3
+```
+
+### Using with Helm chart
+
+```bash
+# In values.yaml
+kafkaConnect:
+  enabled: true
+  image: "ghcr.io/bmscomp/connect:3.0.2"
+```
+
+## Building Locally
+
+```bash
+# Build the image
+make connect-build
+
+# Build with a specific Debezium version
+docker build \
+  --build-arg DEBEZIUM_VERSION=3.0.2.Final \
+  -t connect:3.0.2 \
+  -f Dockerfile.connect .
+
+# Push to GHCR
+make connect-push
+```
+
+## CI/CD Pipeline
+
+The image is automatically built and published via GitHub Actions:
+
+```
+publish-connect.yml
+├── meta           → extract version from Dockerfile ARG
+├── build          → native amd64 + arm64 builds (no QEMU)
+├── merge          → create multi-arch manifest
+├── sign           → cosign keyless signing (tagged releases)
+└── verify         → pull and validate plugins
+```
+
+### Triggering a build
+
+```bash
+# Tag-based release
+git tag v1.0.0 && git push --tags
+
+# Manual dispatch with custom Debezium version
+gh workflow run publish-connect.yml \
+  -f debezium_version=3.0.2.Final \
+  -f platforms=linux/amd64,linux/arm64
+```
+
+## Security
+
+- **Base image**: Strimzi Kafka (Red Hat UBI-based, minimal attack surface)
+- **Non-root**: Runs as UID 1001
+- **Signing**: Images are signed with [Cosign](https://github.com/sigstore/cosign) keyless signing
+- **No Confluent dependencies**: All plugins use Apache 2.0 licensed components
+- **Verification**: `cosign verify ghcr.io/bmscomp/connect:3.0.2`
+
+## Upgrading Debezium
+
+1. Update `DEBEZIUM_VERSION` in `Dockerfile.connect`
+2. Push to main or tag a release
+3. CI builds and publishes the new image
+4. Update `kafkaConnect.image` in your Helm values
+
+```bash
+# Example: upgrade to Debezium 3.1.0
+sed -i 's/DEBEZIUM_VERSION=.*/DEBEZIUM_VERSION=3.1.0.Final/' Dockerfile.connect
+git commit -am "chore: bump Debezium to 3.1.0"
+git tag v1.1.0 && git push --tags
+```

--- a/kates/src/main/java/com/bmscomp/kates/service/ClusterTopologyService.java
+++ b/kates/src/main/java/com/bmscomp/kates/service/ClusterTopologyService.java
@@ -69,6 +69,13 @@ public class ClusterTopologyService {
             .withScope("Namespaced")
             .build();
 
+    private static final CustomResourceDefinitionContext KAFKA_CONNECTOR_CRD = new CustomResourceDefinitionContext.Builder()
+            .withGroup("kafka.strimzi.io")
+            .withVersion("v1")
+            .withPlural("kafkaconnectors")
+            .withScope("Namespaced")
+            .build();
+
     private static final CustomResourceDefinitionContext KAFKA_MM2_CRD = new CustomResourceDefinitionContext.Builder()
             .withGroup("kafka.strimzi.io")
             .withVersion("v1")
@@ -253,6 +260,24 @@ public class ClusterTopologyService {
             }
         } catch (Exception e) {
             LOG.debug("Unable to read Kafka Exporter info", e);
+        }
+
+        // Kafka Connect
+        try {
+            var connectPods = kubernetesClient.pods()
+                    .inNamespace(kafkaNamespace)
+                    .withLabel("strimzi.io/name", kafkaCluster + "-connect")
+                    .list().getItems();
+            if (!connectPods.isEmpty()) {
+                long readyCount = connectPods.stream().filter(this::isPodReady).count();
+                strimzi.put("kafkaConnectReady", readyCount == connectPods.size());
+                strimzi.put("kafkaConnectPods", connectPods.size());
+                strimzi.put("kafkaConnectReadyPods", readyCount);
+                String connectImage = connectPods.get(0).getSpec().getContainers().get(0).getImage();
+                strimzi.put("kafkaConnectImage", connectImage);
+            }
+        } catch (Exception e) {
+            LOG.debug("Unable to read Kafka Connect pod info", e);
         }
 
         return strimzi;
@@ -1083,11 +1108,174 @@ public class ClusterTopologyService {
                     .getItems();
             for (GenericKubernetesResource res : list) {
                 Map<String, Object> c = new LinkedHashMap<>();
-                c.put("name", res.getMetadata().getName());
+                String connectName = res.getMetadata().getName();
+                c.put("name", connectName);
                 Map<String, Object> spec = (Map<String, Object>) res.getAdditionalProperties()
                         .getOrDefault("spec", Map.of());
                 if (spec.get("replicas") instanceof Number n) c.put("replicas", n.intValue());
                 if (spec.get("bootstrapServers") != null) c.put("bootstrapServers", spec.get("bootstrapServers"));
+                if (spec.get("version") != null) c.put("version", spec.get("version"));
+
+                // CR status
+                Map<String, Object> status = (Map<String, Object>) res.getAdditionalProperties()
+                        .getOrDefault("status", Map.of());
+                if (status.get("conditions") instanceof List<?> conditions) {
+                    for (Object cond : conditions) {
+                        if (cond instanceof Map<?, ?> cm && "Ready".equals(cm.get("type"))) {
+                            c.put("ready", "True".equals(cm.get("status")));
+                        }
+                    }
+                }
+                if (status.get("url") != null) c.put("restUrl", status.get("url"));
+
+                // Build status
+                if (spec.get("build") != null) {
+                    c.put("hasBuild", true);
+                    Map<String, Object> buildSpec = (Map<String, Object>) spec.get("build");
+                    if (buildSpec.get("output") instanceof Map<?, ?> output) {
+                        c.put("buildImage", output.get("image"));
+                        c.put("buildType", output.get("type"));
+                    }
+                }
+
+                // Installed plugins from status
+                if (status.get("connectorPlugins") instanceof List<?> plugins) {
+                    List<Map<String, Object>> pluginList = new ArrayList<>();
+                    for (Object p : plugins) {
+                        if (p instanceof Map<?, ?> pm) {
+                            Map<String, Object> pi = new LinkedHashMap<>();
+                            pi.put("class", pm.get("class"));
+                            pi.put("type", pm.get("type"));
+                            pi.put("version", pm.get("version"));
+                            pluginList.add(pi);
+                        }
+                    }
+                    c.put("plugins", pluginList);
+                }
+
+                // Rack awareness
+                if (spec.get("rack") != null) {
+                    c.put("rackAware", true);
+                    if (spec.get("rack") instanceof Map<?, ?> rack) {
+                        c.put("rackTopologyKey", rack.get("topologyKey"));
+                    }
+                }
+
+                // Tracing
+                if (spec.get("tracing") instanceof Map<?, ?> tracing) {
+                    c.put("tracingEnabled", true);
+                    c.put("tracingType", tracing.get("type"));
+                }
+
+                // Resources
+                if (spec.get("resources") instanceof Map<?, ?> resources) {
+                    c.put("resources", resources);
+                }
+
+                // JVM options
+                if (spec.get("jvmOptions") instanceof Map<?, ?> jvm) {
+                    c.put("jvmOptions", jvm);
+                }
+
+                // Config details (schema registry, converters)
+                if (spec.get("config") instanceof Map<?, ?> config) {
+                    Map<String, Object> configSummary = new LinkedHashMap<>();
+                    if (config.get("key.converter") != null) configSummary.put("keyConverter", config.get("key.converter"));
+                    if (config.get("value.converter") != null) configSummary.put("valueConverter", config.get("value.converter"));
+                    if (config.get("schema.registry.url") != null) configSummary.put("schemaRegistryUrl", config.get("schema.registry.url"));
+                    if (!configSummary.isEmpty()) c.put("configSummary", configSummary);
+                }
+
+                // Pods for this KafkaConnect resource
+                try {
+                    var connectPods = kubernetesClient.pods()
+                            .inNamespace(kafkaNamespace)
+                            .withLabel("strimzi.io/name", connectName)
+                            .list().getItems();
+                    List<Map<String, Object>> podDetails = new ArrayList<>();
+                    int readyCount = 0;
+                    for (Pod pod : connectPods) {
+                        Map<String, Object> p = new LinkedHashMap<>();
+                        p.put("name", pod.getMetadata().getName());
+                        boolean ready = isPodReady(pod);
+                        p.put("ready", ready);
+                        if (ready) readyCount++;
+                        p.put("phase", pod.getStatus() != null ? pod.getStatus().getPhase() : "Unknown");
+                        if (pod.getSpec().getNodeName() != null) {
+                            p.put("k8sNode", pod.getSpec().getNodeName());
+                        }
+                        if (!pod.getSpec().getContainers().isEmpty()) {
+                            p.put("image", pod.getSpec().getContainers().get(0).getImage());
+                        }
+                        // Container restart count
+                        if (pod.getStatus() != null && pod.getStatus().getContainerStatuses() != null) {
+                            int restarts = pod.getStatus().getContainerStatuses().stream()
+                                    .mapToInt(cs -> cs.getRestartCount() != null ? cs.getRestartCount() : 0)
+                                    .sum();
+                            p.put("restarts", restarts);
+                        }
+                        podDetails.add(p);
+                    }
+                    c.put("pods", podDetails);
+                    c.put("readyPods", readyCount);
+                    c.put("totalPods", connectPods.size());
+                } catch (Exception e) {
+                    LOG.debug("Unable to read Kafka Connect pods for " + connectName, e);
+                }
+
+                // KafkaConnector resources
+                try {
+                    var connectors = kubernetesClient.genericKubernetesResources(KAFKA_CONNECTOR_CRD)
+                            .inNamespace(kafkaNamespace)
+                            .withLabel("strimzi.io/cluster", connectName)
+                            .list()
+                            .getItems();
+                    List<Map<String, Object>> connectorList = new ArrayList<>();
+                    for (GenericKubernetesResource connector : connectors) {
+                        Map<String, Object> ci = new LinkedHashMap<>();
+                        ci.put("name", connector.getMetadata().getName());
+                        Map<String, Object> connSpec = (Map<String, Object>) connector.getAdditionalProperties()
+                                .getOrDefault("spec", Map.of());
+                        if (connSpec.get("class") != null) ci.put("class", connSpec.get("class"));
+                        if (connSpec.get("tasksMax") instanceof Number n) ci.put("tasksMax", n.intValue());
+                        if (connSpec.get("pause") instanceof Boolean paused) ci.put("paused", paused);
+
+                        Map<String, Object> connStatus = (Map<String, Object>) connector.getAdditionalProperties()
+                                .getOrDefault("status", Map.of());
+                        if (connStatus.get("conditions") instanceof List<?> connConds) {
+                            for (Object cond : connConds) {
+                                if (cond instanceof Map<?, ?> cm && "Ready".equals(cm.get("type"))) {
+                                    ci.put("ready", "True".equals(cm.get("status")));
+                                    if (cm.get("message") != null) ci.put("message", cm.get("message"));
+                                }
+                            }
+                        }
+                        if (connStatus.get("connectorStatus") instanceof Map<?, ?> cs) {
+                            if (cs.get("connector") instanceof Map<?, ?> conn) {
+                                ci.put("state", conn.get("state"));
+                            }
+                            if (cs.get("tasks") instanceof List<?> tasks) {
+                                List<Map<String, Object>> taskList = new ArrayList<>();
+                                for (Object t : tasks) {
+                                    if (t instanceof Map<?, ?> tm) {
+                                        Map<String, Object> ti = new LinkedHashMap<>();
+                                        ti.put("id", tm.get("id"));
+                                        ti.put("state", tm.get("state"));
+                                        if (tm.get("trace") != null) ti.put("trace", tm.get("trace"));
+                                        taskList.add(ti);
+                                    }
+                                }
+                                ci.put("tasks", taskList);
+                            }
+                        }
+                        connectorList.add(ci);
+                    }
+                    connectorList.sort(Comparator.comparing(ci -> (String) ci.get("name")));
+                    c.put("connectors", connectorList);
+                } catch (Exception e) {
+                    LOG.debug("Unable to read KafkaConnectors for " + connectName, e);
+                }
+
                 connects.add(c);
             }
         } catch (Exception e) {


### PR DESCRIPTION
## Overview
This pull request introduces comprehensive support for deploying and monitoring **Kafka Connect** and **Debezium PostgreSQL CDC**, alongside a significantly improved deployment UI and robust timeout handling.

## Key Features & Enhancements

### Kafka Connect & PostgreSQL CDC Integration
- **Production-Ready Docker Image**: Introduced a fully-featured Kafka Connect image bundled with Debezium CDC, Apicurio converters, and Aiven JDBC plugins, complete with an automated CI/CD build pipeline (`.github/workflows/publish-connect.yml`).
- **Access Control Configuration**: Added the `kates-connect` Kafka user equipped with the necessary ACLs and transactional IDs to allow Connect to operate securely.
- **Ecosystem Checks**: Enhanced the `kates detect` command to audit and validate the Kafka Connect and CDC ecosystem setup.

### Beautiful & Interactive Deployment UI
- **Bubble Tea Progress Bars**: Completely revamped the CLI deployment output. Added sleek, interactive progress bars and spinners for:
  - Strimzi Cluster Operator installation
  - Kafka Connect deployment
  - Connector instantiation
  - PostgreSQL provisioning
- **Perfect Terminal Alignment**: Fixed UI alignment issues to ensure all `kates upgrade` tables and progress boxes have pixel-perfect layout and consistent widths regardless of terminal size.

### Resilience & Timeout Hardening
- **Kubernetes Probe Adjustments**: Doubled the default `readinessProbe` and `livenessProbe` timeouts to `30s` for Kafka Connect pods to prevent Kubernetes from aggressively killing the JVM during heavy startups.
- **Resource Scaling**: Increased default CPU and Memory allocations for Kafka Connect (now taking up 10% of cluster limits by default and capping at higher margins).
- **Strimzi Operator Resilience**: Bumped the Strimzi `operationTimeoutMs` to 15 minutes to guarantee it won't time out while waiting for heavy Connect instances to initialize.
- **Analyzer Refinements**: Updated the `detect` CLI log analyzer to only scan Strimzi logs from the last 15 minutes, preventing stale historical errors from triggering false-positive warnings.

## Verification
- Deployed locally to Kind clusters successfully.
- Progress UI redraws in-place seamlessly without "scrolling duplication".
- Helm overrides for Strimzi and KafkaConnect are working as intended.
