### PR TITLE
chore: update charts to use the latest image versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <p>
     <a href="https://github.com/bmscomp/kates/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/bmscomp/kates/ci.yml?branch=main&label=CI&logo=github" alt="CI" /></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?logo=apache" alt="License" /></a>
-    <a href="https://github.com/bmscomp/kates/releases/tag/v1.13.0"><img src="https://img.shields.io/badge/release-v1.13.0-brightgreen?logo=github" alt="Release" /></a>
+    <a href="https://github.com/bmscomp/kates/releases/tag/v1.17.0"><img src="https://img.shields.io/badge/release-v1.17.0-brightgreen?logo=github" alt="Release" /></a>
     <img src="https://img.shields.io/badge/CLI-Go%201.24-00ADD8?logo=go&logoColor=white" alt="Go" />
     <img src="https://img.shields.io/badge/Backend-Quarkus%203.32-4695EB?logo=quarkus&logoColor=white" alt="Quarkus" />
     <img src="https://img.shields.io/badge/Kafka-4.2.0%20KRaft-231F20?logo=apachekafka&logoColor=white" alt="Kafka" />
@@ -300,7 +300,7 @@ brew install kates
 ```
 
 #### Pre-Compiled Binaries
-Download the official **`v1.13.0`** binaries from the [GitHub Releases](https://github.com/bmscomp/kates/releases/tag/v1.13.0) page. Available for macOS and Linux (amd64 and arm64).
+Download the official **`v1.17.0`** binaries from the [GitHub Releases](https://github.com/bmscomp/kates/releases/tag/v1.17.0) page. Available for macOS and Linux (amd64 and arm64).
 
 #### From Source
 ```bash

--- a/charts/kates/values-generic.yaml
+++ b/charts/kates/values-generic.yaml
@@ -3,7 +3,7 @@
 
 image:
   repository: ghcr.io/bmscomp/kates
-  tag: "1.11"
+  tag: "1.17.0"
   pullPolicy: IfNotPresent
 
 resources:

--- a/charts/kates/values-prod.yaml
+++ b/charts/kates/values-prod.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/bmscomp/kates
-  tag: "1.9"
+  tag: "1.17.0"
   pullPolicy: Always
 
 resources:

--- a/docs/book/appendix-c-cicd.md
+++ b/docs/book/appendix-c-cicd.md
@@ -210,8 +210,8 @@ graph TD
 
 | Variant | Image | Platforms |
 |---------|-------|-----------|
-| **JVM** | `ghcr.io/bmscomp/kates:v1.x.x` | `linux/amd64`, `linux/arm64` |
-| **Native** | `ghcr.io/bmscomp/kates:v1.x.x-native` | `linux/amd64`, `linux/arm64` |
+| **JVM** | `ghcr.io/bmscomp/kates:1.17.0` | `linux/amd64`, `linux/arm64` |
+| **Native** | `ghcr.io/bmscomp/kates:1.17.0-native` | `linux/amd64`, `linux/arm64` |
 
 ### Process
 
@@ -245,7 +245,7 @@ graph TD
 
 | Property | Value |
 |----------|-------|
-| **Image** | `ghcr.io/bmscomp/kates-tester` |
+| **Image** | `ghcr.io/bmscomp/kates-tester:1.17.0` |
 | **Base** | Minimal Alpine/distroless |
 | **Contents** | Pre-built Kates CLI binary, `curl`, `kafkacat`, connectivity test scripts |
 | **Platforms** | `linux/amd64`, `linux/arm64` |


### PR DESCRIPTION
The purpose of this pull request is to update the images used on charts of litmus and upgrade the documentation 
