### PR TITLE
fix(kates): resolve strict network policy blocks and static init crash

### DIFF
--- a/charts/connect-cluster/templates/networkpolicies.yaml
+++ b/charts/connect-cluster/templates/networkpolicies.yaml
@@ -31,10 +31,19 @@ spec:
         - podSelector:
             matchLabels:
               strimzi.io/kind: cluster-operator
+        # Allow ingress from all sources for health probes (kubelet)
+        - namespaceSelector: {}
       ports:
         - port: 8083
           protocol: TCP
   egress:
+    # Allow DNS resolution
+    - to: []
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
     - to:
         - podSelector:
             matchLabels:
@@ -67,6 +76,7 @@ spec:
         - port: {{ .port | default 5432 }}
           protocol: TCP
     {{- end }}
+    # Allow API Server egress
     - to: []
       ports:
         - port: 443

--- a/charts/kates/templates/networkpolicy.yaml
+++ b/charts/kates/templates/networkpolicy.yaml
@@ -13,6 +13,14 @@ spec:
     - Ingress
     - Egress
   ingress:
+    # Allow Kubelet probes (and other general ingress for now to prevent probe drops)
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - port: 8080
+          protocol: TCP
+        - port: 9000
+          protocol: TCP
     {{- with .Values.networkPolicy.ingressRules }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -54,6 +62,11 @@ spec:
               kubernetes.io/metadata.name: {{ .Values.networkPolicy.prometheus.namespace | default "monitoring" }}
       ports:
         - port: {{ .Values.networkPolicy.prometheus.port | default 9090 }}
+          protocol: TCP
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - port: 8889
           protocol: TCP
     {{- with .Values.networkPolicy.egressRules }}
     {{- toYaml . | nindent 4 }}

--- a/kates/src/main/java/com/bmscomp/kates/security/ApiKeyAuthFilter.java
+++ b/kates/src/main/java/com/bmscomp/kates/security/ApiKeyAuthFilter.java
@@ -29,9 +29,11 @@ public class ApiKeyAuthFilter implements ContainerRequestFilter {
             "/openapi");
 
     @ConfigProperty(name = "kates.api.security-enabled", defaultValue = "true")
+    @io.quarkus.runtime.annotations.StaticInitSafe
     boolean securityEnabled;
 
     @ConfigProperty(name = "kates.api.key", defaultValue = "")
+    @io.quarkus.runtime.annotations.StaticInitSafe
     String apiKey;
 
     @Override


### PR DESCRIPTION
- Added UDP/TCP DNS egress and unrestricted ingress on port 8083 for connect-cluster NetworkPolicy to allow Strimzi controller resolution and Kubelet probes.
- Added unrestricted ingress on ports 8080/9000 and egress to Trogdor (port 8889) for kates backend NetworkPolicy to fix probe rejections.
- Annotated apiKey and securityEnabled config properties with @StaticInitSafe in ApiKeyAuthFilter.java to prevent Quarkus from crashing with IllegalStateException when dynamic API keys are injected by Helm.