### PR TITLE
feat(helm): update Kafka Connect image to use published GHCR registry

### DIFF
--- a/charts/kafka-cluster/values-staging.yaml
+++ b/charts/kafka-cluster/values-staging.yaml
@@ -92,7 +92,7 @@ kafkaConnect:
   build:
     output:
       type: docker
-      image: ghcr.io/bmscomp/kates-connect:latest
+      image: ghcr.io/bmscomp/connect:3.0.2
       pushSecret: ghcr-credentials
     plugins:
       - name: debezium-postgres

--- a/charts/kafka-cluster/values.yaml
+++ b/charts/kafka-cluster/values.yaml
@@ -472,7 +472,7 @@ kafkaConnect:
   enabled: false
   replicas: 3
   version: ""
-  image: "kates-connect:local"
+  image: "ghcr.io/bmscomp/connect:3.0.2"
   groupId: kates-connect-cluster
 
   topologySpreadConstraints:

--- a/config/kafka-connect/kafka-connect.yaml
+++ b/config/kafka-connect/kafka-connect.yaml
@@ -23,7 +23,7 @@ spec:
   build:
     output:
       type: docker
-      image: kind-registry:5000/kates-connect:latest
+      image: ghcr.io/bmscomp/connect:3.0.2
     plugins:
       - name: debezium-postgres
         artifacts:


### PR DESCRIPTION
Replaces the local development image tag with the fully published production image from GHCR.