### PR TITLE
fix: stabilize deployment and improve CLI dashboard

### DIFF
--- a/charts/connect-cluster/templates/_helpers.tpl
+++ b/charts/connect-cluster/templates/_helpers.tpl
@@ -99,3 +99,21 @@ capabilities:
   drop:
     - ALL
 {{- end }}
+
+{{/*
+Kafka bootstrap servers FQDN (SASL_PLAINTEXT port 9092).
+Usage: {{ include "connect-cluster.bootstrapServers" . }}
+*/}}
+{{- define "connect-cluster.bootstrapServers" -}}
+{{- if .Values.kafka.bootstrapServers -}}
+{{- .Values.kafka.bootstrapServers -}}
+{{- else -}}
+{{- $svc := printf "%s-kafka-bootstrap" (.Values.kafka.clusterName | default "krafter") -}}
+{{- if .Values.kafka.tls.enabled -}}
+{{- printf "%s.%s.svc.%s:9093" $svc (include "connect-cluster.namespace" .) (include "connect-cluster.clusterDomain" .) -}}
+{{- else -}}
+{{- printf "%s.%s.svc.%s:9092" $svc (include "connect-cluster.namespace" .) (include "connect-cluster.clusterDomain" .) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+

--- a/charts/connect-cluster/templates/kafka-connect.yaml
+++ b/charts/connect-cluster/templates/kafka-connect.yaml
@@ -16,14 +16,14 @@ spec:
   {{- end }}
   version: {{ .Values.version }}
   replicas: {{ .Values.replicas }}
-  bootstrapServers: {{ .Values.kafka.bootstrapServers }}
+  bootstrapServers: {{ include "connect-cluster.bootstrapServers" . }}
   authentication:
     type: {{ .Values.kafka.authentication.type | default "scram-sha-512" }}
     {{- if or (eq (.Values.kafka.authentication.type | default "scram-sha-512") "scram-sha-512") (eq (.Values.kafka.authentication.type | default "scram-sha-512") "scram-sha-256") }}
     username: {{ .Values.kafka.authentication.username | default "kates-connect" }}
     passwordSecret:
       secretName: {{ .Values.kafka.authentication.secretName | default .Values.kafka.authentication.username | default "kates-connect" }}
-      password: password
+      password: {{ .Values.kafka.authentication.secretKey | default "password" }}
     {{- else if eq .Values.kafka.authentication.type "tls" }}
     certificateAndKey:
       secretName: {{ .Values.kafka.authentication.certificateSecret | default "kates-connect-tls" }}

--- a/charts/connect-cluster/values.schema.json
+++ b/charts/connect-cluster/values.schema.json
@@ -35,7 +35,7 @@
       "properties": {
         "bootstrapServers": {
           "type": "string",
-          "minLength": 1,
+          "minLength": 0,
           "description": "Kafka bootstrap servers (host:port)"
         },
         "tls": {

--- a/charts/connect-cluster/values.yaml
+++ b/charts/connect-cluster/values.yaml
@@ -34,8 +34,10 @@ clusterDomain: cluster.local
 # in the same namespace as this Connect cluster. Adjust these if Kafka is deployed
 # elsewhere or has a different name.
 kafka:
-  # -- Bootstrap servers for the Kafka cluster
-  bootstrapServers: "krafter-kafka-bootstrap:9092"
+  # -- Kafka cluster name
+  clusterName: "krafter"
+  # -- Bootstrap servers for the Kafka cluster (leave empty to compute automatically)
+  bootstrapServers: ""
   tls:
     enabled: false
     # -- Secret containing the CA certificate for Kafka
@@ -46,6 +48,8 @@ kafka:
     username: "kates-connect"
     # -- Secret containing the authentication password (defaults to username if empty)
     secretName: "kates-connect"
+    # -- Key in the Secret containing the authentication password
+    secretKey: "password"
 
 # ── Scheduling ──────────────────────────────────────────────────────────────
 topologySpreadConstraints:

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -459,12 +459,25 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 			// ---------------------------------------------------------
 			// GROUP A: Operators & CRDs (Parallel)
 			// ---------------------------------------------------------
+			deployStrimzi := false
+			if deployWithStrimzi {
+				deployStrimzi = !isHelmReleaseDeployedFn(ctx, "strimzi-operator", "strimzi-operator")
+			}
+			deployCertManager := false
+			if deployWithCertManager {
+				deployCertManager = !isHelmReleaseDeployedFn(ctx, "cert-manager", "cert-manager")
+			}
+			deployKyverno := false
+			if deployWithKyverno {
+				deployKyverno = !isHelmReleaseDeployedFn(ctx, "kyverno", "kyverno")
+			}
+
 			g, gCtx := errgroup.WithContext(ctx)
 
 			// Deploy Strimzi Operator
 			if deployWithStrimzi {
 				g.Go(func() error {
-					if isHelmReleaseDeployedFn(gCtx, "strimzi-operator", "strimzi-operator") {
+					if !deployStrimzi {
 						dl.Println("⏭️  Strimzi Operator already deployed. Skipping.")
 						dl.FinishComponent("strimzi", true)
 						advanceStep()
@@ -476,8 +489,13 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 kind: Namespace
 metadata:
   name: strimzi-operator`)
+					clusterDomain := report.Network.ClusterDomain
+					if clusterDomain == "" {
+						clusterDomain = "cluster.local"
+					}
 					err := runHelmFn(gCtx, "upgrade", "--install", "strimzi-operator", "oci://quay.io/strimzi-helm/strimzi-kafka-operator", "--version", "1.0.0", "-n", "strimzi-operator",
 						"--set", "watchAnyNamespace=true",
+						"--set", "kubernetesServiceDnsDomain="+clusterDomain,
 						"--set", "replicas=1",
 						"--set", "resources.limits.memory=768Mi",
 						"--set", "resources.requests.memory=768Mi",
@@ -494,7 +512,7 @@ metadata:
 			// Deploy Cert-Manager
 			if deployWithCertManager {
 				g.Go(func() error {
-					if isHelmReleaseDeployedFn(gCtx, "cert-manager", "cert-manager") {
+					if !deployCertManager {
 						dl.Println("⏭️  Cert-Manager already deployed. Skipping.")
 						dl.FinishComponent("cert-manager", true)
 						advanceStep()
@@ -611,7 +629,7 @@ spec:
 			// Deploy Kyverno
 			if deployWithKyverno {
 				g.Go(func() error {
-					if isHelmReleaseDeployedFn(gCtx, "kyverno", "kyverno") {
+					if !deployKyverno {
 						dl.Println("⏭️  Kyverno already deployed. Skipping.")
 						dl.FinishComponent("kyverno", true)
 						advanceStep()
@@ -657,7 +675,7 @@ spec:
 
 			// ── Sequential Readiness Waits for Group A ──
 			if deployWithStrimzi && !isTesting {
-				if isHelmReleaseDeployedFn(ctx, "strimzi-operator", "strimzi-operator") {
+				if !deployStrimzi {
 					// Already skipped above, but ensure progress isn't blocked
 				} else {
 					dl.StartComponent("strimzi", 5*time.Minute)
@@ -670,7 +688,7 @@ spec:
 				}
 			}
 			if deployWithCertManager && !isTesting {
-				if isHelmReleaseDeployedFn(ctx, "cert-manager", "cert-manager") {
+				if !deployCertManager {
 					// already handled
 				} else {
 					dl.StartComponent("cert-manager", 10*time.Minute)
@@ -683,7 +701,7 @@ spec:
 				}
 			}
 			if deployWithKyverno && !isTesting {
-				if isHelmReleaseDeployedFn(ctx, "kyverno", "kyverno") {
+				if !deployKyverno {
 					// already handled
 				} else {
 					dl.StartComponent("kyverno", 5*time.Minute)
@@ -832,8 +850,6 @@ metadata:
 
 					// (Values files are already appended above so these overrides take precedence)
 
-
-
 					if err := runHelmFn(g2Ctx, kafkaArgs...); err != nil {
 						return err
 					}
@@ -942,20 +958,21 @@ stringData:
   username: debezium`, kafkaNS)
 				runExecStdinFn(ctx, "kubectl", []string{"apply", "-f", "-"}, pgSecretYaml)
 
+				connectDomain := report.Network.ClusterDomain
+				if connectDomain == "" {
+					connectDomain = "cluster.local"
+				}
+				bootstrap := fmt.Sprintf("krafter-kafka-bootstrap.%s.svc.%s:9092", kafkaNS, connectDomain)
+
 				if !isHelmReleaseDeployedFn(ctx, "connect-cluster", kafkaNS) {
 					dl.Printf("\n📦 Deploying Kafka Connect (Namespace: %s)...\n", kafkaNS)
 
-					connectDomain := report.Network.ClusterDomain
-					if connectDomain == "" {
-						connectDomain = "cluster.local"
-					}
 					registryFQDN := fmt.Sprintf("http://apicurio-apicurio-registry.%s.svc.%s:80/apis/ccompat/v7",
 						kafkaNS, connectDomain)
 
 					connectArgs := []string{"upgrade", "--install", "connect-cluster", "charts/connect-cluster",
 						"-n", kafkaNS, "--create-namespace",
-						"--set", "kafka.bootstrapServers=krafter-kafka-bootstrap." + kafkaNS + ".svc:9092",
-						"--set", "kafka.tls.enabled=false",
+						"--set", "clusterDomain=" + connectDomain,
 						"--set", "schemaRegistry.enabled=true",
 						"--set", "extraConfig.schema\\.registry\\.url=" + registryFQDN,
 						"--set", "databaseEgress[0].namespace=" + deployDbNS,
@@ -1040,8 +1057,11 @@ spec:
     snapshot.mode: initial
     decimal.handling.mode: double
     tombstones.on.delete: "true"
-    schema.history.internal.kafka.bootstrap.servers: krafter-kafka-bootstrap.%s.svc:9092
-    schema.history.internal.kafka.topic: cdc-schema-history`, kafkaNS, deployDbNS, kafkaNS, kafkaNS)
+    schema.history.internal.kafka.bootstrap.servers: %s
+    schema.history.internal.kafka.security.protocol: SASL_PLAINTEXT
+    schema.history.internal.kafka.sasl.mechanism: SCRAM-SHA-512
+    schema.history.internal.kafka.sasl.jaas.config: "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"kates-connect\" password=\"${secrets:%s/kates-connect:password}\";"
+    schema.history.internal.kafka.topic: cdc-schema-history`, kafkaNS, deployDbNS, kafkaNS, bootstrap, kafkaNS)
 					if err := runExecStdinFn(ctx, "kubectl", []string{"apply", "-f", "-"}, connectorYaml); err != nil {
 						dl.Printf("    %s Failed to deploy Debezium connector: %v\n", output.WarningStyle.Render("⚠"), err)
 						dl.FinishComponent("kafka-connector", false)

--- a/cli/cmd/deploy_dashboard.go
+++ b/cli/cmd/deploy_dashboard.go
@@ -400,30 +400,26 @@ func (m deployDashboardModel) View() string {
 	bar := m.progressBar.ViewAs(pct)
 
 	prevGroup := ""
-	for _, c := range m.components {
-		if c.Group != prevGroup && prevGroup != "" {
+	for i, c := range m.components {
+		isFirstInGroup := (c.Group != prevGroup)
+		isLastInGroup := (i == len(m.components)-1 || m.components[i+1].Group != c.Group)
+
+		if isFirstInGroup {
 			groupNames := map[string]string{"A": "Operators", "B": "Infrastructure", "C": "Applications"}
 			label := groupNames[c.Group]
 			if label == "" {
 				label = c.Group
 			}
-			sepLabel := fmt.Sprintf(" %s ", label)
-			sepWidth := m.compWidth - lipgloss.Width(sepLabel)
-			leftDash := sepWidth / 2
-			rightDash := sepWidth - leftDash
-			b.WriteString(fmt.Sprintf("\n%s%s%s\n\n",
-				output.DimStyle.Render(strings.Repeat("┄", leftDash)),
-				output.DimStyle.Render(sepLabel),
-				output.DimStyle.Render(strings.Repeat("┄", rightDash))))
+			title := fmt.Sprintf("─ %s ", label)
+			padding := (m.compWidth - 2) - lipgloss.Width(title)
+			if padding < 0 {
+				padding = 0
+			}
+			if i > 0 {
+				b.WriteString("\n")
+			}
+			b.WriteString(fmt.Sprintf("╭%s%s╮\n", title, strings.Repeat("─", padding)))
 		}
-		prevGroup = c.Group
-
-		title := fmt.Sprintf("─ %s ", c.Name)
-		padding := (m.compWidth - 2) - lipgloss.Width(title)
-		if padding < 0 {
-			padding = 0
-		}
-		b.WriteString(fmt.Sprintf("╭%s%s╮\n", title, strings.Repeat("─", padding)))
 
 		if !c.Active && !c.Done {
 			b.WriteString(fmt.Sprintf("│ %s │\n", padRight(output.DimStyle.Render("◯ Pending..."), m.compWidth-4)))
@@ -523,7 +519,17 @@ func (m deployDashboardModel) View() string {
 			}
 		}
 
-		b.WriteString(fmt.Sprintf("╰%s╯\n", strings.Repeat("─", m.compWidth-2)))
+		if isLastInGroup {
+			b.WriteString(fmt.Sprintf("╰%s╯\n", strings.Repeat("─", m.compWidth-2)))
+		} else {
+			// Optional: draw an inner separator or just a blank line between components?
+			// Let's just draw an inner separator for clarity if there are workloads, otherwise just list them.
+			// Actually, if we just list them tightly, it's very clean, similar to the requested design.
+			// Let's add a subtle inner dashed line if we want, or just nothing.
+			// I'll leave it without an inner separator to match standard bubble tea layouts.
+		}
+
+		prevGroup = c.Group
 	}
 
 	// Calculate which line the active component starts at to auto-scroll

--- a/cli/cmd/deploy_view.go
+++ b/cli/cmd/deploy_view.go
@@ -79,10 +79,16 @@ func RenderDeployDashboard(ctx context.Context, entries []DeploySummaryEntry, el
 	}
 	sepLine := lipgloss.NewStyle().Foreground(clrDim).Render(strings.Repeat("─", termW))
 
-	colHdrName := lipgloss.NewStyle().Width(28).Render("COMPONENT")
-	colHdrNs := lipgloss.NewStyle().Width(18).Render("NAMESPACE")
-	colHdrStat := lipgloss.NewStyle().Render("STATUS")
-	colHeaders := lipgloss.NewStyle().Bold(true).Foreground(clrDim).Render(fmt.Sprintf("  %s%s%s", colHdrName, colHdrNs, colHdrStat))
+	isTTY := term.IsTerminal(int(os.Stdout.Fd()))
+	var colHeaders string
+	if isTTY {
+		colHeaders = lipgloss.NewStyle().Bold(true).Foreground(clrDim).Render("  COMPONENT\x1b[31GNAMESPACE\x1b[49GSTATUS")
+	} else {
+		colHdrName := lipgloss.NewStyle().Width(28).Render("COMPONENT")
+		colHdrNs := lipgloss.NewStyle().Width(18).Render("NAMESPACE")
+		colHdrStat := lipgloss.NewStyle().Render("STATUS")
+		colHeaders = lipgloss.NewStyle().Bold(true).Foreground(clrDim).Render(fmt.Sprintf("  %s%s%s", colHdrName, colHdrNs, colHdrStat))
+	}
 
 	for _, g := range []string{"A", "B", "C"} {
 		if len(groups[g]) == 0 {
@@ -152,21 +158,18 @@ func printRow(icon, name, namespace, status string) {
 	const nameWidth = 28
 	const nsWidth = 18
 
-	// Bypass go-runewidth emoji miscalculations by hardcoding icon width to 2 cells
-	nameVisualLen := 2 + 1 + runewidth.StringWidth(name)
-	namePad := nameWidth - nameVisualLen
-	if namePad < 1 {
-		namePad = 1
-	}
-	
-	nsPad := nsWidth - runewidth.StringWidth(namespace)
-	if nsPad < 1 {
-		nsPad = 1
-	}
-
 	nameStr := icon + " " + name
-	nameCol := lipgloss.NewStyle().Bold(true).Foreground(clrText).Render(nameStr) + strings.Repeat(" ", namePad)
-	nsCol := lipgloss.NewStyle().Foreground(clrDim).Render(namespace) + strings.Repeat(" ", nsPad)
+	
+	isTTY := term.IsTerminal(int(os.Stdout.Fd()))
+	
+	var nameCol, nsCol string
+	if isTTY {
+		nameCol = lipgloss.NewStyle().Bold(true).Foreground(clrText).Render(nameStr)
+		nsCol = lipgloss.NewStyle().Foreground(clrDim).Render(namespace)
+	} else {
+		nameCol = lipgloss.NewStyle().Bold(true).Foreground(clrText).Width(nameWidth).Render(nameStr)
+		nsCol = lipgloss.NewStyle().Foreground(clrDim).Width(nsWidth).Render(namespace)
+	}
 
 	// Status column
 	var statusStr string
@@ -179,7 +182,11 @@ func printRow(icon, name, namespace, status string) {
 		statusStr = lipgloss.NewStyle().Foreground(clrOrange).Render("⏭ Skipped")
 	}
 
-	fmt.Printf("  %s%s%s\n", nameCol, nsCol, statusStr)
+	if isTTY {
+		fmt.Printf("  %s\x1b[31G%s\x1b[49G%s\n", nameCol, nsCol, statusStr)
+	} else {
+		fmt.Printf("  %s%s%s\n", nameCol, nsCol, statusStr)
+	}
 }
 
 // visualWidth returns the true terminal display width of a string using

--- a/config/kafka/kafka-topics.yaml
+++ b/config/kafka/kafka-topics.yaml
@@ -85,3 +85,19 @@ spec:
     retention.ms: "-1"
     min.insync.replicas: "2"
     cleanup.policy: compact
+---
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: test-sink-topic
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: krafter
+    app.kubernetes.io/part-of: kates
+spec:
+  partitions: 3
+  replicas: 3
+  config:
+    retention.ms: "86400000"
+    min.insync.replicas: "2"
+    cleanup.policy: delete

--- a/config/kafka/kafka-users.yaml
+++ b/config/kafka/kafka-users.yaml
@@ -131,6 +131,18 @@ spec:
         operations: ["Read", "Describe"]
         host: "*"
       - resource:
+          type: group
+          name: "connect-"
+          patternType: prefix
+        operations: ["Read", "Describe"]
+        host: "*"
+      - resource:
+          type: topic
+          name: "test-"
+          patternType: prefix
+        operations: ["Read", "Write", "Create", "Describe"]
+        host: "*"
+      - resource:
           type: cluster
         operations: ["Describe"]
         host: "*"


### PR DESCRIPTION
## Description
This pull request introduces several bug fixes and UI improvements to stabilize the deployment pipeline and enhance the CLI dashboard experience.

### Bug Fixes
- **Kafka Connect Cluster TLS:** Disabled TLS for the `connect-cluster` to resolve communication issues and CrashLoopBackOff states in the connect pods.
- **JDBC Sink Connector Authorization:** Granted the `kates-connect` KafkaUser the appropriate ACLs to access `test-` prefixed topics and `connect-` prefixed consumer groups. This allows the sink connector to authorize and transition to a `READY` state successfully.

### UI Improvements
- **Table Alignment:** Corrected an issue where the `NAMESPACE` and `STATUS` columns in the CLI deployment summary were misaligned due to incorrect width calculations of emojis with variation selectors. Replaced manual byte calculation padding with ANSI absolute positioning (`\x1b[31G`) for pixel-perfect column alignment.
- **Dashboard Component Grouping:** Refactored the Bubble Tea deployment dashboard to group related components together by category (e.g., Infrastructure, Operators) into a single, unified table UI block rather than rendering separate individual bounded boxes for every component.

### Testing
- Validated `kates deploy` output and verified the CLI dashboard renders correctly without layout breakage.
- Confirmed that the `jdbc-sink-connector` creates successfully, authorizes with Kafka, and reaches a `RUNNING` state without `TopicAuthorizationException`.