### PR TITLE
feat: Kafka Connect multi-namespace support & deploy reliability

### DIFF
--- a/charts/connect-cluster/Chart.yaml
+++ b/charts/connect-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: connect-cluster
 description: A Helm chart for deploying Strimzi Kafka Connect clusters
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "3.0.2"
 kubeVersion: ">=1.27.0-0"
 home: https://github.com/bmscomp/kates

--- a/charts/connect-cluster/templates/_helpers.tpl
+++ b/charts/connect-cluster/templates/_helpers.tpl
@@ -101,6 +101,18 @@ capabilities:
 {{- end }}
 
 {{/*
+Kafka namespace — where the Kafka cluster lives.
+Defaults to the Connect cluster namespace if not set.
+*/}}
+{{- define "connect-cluster.kafkaNamespace" -}}
+{{- if .Values.kafka.namespace -}}
+{{- .Values.kafka.namespace -}}
+{{- else -}}
+{{- include "connect-cluster.namespace" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Kafka bootstrap servers FQDN (SASL_PLAINTEXT port 9092).
 Usage: {{ include "connect-cluster.bootstrapServers" . }}
 */}}
@@ -110,9 +122,9 @@ Usage: {{ include "connect-cluster.bootstrapServers" . }}
 {{- else -}}
 {{- $svc := printf "%s-kafka-bootstrap" (.Values.kafka.clusterName | default "krafter") -}}
 {{- if .Values.kafka.tls.enabled -}}
-{{- printf "%s.%s.svc.%s:9093" $svc (include "connect-cluster.namespace" .) (include "connect-cluster.clusterDomain" .) -}}
+{{- printf "%s.%s.svc.%s:9093" $svc (include "connect-cluster.kafkaNamespace" .) (include "connect-cluster.clusterDomain" .) -}}
 {{- else -}}
-{{- printf "%s.%s.svc.%s:9092" $svc (include "connect-cluster.namespace" .) (include "connect-cluster.clusterDomain" .) -}}
+{{- printf "%s.%s.svc.%s:9092" $svc (include "connect-cluster.kafkaNamespace" .) (include "connect-cluster.clusterDomain" .) -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/connect-cluster/templates/networkpolicies.yaml
+++ b/charts/connect-cluster/templates/networkpolicies.yaml
@@ -17,9 +17,7 @@ spec:
     - Egress
   ingress:
     - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ .Values.networkPolicy.monitoringNamespace | default "monitoring" }}
+        - namespaceSelector: {}
       ports:
         - port: 9404
           protocol: TCP
@@ -28,7 +26,8 @@ spec:
           podSelector:
             matchLabels:
               app.kubernetes.io/name: kates
-        - podSelector:
+        - namespaceSelector: {}
+          podSelector:
             matchLabels:
               strimzi.io/kind: cluster-operator
         # Allow ingress from all sources for health probes (kubelet)
@@ -46,6 +45,9 @@ spec:
           protocol: TCP
     - to:
         - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              strimzi.io/cluster: {{ .Values.kafka.clusterName }}
       ports:
         {{- range .Values.networkPolicy.kafkaPorts | default (list 9092 9093) }}
         - protocol: TCP
@@ -53,18 +55,17 @@ spec:
         {{- end }}
     {{- if .Values.schemaRegistry.enabled }}
     - to:
-        - podSelector:
+        - namespaceSelector: {}
+          podSelector:
             matchLabels:
-              app: apicurio-registry
+              app.kubernetes.io/name: apicurio-registry
       ports:
         - port: {{ .Values.schemaRegistry.port | default 80 }}
           protocol: TCP
     {{- end }}
     {{- range (default (list) .Values.databaseEgress) }}
     - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ .namespace }}
+        - namespaceSelector: {}
           {{- with .podSelector }}
           podSelector:
             matchLabels:
@@ -103,9 +104,7 @@ spec:
     - Ingress
   ingress:
     - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ $namespace }}
+        - namespaceSelector: {}
           podSelector:
             matchLabels:
               strimzi.io/name: {{ $clusterName }}

--- a/charts/connect-cluster/templates/secret-reader-rbac.yaml
+++ b/charts/connect-cluster/templates/secret-reader-rbac.yaml
@@ -27,6 +27,37 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "connect-cluster.fullname" . }}-connect
     namespace: {{ include "connect-cluster.namespace" . }}
+{{- if and .Values.kafka.namespace (ne .Values.kafka.namespace (include "connect-cluster.namespace" .)) }}
+---
+# Cross-namespace secret access: allow Connect pods to read secrets in the Kafka namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "connect-cluster.fullname" . }}-kafka-secret-reader
+  namespace: {{ .Values.kafka.namespace }}
+  labels:
+    {{- include "connect-cluster.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "connect-cluster.fullname" . }}-kafka-secret-reader
+  namespace: {{ .Values.kafka.namespace }}
+  labels:
+    {{- include "connect-cluster.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "connect-cluster.fullname" . }}-kafka-secret-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "connect-cluster.fullname" . }}-connect
+    namespace: {{ include "connect-cluster.namespace" . }}
+{{- end }}
 ---
 # RBAC for Helm test pods — allows kubectl get on connect resources
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/connect-cluster/values-kind.yaml
+++ b/charts/connect-cluster/values-kind.yaml
@@ -1,0 +1,17 @@
+# Generic cluster overlay for connect-cluster
+# Disables components that require extra operators (like Prometheus CRDs)
+
+alerts:
+  enabled: false
+
+podMonitors:
+  enabled: false
+
+dashboards:
+  enabled: false
+
+networkPolicy:
+  enabled: false
+
+tracing:
+  enabled: false

--- a/charts/connect-cluster/values.yaml
+++ b/charts/connect-cluster/values.yaml
@@ -36,6 +36,8 @@ clusterDomain: cluster.local
 kafka:
   # -- Kafka cluster name
   clusterName: "krafter"
+  # -- Namespace where the Kafka cluster is deployed (leave empty if same namespace as Connect)
+  namespace: ""
   # -- Bootstrap servers for the Kafka cluster (leave empty to compute automatically)
   bootstrapServers: ""
   tls:
@@ -56,7 +58,7 @@ topologySpreadConstraints:
   enabled: true
   maxSkew: 1
   topologyKey: topology.kubernetes.io/zone
-  whenUnsatisfiable: DoNotSchedule
+  whenUnsatisfiable: ScheduleAnyway
   additional: []
 
 podDisruptionBudget:

--- a/charts/kafka-cluster/templates/drain-cleaner.yaml
+++ b/charts/kafka-cluster/templates/drain-cleaner.yaml
@@ -149,5 +149,5 @@ webhooks:
     failurePolicy: Ignore
     namespaceSelector:
       matchLabels:
-        kubernetes.io/metadata.name: {{ $namespace }}
+        kates.io/namespace: {{ $namespace }}
 {{- end }}

--- a/charts/kafka-cluster/templates/networkpolicies.yaml
+++ b/charts/kafka-cluster/templates/networkpolicies.yaml
@@ -85,9 +85,15 @@ spec:
         - namespaceSelector: {}
           podSelector:
             matchLabels:
-              app: apicurio-registry
+              app.kubernetes.io/name: apicurio-registry
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              strimzi.io/kind: KafkaConnect
       ports:
         - port: 9092
+          protocol: TCP
+        - port: 9093
           protocol: TCP
     - from:
         - namespaceSelector: {}
@@ -106,9 +112,7 @@ spec:
         - port: 9094
           protocol: TCP
     - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ $monitoringNs }}
+        - namespaceSelector: {}
       ports:
         - port: 9404
           protocol: TCP
@@ -205,14 +209,22 @@ spec:
           protocol: TCP
     # Allow egress to the target Kafka application namespace pods
     - to:
-        - namespaceSelector:
+        - namespaceSelector: {}
+          podSelector:
             matchLabels:
-              kubernetes.io/metadata.name: {{ $namespace }}
+              strimzi.io/cluster: {{ $clusterName }}
+    # Allow egress to Kafka Connect pods across all namespaces
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              strimzi.io/kind: KafkaConnect
     # Allow egress to its own namespace pods
     - to:
-        - namespaceSelector:
+        - namespaceSelector: {}
+          podSelector:
             matchLabels:
-              kubernetes.io/metadata.name: {{ .Values.networkPolicies.operatorNamespace | default "strimzi-operator" }}
+              strimzi.io/kind: cluster-operator
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -270,9 +282,7 @@ spec:
         - port: 9090
           protocol: TCP
     - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ $monitoringNs }}
+        - namespaceSelector: {}
       ports:
         - port: 9404
           protocol: TCP
@@ -329,9 +339,7 @@ spec:
     - Egress
   ingress:
     - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ $monitoringNs }}
+        - namespaceSelector: {}
       ports:
         - port: 9404
           protocol: TCP
@@ -369,9 +377,7 @@ spec:
     - Egress
   ingress:
     - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ $monitoringNs }}
+        - namespaceSelector: {}
       ports:
         - port: 8080
           protocol: TCP
@@ -411,9 +417,7 @@ spec:
     - Egress
   ingress:
     - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ $monitoringNs }}
+        - namespaceSelector: {}
       ports:
         - port: 9404
           protocol: TCP

--- a/charts/kafka-cluster/values.yaml
+++ b/charts/kafka-cluster/values.yaml
@@ -450,6 +450,8 @@ networkPolicies:
     - kates
     - litmus
   monitoringNamespace: kafka
+  # Namespace where Kafka Connect is deployed (for cross-namespace ingress)
+  connectNamespace: connect
   # Namespace where the Strimzi Operator is deployed (for its NetworkPolicy)
   operatorNamespace: strimzi-operator
 

--- a/charts/kates-chaos/templates/networkpolicy.yaml
+++ b/charts/kates-chaos/templates/networkpolicy.yaml
@@ -17,26 +17,28 @@ spec:
     - Egress
   ingress:
     - from:
-        - namespaceSelector:
+        - namespaceSelector: {}
+          podSelector:
             matchLabels:
-              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+              app.kubernetes.io/instance: {{ .Release.Name }}
   egress:
     - to:
-        - namespaceSelector:
+        - namespaceSelector: {}
+          podSelector:
             matchLabels:
-              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+              app.kubernetes.io/instance: {{ .Release.Name }}
     - to:
-        - namespaceSelector:
+        - namespaceSelector: {}
+          podSelector:
             matchLabels:
-              kubernetes.io/metadata.name: {{ $kafkaNamespace }}
+              strimzi.io/kind: Kafka
     - to:
-        - namespaceSelector:
+        - namespaceSelector: {}
+          podSelector:
             matchLabels:
-              kubernetes.io/metadata.name: {{ $katesNamespace }}
+              app.kubernetes.io/name: kates
     - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: kube-system
+        - namespaceSelector: {}
       ports:
         - protocol: UDP
           port: 53

--- a/charts/kates/templates/kyverno-network-policies.yaml
+++ b/charts/kates/templates/kyverno-network-policies.yaml
@@ -90,9 +90,7 @@ spec:
               - Egress
             egress:
               - to:
-                  - namespaceSelector:
-                      matchLabels:
-                        kubernetes.io/metadata.name: kube-system
+                  - namespaceSelector: {}
                 ports:
                   - protocol: UDP
                     port: 53

--- a/charts/kates/templates/networkpolicy.yaml
+++ b/charts/kates/templates/networkpolicy.yaml
@@ -32,9 +32,7 @@ spec:
           protocol: TCP
     {{- if .Values.postgresql.enabled }}
     - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+        - namespaceSelector: {}
           podSelector:
             matchLabels:
               app.kubernetes.io/name: {{ include "kates.postgresql.fullname" . }}
@@ -57,9 +55,7 @@ spec:
         - port: {{ .Values.networkPolicy.kafka.port | default 9092 }}
           protocol: TCP
     - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ .Values.networkPolicy.prometheus.namespace | default "monitoring" }}
+        - namespaceSelector: {}
       ports:
         - port: {{ .Values.networkPolicy.prometheus.port | default 9090 }}
           protocol: TCP
@@ -91,9 +87,7 @@ spec:
     - Ingress
   ingress:
     - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+        - namespaceSelector: {}
           podSelector:
             matchLabels:
               {{- include "kates.selectorLabels" . | nindent 14 }}

--- a/charts/kates/values.yaml
+++ b/charts/kates/values.yaml
@@ -342,16 +342,12 @@ networkPolicy:
   # -- Ingress rules
   ingressRules:
     - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: ingress-nginx
+        - namespaceSelector: {}
       ports:
         - port: 8080
           protocol: TCP
     - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: monitoring
+        - namespaceSelector: {}
       ports:
         - port: 8080
           protocol: TCP

--- a/cli/cmd/clean.go
+++ b/cli/cmd/clean.go
@@ -34,6 +34,7 @@ var (
 	cleanTopology     string
 	cleanNamespace    string
 	cleanKafkaNS      string
+	cleanConnectNS    string
 	cleanDbNS         string
 	cleanAppNS        string
 	cleanChaosNS      string
@@ -46,6 +47,7 @@ func init() {
 	cleanCmd.Flags().StringVar(&cleanTopology, "topology", "", "Topology to clean: 'isolated' or 'single'. If empty, cleans both.")
 	cleanCmd.Flags().StringVar(&cleanNamespace, "namespace", "kates-stack", "Target namespace when topology is 'single'")
 	cleanCmd.Flags().StringVar(&cleanKafkaNS, "kafka-ns", "kafka", "Namespace for Kafka when topology is 'isolated'")
+	cleanCmd.Flags().StringVar(&cleanConnectNS, "connect-ns", "connect", "Namespace for Kafka Connect when topology is 'isolated'")
 	cleanCmd.Flags().StringVar(&cleanDbNS, "db-ns", "database", "Namespace for PostgreSQL Database when topology is 'isolated'")
 	cleanCmd.Flags().StringVar(&cleanAppNS, "app-ns", "kates", "Namespace for Kates Backend when topology is 'isolated'")
 	cleanCmd.Flags().StringVar(&cleanChaosNS, "chaos-ns", "litmus", "Namespace for Chaos Engine when topology is 'isolated'")
@@ -213,6 +215,7 @@ func runClean(cmd *cobra.Command, args []string) error {
 			helmRelease{"chaos", cleanNamespace},
 			helmRelease{"kates", cleanNamespace},
 			helmRelease{"apicurio", cleanNamespace},
+			helmRelease{"connect-cluster", cleanNamespace},
 		)
 		coreReleases = append(coreReleases,
 			helmRelease{"jaeger", cleanNamespace},
@@ -229,6 +232,7 @@ func runClean(cmd *cobra.Command, args []string) error {
 			helmRelease{"chaos", cleanChaosNS},
 			helmRelease{"kates", cleanAppNS},
 			helmRelease{"apicurio", cleanKafkaNS},
+			helmRelease{"connect-cluster", cleanConnectNS},
 		)
 		coreReleases = append(coreReleases,
 			helmRelease{"jaeger", cleanMonitoringNS},
@@ -237,7 +241,7 @@ func runClean(cmd *cobra.Command, args []string) error {
 			helmRelease{"postgresql", cleanDbNS},
 		)
 		managedNamespaces = append(managedNamespaces,
-			cleanKafkaNS, cleanAppNS, cleanChaosNS, cleanMonitoringNS, cleanDbNS,
+			cleanKafkaNS, cleanConnectNS, cleanAppNS, cleanChaosNS, cleanMonitoringNS, cleanDbNS,
 		)
 		strimziNS = append(strimziNS, cleanKafkaNS)
 	}

--- a/cli/cmd/connect.go
+++ b/cli/cmd/connect.go
@@ -251,10 +251,7 @@ var connectScaleCmd = &cobra.Command{
 }
 
 func init() {
-	defaultNS := "kafka"
-	if envNS := os.Getenv("KATES_KAFKA_NS"); envNS != "" {
-		defaultNS = envNS
-	}
+	defaultNS := detectConnectNamespace()
 	kafkaConnectCmd.PersistentFlags().StringVarP(&connectNamespace, "namespace", "n", defaultNS, "Namespace where Kafka Connect is deployed")
 
 	kafkaConnectCmd.AddCommand(connectStatusCmd)
@@ -271,4 +268,28 @@ func init() {
 	kafkaConnectCmd.AddCommand(connectConfigCmd)
 	kafkaConnectCmd.AddCommand(connectDeleteCmd)
 	kafkaConnectCmd.AddCommand(connectScaleCmd)
+}
+
+// detectConnectNamespace resolves the namespace where Kafka Connect is deployed.
+// Priority: KATES_CONNECT_NS env → live cluster auto-detect → KATES_KAFKA_NS env → "kafka".
+func detectConnectNamespace() string {
+	if envNS := os.Getenv("KATES_CONNECT_NS"); envNS != "" {
+		return envNS
+	}
+
+	// Auto-detect from cluster: find the namespace of any KafkaConnect CR
+	out, err := exec.Command("kubectl", "get", "kafkaconnect", "-A",
+		"-o", "jsonpath={.items[0].metadata.namespace}").Output()
+	if err == nil {
+		ns := strings.TrimSpace(string(out))
+		if ns != "" {
+			return ns
+		}
+	}
+
+	// Backwards compatibility fallback
+	if envNS := os.Getenv("KATES_KAFKA_NS"); envNS != "" {
+		return envNS
+	}
+	return "kafka"
 }

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -45,6 +45,7 @@ var (
 	deployTopology           string
 	deployNamespace          string
 	deployKafkaNS            string
+	deployConnectNS          string
 	deployDbNS               string
 	deployAppNS              string
 	deployChaosNS            string
@@ -68,14 +69,15 @@ func init() {
 	deployCmd.Flags().StringVar(&deployTopology, "topology", "isolated", "Deployment topology: 'isolated' (separate namespaces) or 'single' (one namespace)")
 	deployCmd.Flags().StringVar(&deployNamespace, "namespace", "kates-stack", "Target namespace when topology is 'single'")
 	deployCmd.Flags().StringVar(&deployKafkaNS, "kafka-ns", "kafka", "Namespace for Kafka when topology is 'isolated'")
+	deployCmd.Flags().StringVar(&deployConnectNS, "connect-ns", "connect", "Namespace for Kafka Connect when topology is 'isolated'")
 	deployCmd.Flags().StringVar(&deployDbNS, "db-ns", "database", "Namespace for PostgreSQL Database when topology is 'isolated'")
 	deployCmd.Flags().StringVar(&deployAppNS, "app-ns", "kates", "Namespace for Kates Backend when topology is 'isolated'")
 	deployCmd.Flags().StringVar(&deployChaosNS, "chaos-ns", "litmus", "Namespace for Chaos Engine when topology is 'isolated'")
 	deployCmd.Flags().StringVar(&deployMonitoringNS, "monitoring-ns", "monitoring", "Namespace for monitoring components (Jaeger) when topology is 'isolated'")
 
 	// Component flags
-	deployCmd.Flags().StringVar(&deployWithSchemaRegistry, "with-schema-registry", "none", "Schema Registry to deploy: 'none', 'apicurio', or 'confluent'")
-	deployCmd.Flags().BoolVar(&deployHA, "ha", false, "Enable High Availability (Multi-AZ)")
+	deployCmd.Flags().StringVar(&deployWithSchemaRegistry, "with-schema-registry", "apicurio", "Schema Registry to deploy: 'none', 'apicurio', or 'confluent'")
+	deployCmd.Flags().BoolVar(&deployHA, "ha", true, "Enable High Availability (Multi-AZ)")
 	deployCmd.Flags().BoolVar(&deployWithChaos, "with-chaos", true, "Deploy LitmusChaos engine")
 	deployCmd.Flags().BoolVar(&deployWithMonitoring, "with-monitoring", true, "Deploy monitoring components (Prometheus/Grafana/Jaeger)")
 	deployCmd.Flags().BoolVar(&deployWithCertManager, "with-cert-manager", true, "Deploy Cert-Manager for TLS certificate management")
@@ -100,7 +102,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	if deployInteractive || cmd.Flags().NFlag() == 0 {
 		var components []string
 
-		form := huh.NewForm(
+		form1 := huh.NewForm(
 			// ── Group 1: What to deploy ──────────────────────────────────────────
 			huh.NewGroup(
 				huh.NewSelect[string]().
@@ -115,8 +117,8 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 				huh.NewSelect[string]().
 					Title("Schema Registry").
 					Options(
-						huh.NewOption("None", "none"),
 						huh.NewOption("Apicurio", "apicurio"),
+						huh.NewOption("None", "none"),
 					).
 					Value(&deployWithSchemaRegistry),
 
@@ -138,35 +140,68 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 					).
 					Value(&components),
 			),
+		).WithTheme(ThemeKates())
 
-			// ── Group 2: Namespace configuration (isolated topology only) ────────
-			huh.NewGroup(
+		if err := form1.Run(); err != nil {
+			return err
+		}
+
+		// ── Form 2: Namespace configuration ──────────────────────────────────
+		// Built after Form 1 completes so that `components` is fully populated.
+		// This avoids a huh library issue where MultiSelect values from a
+		// previous group aren't reliably available in WithHideFunc closures
+		// of subsequent groups within the same form.
+		if deployTopology != "single" {
+			var nsGroups []*huh.Group
+
+			// Core namespaces (always shown for isolated topology)
+			nsGroups = append(nsGroups, huh.NewGroup(
 				huh.NewInput().
 					Title("Kafka Namespace").
 					Description("Namespace for Strimzi operator and Kafka cluster").
 					Value(&deployKafkaNS),
 				huh.NewInput().
-					Title("Database Namespace").
-					Description("Namespace for PostgreSQL CDC database").
-					Value(&deployDbNS),
-				huh.NewInput().
 					Title("Kates App Namespace").
 					Description("Namespace for the Kates backend service").
 					Value(&deployAppNS),
-				huh.NewInput().
-					Title("Monitoring Namespace").
-					Description("Namespace for Jaeger and monitoring components").
-					Value(&deployMonitoringNS),
-				huh.NewInput().
-					Title("Chaos Namespace").
-					Description("Namespace for Litmus Chaos engine").
-					Value(&deployChaosNS),
-			).WithHideFunc(func() bool { return deployTopology == "single" }),
-		).WithTheme(ThemeKates())
+			))
 
-		err := form.Run()
-		if err != nil {
-			return err
+			// Conditional namespace groups based on selected components
+			if sliceContains(components, "monitoring") {
+				nsGroups = append(nsGroups, huh.NewGroup(
+					huh.NewInput().
+						Title("Monitoring Namespace").
+						Description("Namespace for Jaeger and monitoring components").
+						Value(&deployMonitoringNS),
+				))
+			}
+
+			if sliceContains(components, "chaos") {
+				nsGroups = append(nsGroups, huh.NewGroup(
+					huh.NewInput().
+						Title("Chaos Namespace").
+						Description("Namespace for Litmus Chaos engine").
+						Value(&deployChaosNS),
+				))
+			}
+
+			if sliceContains(components, "kafka-connect") {
+				nsGroups = append(nsGroups, huh.NewGroup(
+					huh.NewInput().
+						Title("Kafka Connect Namespace").
+						Description("Namespace for Kafka Connect cluster (separate from Kafka)").
+						Value(&deployConnectNS),
+					huh.NewInput().
+						Title("Database Namespace").
+						Description("Namespace for PostgreSQL CDC database").
+						Value(&deployDbNS),
+				))
+			}
+
+			form2 := huh.NewForm(nsGroups...).WithTheme(ThemeKates())
+			if err := form2.Run(); err != nil {
+				return err
+			}
 		}
 
 		deployWithChaos = false
@@ -200,6 +235,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	} else {
 		PrintPhaseItem(fmt.Sprintf("%-14s → %s", "Kafka", deployKafkaNS))
 		if deployWithKafkaConnect {
+			PrintPhaseItem(fmt.Sprintf("%-14s → %s", "Kafka Connect", deployConnectNS))
 			PrintPhaseItem(fmt.Sprintf("%-14s → %s", "Database", deployDbNS))
 		}
 		PrintPhaseItem(fmt.Sprintf("%-14s → %s", "Kates App", deployAppNS))
@@ -317,11 +353,11 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	}
 
 	// Resolve namespaces before building entries
-	var kafkaNS, appNS, chaosNS, jaegerNS string
+	var kafkaNS, connectNS, appNS, chaosNS, jaegerNS string
 	if deployTopology == "single" {
-		kafkaNS, appNS, chaosNS, jaegerNS = deployNamespace, deployNamespace, deployNamespace, deployNamespace
+		kafkaNS, connectNS, appNS, chaosNS, jaegerNS = deployNamespace, deployNamespace, deployNamespace, deployNamespace, deployNamespace
 	} else {
-		kafkaNS, appNS, chaosNS, jaegerNS = deployKafkaNS, deployAppNS, deployChaosNS, deployMonitoringNS
+		kafkaNS, connectNS, appNS, chaosNS, jaegerNS = deployKafkaNS, deployConnectNS, deployAppNS, deployChaosNS, deployMonitoringNS
 	}
 
 	// ── Build shared component registry (single source of truth) ──
@@ -338,7 +374,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	sharedEntries = append(sharedEntries, DeploySummaryEntry{Icon: "📨", Name: "Kafka (krafter)", Release: "krafter", Namespace: kafkaNS, Group: "B"})
 	if deployWithKafkaConnect {
 		sharedEntries = append(sharedEntries, DeploySummaryEntry{Icon: "🐘", Name: "PostgreSQL (CDC)", Release: "postgresql", Namespace: deployDbNS, Group: "B"})
-		sharedEntries = append(sharedEntries, DeploySummaryEntry{Icon: "🔗", Name: "Kafka Connect", Release: "connect-cluster", Namespace: kafkaNS, Group: "B"})
+		sharedEntries = append(sharedEntries, DeploySummaryEntry{Icon: "🔗", Name: "Kafka Connect", Release: "connect-cluster", Namespace: connectNS, Group: "B"})
 	}
 	if deployWithMonitoring {
 		sharedEntries = append(sharedEntries, DeploySummaryEntry{Icon: "📊", Name: "Monitoring Stack", Release: "monitoring", Namespace: jaegerNS, Group: "B"})
@@ -420,9 +456,9 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		dashboard.RegisterComponent("postgres", "PostgreSQL", "B",
 			Target{deployDbNS, "app.kubernetes.io/instance=postgresql"})
 		dashboard.RegisterComponent("kafka-connect", "Kafka Connect", "B",
-			Target{kafkaNS, "strimzi.io/kind=KafkaConnect"})
+			Target{connectNS, "strimzi.io/kind=KafkaConnect"})
 		dashboard.RegisterComponent("kafka-connector", "CDC Connector", "B",
-			Target{kafkaNS, "strimzi.io/cluster=connect-cluster"})
+			Target{connectNS, "strimzi.io/cluster=connect-cluster"})
 	}
 	if deployWithSchemaRegistry == "apicurio" {
 		dashboard.RegisterComponent("apicurio", "Apicurio Registry", "C", Target{kafkaNS, "app.kubernetes.io/instance=apicurio"})
@@ -826,6 +862,7 @@ metadata:
 					kafkaArgs = append(kafkaArgs,
 						"-f", valuesFile,
 						"--set", "global.clusterDomain="+clusterDomain,
+						"--set", "networkPolicies.connectNamespace="+connectNS,
 						"--timeout", "10m",
 					)
 					if isKind {
@@ -944,8 +981,66 @@ metadata:
 				}
 			}
 
-			// 3. Kafka Connect (separate chart)
+			// 3. Kafka Connect (separate chart — deployed in connectNS)
 			if deployWithKafkaConnect {
+				// Ensure connect namespace exists (idempotent — won't fail if already present)
+				dl.Println("    - Ensuring connect namespace exists...")
+				connectNsYaml := fmt.Sprintf(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s`, connectNS)
+				runExecStdinFn(ctx, "kubectl", []string{"apply", "-f", "-"}, connectNsYaml)
+
+				connectDomain := report.Network.ClusterDomain
+				if connectDomain == "" {
+					connectDomain = "cluster.local"
+				}
+				bootstrap := fmt.Sprintf("krafter-kafka-bootstrap.%s.svc.%s:9092", kafkaNS, connectDomain)
+
+				// Copy kates-connect secret and kafka-metrics ConfigMap from kafka namespace to connect namespace (cross-namespace)
+				if connectNS != kafkaNS {
+					// Copy kafka-metrics ConfigMap (required by KafkaConnect metricsConfig)
+					dl.Println("    - Copying kafka-metrics ConfigMap to connect namespace...")
+					metricsData, metricsErr := exec.CommandContext(ctx, "kubectl", "get", "configmap", "kafka-metrics",
+						"-n", kafkaNS, "-o", "jsonpath={.data.kafka-metrics-config\\.yml}").Output()
+					if metricsErr == nil && len(metricsData) > 0 {
+						// Build a clean ConfigMap without Helm ownership annotations
+						// to avoid field-manager conflicts on kubectl apply.
+						var indented strings.Builder
+						for _, line := range strings.Split(string(metricsData), "\n") {
+							indented.WriteString("    " + line + "\n")
+						}
+						metricsYaml := fmt.Sprintf("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: kafka-metrics\n  namespace: %s\ndata:\n  kafka-metrics-config.yml: |\n%s", connectNS, indented.String())
+						if err := runExecStdinFn(ctx, "kubectl", []string{"apply", "-f", "-"}, metricsYaml); err != nil {
+							// Fallback: force ownership with server-side apply (handles leftover
+							// field-manager conflicts from prior broken deploys)
+							dl.Println("    - Retrying with server-side apply (--force-conflicts)...")
+							runExecStdinFn(ctx, "kubectl", []string{"apply", "--server-side", "--force-conflicts", "-f", "-"}, metricsYaml)
+						}
+					} else {
+						dl.Printf("    ⚠️  ConfigMap 'kafka-metrics' not found in namespace %s\n", kafkaNS)
+					}
+
+					dl.Println("    - Copying kates-connect credentials to connect namespace...")
+					pwCmd := exec.CommandContext(ctx, "kubectl", "get", "secret", "kates-connect",
+						"-n", kafkaNS, "-o", "jsonpath={.data.password}")
+					pwBytes, pwErr := pwCmd.Output()
+
+					if pwErr == nil && len(pwBytes) > 0 {
+						connectSecretYaml := fmt.Sprintf(`apiVersion: v1
+kind: Secret
+metadata:
+  name: kates-connect
+  namespace: %s
+type: Opaque
+data:
+  password: %s`, connectNS, string(pwBytes))
+						runExecStdinFn(ctx, "kubectl", []string{"apply", "-f", "-"}, connectSecretYaml)
+					} else {
+						dl.Printf("    ⚠️  Secret 'kates-connect' not found in namespace %s — KafkaUser may not be ready\n", kafkaNS)
+					}
+				}
+
 				dl.Println("    - Creating PostgreSQL credentials secret for Kafka Connect...")
 				pgSecretYaml := fmt.Sprintf(`apiVersion: v1
 kind: Secret
@@ -955,24 +1050,37 @@ metadata:
 type: Opaque
 stringData:
   password: debezium
-  username: debezium`, kafkaNS)
+  username: debezium`, connectNS)
 				runExecStdinFn(ctx, "kubectl", []string{"apply", "-f", "-"}, pgSecretYaml)
 
-				connectDomain := report.Network.ClusterDomain
-				if connectDomain == "" {
-					connectDomain = "cluster.local"
+				connectDeployed := isHelmReleaseDeployedFn(ctx, "connect-cluster", connectNS)
+				if connectDeployed && !isTesting {
+					// Helm says deployed, but verify pods actually exist.
+					// A previous deploy may have installed the chart but the
+					// workload never started (e.g. missing ConfigMap).
+					podCheck, _ := exec.CommandContext(ctx, "kubectl", "get", "pods",
+						"-n", connectNS, "-l", "strimzi.io/kind=KafkaConnect",
+						"-o", "jsonpath={.items}").Output()
+					if string(podCheck) == "[]" || len(strings.TrimSpace(string(podCheck))) == 0 {
+						dl.Println("    ⚠️  Kafka Connect release exists but no pods found — upgrading...")
+						connectDeployed = false
+					}
 				}
-				bootstrap := fmt.Sprintf("krafter-kafka-bootstrap.%s.svc.%s:9092", kafkaNS, connectDomain)
-
-				if !isHelmReleaseDeployedFn(ctx, "connect-cluster", kafkaNS) {
-					dl.Printf("\n📦 Deploying Kafka Connect (Namespace: %s)...\n", kafkaNS)
+				if !connectDeployed {
+					dl.Printf("\n📦 Deploying Kafka Connect (Namespace: %s)...\n", connectNS)
 
 					registryFQDN := fmt.Sprintf("http://apicurio-apicurio-registry.%s.svc.%s:80/apis/ccompat/v7",
 						kafkaNS, connectDomain)
 
+					// Use the same FQDN pattern as the kates backend for bootstrap servers
+					bootstrap := fmt.Sprintf("krafter-kafka-bootstrap.%s.svc.%s:9092", kafkaNS, connectDomain)
+
 					connectArgs := []string{"upgrade", "--install", "connect-cluster", "charts/connect-cluster",
-						"-n", kafkaNS, "--create-namespace",
+						"-n", connectNS, "--create-namespace",
+						"-f", chartOverlay("charts/connect-cluster"),
 						"--set", "clusterDomain=" + connectDomain,
+						"--set", "kafka.namespace=" + kafkaNS,
+						"--set", "kafka.bootstrapServers=" + bootstrap,
 						"--set", "schemaRegistry.enabled=true",
 						"--set", "extraConfig.schema\\.registry\\.url=" + registryFQDN,
 						"--set", "databaseEgress[0].namespace=" + deployDbNS,
@@ -981,7 +1089,21 @@ stringData:
 						"--timeout", "10m",
 					}
 
-					connectArgs = append(connectArgs, "-f", "charts/connect-cluster/values-generic.yaml")
+					// Enable NetworkPolicy on non-Kind clusters (same as kates backend)
+					if !isKind {
+						connectArgs = append(connectArgs, "--set", "networkPolicy.enabled=true")
+					}
+
+					// When Connect is in a different namespace than Kafka, brokers advertise
+					// short hostnames (e.g. krafter-brokers-0.krafter-kafka-brokers.kafka.svc)
+					// that only resolve within the kafka namespace DNS search domain.
+					// Add the kafka namespace to Connect pod DNS search list.
+					if connectNS != kafkaNS {
+						kafkaSvcDomain := fmt.Sprintf("%s.svc.%s", kafkaNS, connectDomain)
+						connectArgs = append(connectArgs,
+							"--set", "dnsConfig.searches[0]="+kafkaSvcDomain,
+						)
+					}
 
 					if deployHA {
 						connectArgs = append(connectArgs, "--set", "replicas=3")
@@ -1018,7 +1140,7 @@ stringData:
 
 				if !isTesting {
 					dl.StartComponent("kafka-connect", 15*time.Minute)
-					if err := waitComponentReadySilent(ctx, kafkaNS, "strimzi.io/kind=KafkaConnect", 15*time.Minute); err != nil {
+					if err := waitComponentReadySilent(ctx, connectNS, "strimzi.io/kind=KafkaConnect", 15*time.Minute); err != nil {
 						dl.FinishComponent("kafka-connect", false)
 						return fmt.Errorf("Kafka Connect failed to become ready: %w", err)
 					}
@@ -1027,7 +1149,7 @@ stringData:
 				}
 
 				// Deploy Debezium connector
-				checkOut, checkErr := exec.CommandContext(ctx, "kubectl", "get", "kafkaconnector", "debezium-postgres-source", "-n", kafkaNS, "--no-headers").CombinedOutput()
+				checkOut, checkErr := exec.CommandContext(ctx, "kubectl", "get", "kafkaconnector", "debezium-postgres-source", "-n", connectNS, "--no-headers").CombinedOutput()
 				if checkErr != nil || strings.Contains(string(checkOut), "not found") {
 					dl.Println("    - Deploying Debezium PostgreSQL CDC connector...")
 					connectorYaml := fmt.Sprintf(`apiVersion: kafka.strimzi.io/v1
@@ -1061,7 +1183,7 @@ spec:
     schema.history.internal.kafka.security.protocol: SASL_PLAINTEXT
     schema.history.internal.kafka.sasl.mechanism: SCRAM-SHA-512
     schema.history.internal.kafka.sasl.jaas.config: "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"kates-connect\" password=\"${secrets:%s/kates-connect:password}\";"
-    schema.history.internal.kafka.topic: cdc-schema-history`, kafkaNS, deployDbNS, kafkaNS, bootstrap, kafkaNS)
+    schema.history.internal.kafka.topic: cdc-schema-history`, connectNS, deployDbNS, connectNS, bootstrap, connectNS)
 					if err := runExecStdinFn(ctx, "kubectl", []string{"apply", "-f", "-"}, connectorYaml); err != nil {
 						dl.Printf("    %s Failed to deploy Debezium connector: %v\n", output.WarningStyle.Render("⚠"), err)
 						dl.FinishComponent("kafka-connector", false)
@@ -1073,7 +1195,7 @@ spec:
 				}
 
 				// Deploy JDBC Sink connector
-				sinkCheckOut, sinkCheckErr := exec.CommandContext(ctx, "kubectl", "get", "kafkaconnector", "jdbc-sink-connector", "-n", kafkaNS, "--no-headers").CombinedOutput()
+				sinkCheckOut, sinkCheckErr := exec.CommandContext(ctx, "kubectl", "get", "kafkaconnector", "jdbc-sink-connector", "-n", connectNS, "--no-headers").CombinedOutput()
 				if sinkCheckErr != nil || strings.Contains(string(sinkCheckOut), "not found") {
 					dl.Println("    - Deploying JDBC Sink connector...")
 					sinkYaml := fmt.Sprintf(`apiVersion: kafka.strimzi.io/v1
@@ -1096,7 +1218,7 @@ spec:
     connection.password: "${secrets:%s/connect-pg-credentials:password}"
     insert.mode: "insert"
     auto.create: "true"
-    auto.evolve: "true"`, kafkaNS, deployDbNS, kafkaNS, kafkaNS)
+    auto.evolve: "true"`, connectNS, deployDbNS, connectNS, connectNS)
 					if err := runExecStdinFn(ctx, "kubectl", []string{"apply", "-f", "-"}, sinkYaml); err != nil {
 						dl.Printf("    %s Failed to deploy JDBC Sink connector: %v\n", output.WarningStyle.Render("⚠"), err)
 					} else {
@@ -1108,7 +1230,7 @@ spec:
 
 				if !isTesting {
 					dl.StartComponent("kafka-connector", 10*time.Minute)
-					if err := waitConnectorReadySilent(ctx, kafkaNS, 10*time.Minute); err != nil {
+					if err := waitConnectorReadySilent(ctx, connectNS, 10*time.Minute); err != nil {
 						dl.FinishComponent("kafka-connector", false)
 						return fmt.Errorf("Kafka Connectors failed to become ready: %w", err)
 					}
@@ -1379,11 +1501,19 @@ func runHelmDefault(ctx context.Context, args ...string) error {
 }
 
 func isHelmReleaseDeployedDefault(ctx context.Context, release, namespace string) bool {
-	// Create context with short timeout
+	// Check that the release exists AND is in "deployed" status.
+	// helm status exits 0 even for failed releases, so we must inspect
+	// the actual status to avoid skipping re-installation of broken releases.
 	checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(checkCtx, "helm", "status", release, "-n", namespace)
-	return cmd.Run() == nil
+	out, err := exec.CommandContext(checkCtx, "helm", "status", release, "-n", namespace, "-o", "json").Output()
+	if err != nil {
+		return false
+	}
+	// Look for "status":"deployed" in the JSON output.
+	// Helm may output with or without spaces after colons, so check both.
+	s := string(out)
+	return strings.Contains(s, `"status":"deployed"`) || strings.Contains(s, `"status": "deployed"`)
 }
 
 // cleanupStaleClusterResource removes a cluster-scoped resource if it belongs
@@ -1419,4 +1549,13 @@ func applyManifestWithNamespace(ctx context.Context, file, namespace string) err
 	// Strip hardcoded namespace lines so -n flag takes effect
 	stripped := nsLineRegex.ReplaceAllString(string(data), "")
 	return runExecStdinFn(ctx, "kubectl", []string{"apply", "-f", "-", "-n", namespace}, stripped)
+}
+
+func sliceContains(s []string, v string) bool {
+	for _, item := range s {
+		if item == v {
+			return true
+		}
+	}
+	return false
 }

--- a/cli/cmd/deploy_status.go
+++ b/cli/cmd/deploy_status.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -37,6 +38,7 @@ func init() {
 	deployStatusCmd.Flags().StringVar(&deployTopology, "topology", "isolated", "Deployment topology: 'isolated' (separate namespaces) or 'single' (one namespace)")
 	deployStatusCmd.Flags().StringVar(&deployNamespace, "namespace", "kates-stack", "Target namespace when topology is 'single'")
 	deployStatusCmd.Flags().StringVar(&deployKafkaNS, "kafka-ns", "kafka", "Namespace for Kafka when topology is 'isolated'")
+	deployStatusCmd.Flags().StringVar(&deployConnectNS, "connect-ns", "connect", "Namespace for Kafka Connect when topology is 'isolated'")
 	deployStatusCmd.Flags().StringVar(&deployDbNS, "db-ns", "database", "Namespace for PostgreSQL Database when topology is 'isolated'")
 	deployStatusCmd.Flags().StringVar(&deployAppNS, "app-ns", "kates", "Namespace for Kates Backend when topology is 'isolated'")
 	deployStatusCmd.Flags().StringVar(&deployChaosNS, "chaos-ns", "litmus", "Namespace for Chaos Engine when topology is 'isolated'")
@@ -150,11 +152,11 @@ type k8sWorkload struct {
 func runDeployStatus(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
-	var kafkaNS, appNS, chaosNS, jaegerNS, dbNS string
+	var kafkaNS, connectNS, appNS, chaosNS, jaegerNS, dbNS string
 	if deployTopology == "single" {
-		kafkaNS, appNS, chaosNS, jaegerNS, dbNS = deployNamespace, deployNamespace, deployNamespace, deployNamespace, deployNamespace
+		kafkaNS, connectNS, appNS, chaosNS, jaegerNS, dbNS = deployNamespace, deployNamespace, deployNamespace, deployNamespace, deployNamespace, deployNamespace
 	} else {
-		kafkaNS, appNS, chaosNS, jaegerNS, dbNS = deployKafkaNS, deployAppNS, deployChaosNS, deployMonitoringNS, deployDbNS
+		kafkaNS, connectNS, appNS, chaosNS, jaegerNS, dbNS = deployKafkaNS, deployConnectNS, deployAppNS, deployChaosNS, deployMonitoringNS, deployDbNS
 	}
 
 	components := []struct {
@@ -169,9 +171,9 @@ func runDeployStatus(cmd *cobra.Command, args []string) error {
 		{"A", "☸️", "Strimzi Operator", "strimzi-operator", "strimzi-operator", "pod", "-l name=strimzi-cluster-operator"},
 		{"A", "🔐", "Cert-Manager", "cert-manager", "cert-manager", "pod", "-l app.kubernetes.io/instance=cert-manager"},
 		{"A", "🛡️", "Kyverno", "kyverno", "kyverno", "pod", "-l app.kubernetes.io/instance=kyverno"},
-		{"B", "📨", "Kafka (krafter)", "krafter", kafkaNS, "kafka", "krafter"},
+		{"B", "📨", "Kafka (krafter)", "krafter", kafkaNS, "kafkas.kafka.strimzi.io", "krafter"},
 		{"B", "🐘", "PostgreSQL (CDC)", "postgresql", dbNS, "statefulset", "postgresql"},
-		{"B", "🔗", "Kafka Connect", "connect-cluster", kafkaNS, "kafkaconnect", "connect-cluster"},
+		{"B", "🔗", "Kafka Connect", "connect-cluster", connectNS, "kafkaconnects.kafka.strimzi.io", "connect-cluster"},
 		{"B", "📊", "Monitoring Stack", "monitoring", jaegerNS, "pod", "-l release=monitoring"},
 		{"C", "📋", "Apicurio Registry", "apicurio", kafkaNS, "pod", "-l app.kubernetes.io/instance=apicurio"},
 		{"C", "📦", "Kates Backend", "kates", appNS, "pod", "-l app.kubernetes.io/instance=kates"},
@@ -274,11 +276,17 @@ func getHealthStatus(ctx context.Context, kind, resource, namespace string) (str
 			return "Healthy", fmt.Sprintf("%d/%d pods running", running, len(lines))
 		}
 		return "Degraded", fmt.Sprintf("%d/%d pods running", running, len(lines))
-	} else if kind == "kafka" || kind == "kafkaconnect" {
+	} else if kind == "kafkas.kafka.strimzi.io" || kind == "kafkaconnects.kafka.strimzi.io" {
 		cmd := exec.CommandContext(checkCtx, "kubectl", "get", kind, resource, "-n", namespace, "-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}")
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
 		out, err := cmd.Output()
 		if err != nil {
-			return "Unknown", "CRD not found"
+			errMsg := strings.TrimSpace(stderr.String())
+			if errMsg == "" {
+				errMsg = err.Error()
+			}
+			return "Unknown", "Error: " + errMsg
 		}
 		status := strings.TrimSpace(string(out))
 		if status == "True" {
@@ -660,7 +668,7 @@ func (m interactiveStatusModel) View() string {
 			statusStr = lipgloss.NewStyle().Foreground(clrDim).Render("[◯ Pending]")
 		}
 
-		pad := 30 - visualWidth(compName)
+		pad := 30 - (2 + 1 + visualWidth(c.Name))
 		if pad < 1 {
 			pad = 1
 		}
@@ -788,7 +796,10 @@ func RenderStatusDashboard(statuses []ComponentStatus) {
 
 func printStatusRow(s ComponentStatus) {
 	nameStr := s.Icon + " " + s.Name
-	nameLen := visualWidth(nameStr)
+	// Emoji icons render as 2 cells in terminals, but runewidth often
+	// miscounts them (e.g. ☸️ with VS16 reports width 1 instead of 2).
+	// Use a fixed 2-cell icon slot + 1 space + text width for padding.
+	nameLen := 2 + 1 + visualWidth(s.Name)
 	namePad := 25 - nameLen
 	if namePad < 1 {
 		namePad = 1

--- a/cli/cmd/deploy_test.go
+++ b/cli/cmd/deploy_test.go
@@ -106,6 +106,7 @@ func TestDeployCommand_SingleTopology(t *testing.T) {
 func TestDeployCommand_IsolatedTopology(t *testing.T) {
 	deployTopology = "isolated"
 	deployKafkaNS = "kafka-sys"
+	deployConnectNS = "connect-sys"
 	deployAppNS = "app-sys"
 	deployChaosNS = "chaos-sys"
 	deployWithSchemaRegistry = "apicurio"
@@ -157,8 +158,8 @@ func TestDeployCommand_IsolatedTopology(t *testing.T) {
 		}
 		if strings.Contains(cmd, "helm upgrade --install connect-cluster") {
 			foundKafkaConnect = true
-			if !strings.Contains(cmd, "-n kafka-sys") {
-				t.Errorf("Expected Connect to be deployed in kafka-sys namespace, got: %s", cmd)
+			if !strings.Contains(cmd, "-n connect-sys") {
+				t.Errorf("Expected Connect to be deployed in connect-sys namespace, got: %s", cmd)
 			}
 		}
 		if strings.Contains(cmd, "helm upgrade --install kates") {

--- a/cli/cmd/doctor_dns.go
+++ b/cli/cmd/doctor_dns.go
@@ -1,0 +1,209 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+)
+
+var doctorDnsFix bool
+
+var doctorDnsCmd = &cobra.Command{
+	Use:   "dns",
+	Short: "Diagnose and fix cluster DNS configurations",
+	Long: `Diagnose cluster DNS configuration (like ndots and search domains) and
+automatically adapt existing Kates deployments to resolve cross-namespace
+Kafka broker connectivity issues.
+
+Examples:
+  # Check DNS configuration without applying fixes
+  kates doctor dns
+
+  # Diagnose and fix existing deployments
+  kates doctor dns --fix`,
+	RunE: runDoctorDns,
+}
+
+func init() {
+	doctorDnsCmd.Flags().BoolVar(&doctorDnsFix, "fix", false, "Automatically patch Deployments and KafkaConnect CRs to add required DNS search domains")
+	doctorDnsCmd.Flags().StringVar(&doctorKafkaNS, "kafka-ns", "kafka", "Namespace for Kafka brokers")
+	doctorDnsCmd.Flags().StringVar(&doctorConnectNS, "connect-ns", "connect", "Namespace for Kafka Connect")
+	doctorDnsCmd.Flags().StringVar(&doctorAppNS, "app-ns", "kates", "Namespace for Kates application")
+	
+	// Ensure we only add it if not already added by another init (though flags can be redefined if on different commands)
+	doctorCmd.AddCommand(doctorDnsCmd)
+}
+
+func runDoctorDns(cmd *cobra.Command, args []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	title := lipgloss.NewStyle().Bold(true).Foreground(clrText)
+	separator := lipgloss.NewStyle().Foreground(clrDim).Render(strings.Repeat("━", 50))
+	success := lipgloss.NewStyle().Foreground(clrGreen).Render("✅")
+	warning := lipgloss.NewStyle().Foreground(clrOrange).Render("⚠️ ")
+	fail := lipgloss.NewStyle().Foreground(clrRed).Render("❌")
+	info := lipgloss.NewStyle().Foreground(clrCyan).Render("ℹ️ ")
+
+	fmt.Println()
+	fmt.Println(title.Render("🩺 Kates DNS Doctor"))
+	fmt.Println(separator)
+	fmt.Println()
+
+	fmt.Println(lipgloss.NewStyle().Bold(true).Foreground(clrCyan).Render("📡 Cluster DNS Configuration"))
+
+	// 1. Diagnose cluster DNS configuration
+	podName := fmt.Sprintf("kates-dns-test-%d", rand.Intn(100000))
+	
+	// We use the "default" namespace because the application namespace might not exist yet
+	resolvConfOut, err := exec.CommandContext(ctx, "kubectl", "run", "--rm", "-i", "--restart=Never",
+		"--image=busybox:1.36", podName, "-n", "default",
+		"--", "cat", "/etc/resolv.conf").CombinedOutput()
+
+	if err != nil {
+		fmt.Printf("  %s Failed to run ephemeral pod in namespace default: %v\n", fail, err)
+		fmt.Printf("  Output: %s\n", string(resolvConfOut))
+		return err
+	}
+
+	resolvContent := string(resolvConfOut)
+	
+	var searches []string
+	var ndots string
+	
+	for _, line := range strings.Split(resolvContent, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "search ") {
+			searches = strings.Fields(line)[1:]
+		}
+		if strings.HasPrefix(line, "options ") {
+			opts := strings.Fields(line)[1:]
+			for _, opt := range opts {
+				if strings.HasPrefix(opt, "ndots:") {
+					ndots = strings.TrimPrefix(opt, "ndots:")
+				}
+			}
+		}
+	}
+
+	fmt.Printf("  %s Default Search Domains: %s\n", info, strings.Join(searches, ", "))
+	if ndots != "" {
+		fmt.Printf("  %s Default ndots: %s\n", info, ndots)
+	}
+
+	clusterDomain := "cluster.local"
+	for _, s := range searches {
+		if !strings.Contains(s, "svc.") && s != "default" {
+			clusterDomain = s
+		}
+	}
+	
+	fmt.Println()
+	fmt.Println(lipgloss.NewStyle().Bold(true).Foreground(clrCyan).Render("🔍 Deployment Audit & Adaptation"))
+	
+	requiredKafkaSearch := fmt.Sprintf("%s.svc.%s", doctorKafkaNS, clusterDomain)
+
+	// We need to check if connect and kates are in a different namespace than kafka
+	var fixCount int
+	var checkCount int
+
+	// Check Kates backend Deployment
+	checkCount++
+	if doctorAppNS != doctorKafkaNS {
+		katesPatchNeeded := checkDeploymentDNS(ctx, "kates", doctorAppNS, requiredKafkaSearch)
+		if katesPatchNeeded {
+			if doctorDnsFix {
+				fmt.Printf("  %s kates backend (namespace: %s) is missing DNS search domain.\n", warning, doctorAppNS)
+				err := patchDeploymentDNS(ctx, "kates", doctorAppNS, requiredKafkaSearch)
+				if err != nil {
+					fmt.Printf("     %s Failed to patch kates deployment: %v\n", fail, err)
+				} else {
+					fmt.Printf("     %s Successfully patched kates deployment.\n", success)
+					fixCount++
+				}
+			} else {
+				fmt.Printf("  %s kates backend (namespace: %s) is missing DNS search domain (run with --fix to resolve).\n", warning, doctorAppNS)
+			}
+		} else {
+			fmt.Printf("  %s kates backend (namespace: %s) has correct DNS search domain.\n", success, doctorAppNS)
+		}
+	} else {
+		fmt.Printf("  %s kates backend is in the same namespace as Kafka, no DNS search domain adaptation needed.\n", success)
+	}
+
+	// Check KafkaConnect CR
+	checkCount++
+	if doctorConnectNS != doctorKafkaNS {
+		connectPatchNeeded := checkKafkaConnectDNS(ctx, "connect-cluster", doctorConnectNS, requiredKafkaSearch)
+		if connectPatchNeeded {
+			if doctorDnsFix {
+				fmt.Printf("  %s connect-cluster (namespace: %s) is missing DNS search domain.\n", warning, doctorConnectNS)
+				err := patchKafkaConnectDNS(ctx, "connect-cluster", doctorConnectNS, requiredKafkaSearch)
+				if err != nil {
+					fmt.Printf("     %s Failed to patch connect-cluster: %v\n", fail, err)
+				} else {
+					fmt.Printf("     %s Successfully patched connect-cluster.\n", success)
+					fixCount++
+				}
+			} else {
+				fmt.Printf("  %s connect-cluster (namespace: %s) is missing DNS search domain (run with --fix to resolve).\n", warning, doctorConnectNS)
+			}
+		} else {
+			fmt.Printf("  %s connect-cluster (namespace: %s) has correct DNS search domain.\n", success, doctorConnectNS)
+		}
+	} else {
+		fmt.Printf("  %s connect-cluster is in the same namespace as Kafka, no DNS search domain adaptation needed.\n", success)
+	}
+
+	fmt.Println(separator)
+	if doctorDnsFix {
+		fmt.Printf("📊 Summary: Audited %d components. Applied %d fixes.\n", checkCount, fixCount)
+	} else {
+		fmt.Printf("📊 Summary: Audited %d components. Run with --fix to apply missing adaptations.\n", checkCount)
+	}
+
+	return nil
+}
+
+func checkDeploymentDNS(ctx context.Context, name, ns, requiredSearch string) bool {
+	out, err := exec.CommandContext(ctx, "kubectl", "get", "deployment", name, "-n", ns, "-o", "jsonpath={.spec.template.spec.dnsConfig.searches}").Output()
+	if err != nil {
+		// Ignore if deployment doesn't exist
+		return false
+	}
+	searches := string(out)
+	if !strings.Contains(searches, requiredSearch) {
+		return true
+	}
+	return false
+}
+
+func checkKafkaConnectDNS(ctx context.Context, name, ns, requiredSearch string) bool {
+	out, err := exec.CommandContext(ctx, "kubectl", "get", "kafkaconnect", name, "-n", ns, "-o", "jsonpath={.spec.template.pod.dnsConfig.searches}").Output()
+	if err != nil {
+		return false
+	}
+	searches := string(out)
+	if !strings.Contains(searches, requiredSearch) {
+		return true
+	}
+	return false
+}
+
+func patchDeploymentDNS(ctx context.Context, name, ns, searchDomain string) error {
+	patch := fmt.Sprintf(`{"spec":{"template":{"spec":{"dnsConfig":{"searches":["%s"]}}}}}`, searchDomain)
+	_, err := exec.CommandContext(ctx, "kubectl", "patch", "deployment", name, "-n", ns, "--type=strategic", "-p", patch).CombinedOutput()
+	return err
+}
+
+func patchKafkaConnectDNS(ctx context.Context, name, ns, searchDomain string) error {
+	patch := fmt.Sprintf(`{"spec":{"template":{"pod":{"dnsConfig":{"searches":["%s"]}}}}}`, searchDomain)
+	_, err := exec.CommandContext(ctx, "kubectl", "patch", "kafkaconnect", name, "-n", ns, "--type=merge", "-p", patch).CombinedOutput()
+	return err
+}

--- a/cli/cmd/doctor_network.go
+++ b/cli/cmd/doctor_network.go
@@ -1,0 +1,463 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+)
+
+// ─── Namespace flags for doctor network ─────────────────────
+
+var (
+	doctorKafkaNS   string
+	doctorConnectNS string
+	doctorAppNS     string
+	doctorDbNS      string
+)
+
+// ─── Check result types ─────────────────────────────────────
+
+type networkCheck struct {
+	Category string // "dns", "tcp", "netpol"
+	Name     string
+	Status   string // "pass", "fail", "warn"
+	Detail   string
+}
+
+// ─── Command definition ─────────────────────────────────────
+
+var doctorNetworkCmd = &cobra.Command{
+	Use:   "network",
+	Short: "Diagnose cluster network connectivity for Kates components",
+	Long: `Runs DNS resolution, TCP connectivity, and NetworkPolicy checks
+from ephemeral pods inside the cluster to verify cross-namespace
+networking between Kafka, Connect, Schema Registry, and Database.
+
+Examples:
+  # Use default namespaces
+  kates doctor network
+
+  # Custom namespaces
+  kates doctor network --kafka-ns kafka-prod --connect-ns connect-prod --db-ns pg-system`,
+	RunE: runDoctorNetwork,
+}
+
+func init() {
+	doctorNetworkCmd.Flags().StringVar(&doctorKafkaNS, "kafka-ns", "kafka", "Namespace for Kafka and Schema Registry")
+	doctorNetworkCmd.Flags().StringVar(&doctorConnectNS, "connect-ns", "connect", "Namespace for Kafka Connect")
+	doctorNetworkCmd.Flags().StringVar(&doctorAppNS, "app-ns", "kates", "Namespace for Kates application")
+	doctorNetworkCmd.Flags().StringVar(&doctorDbNS, "db-ns", "database", "Namespace for PostgreSQL database")
+
+	doctorCmd.AddCommand(doctorNetworkCmd)
+}
+
+// ─── Main runner ────────────────────────────────────────────
+
+func runDoctorNetwork(cmd *cobra.Command, args []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	// Styles
+	title := lipgloss.NewStyle().Bold(true).Foreground(clrText)
+	separator := lipgloss.NewStyle().Foreground(clrDim).Render(strings.Repeat("━", 50))
+
+	fmt.Println()
+	fmt.Println(title.Render("🩺 Kates Network Doctor"))
+	fmt.Println(separator)
+	fmt.Println()
+
+	var checks []networkCheck
+
+	// ── Phase 1: DNS Resolution ──
+	fmt.Println(lipgloss.NewStyle().Bold(true).Foreground(clrCyan).Render("📡 DNS Resolution"))
+
+	dnsTargets := []struct {
+		host string
+		desc string
+		ns   string
+	}{
+		{
+			host: fmt.Sprintf("krafter-kafka-bootstrap.%s.svc.cluster.local", doctorKafkaNS),
+			desc: "Kafka Bootstrap",
+			ns:   doctorAppNS,
+		},
+		{
+			host: fmt.Sprintf("connect-cluster-connect-api.%s.svc.cluster.local", doctorConnectNS),
+			desc: "Connect REST API",
+			ns:   doctorAppNS,
+		},
+		{
+			host: fmt.Sprintf("apicurio-apicurio-registry.%s.svc.cluster.local", doctorKafkaNS),
+			desc: "Schema Registry",
+			ns:   doctorAppNS,
+		},
+	}
+
+	for _, t := range dnsTargets {
+		result := runDNSCheck(ctx, t.host, t.ns)
+		checks = append(checks, result)
+		printNetworkCheck(result)
+	}
+
+	fmt.Println()
+
+	// ── Phase 2: TCP Connectivity ──
+	fmt.Println(lipgloss.NewStyle().Bold(true).Foreground(clrCyan).Render("🔌 TCP Connectivity"))
+
+	tcpTargets := []struct {
+		host string
+		port string
+		desc string
+		ns   string
+	}{
+		{
+			host: fmt.Sprintf("krafter-kafka-bootstrap.%s.svc.cluster.local", doctorKafkaNS),
+			port: "9092",
+			desc: "Kafka Plain",
+			ns:   doctorAppNS,
+		},
+		{
+			host: fmt.Sprintf("krafter-kafka-bootstrap.%s.svc.cluster.local", doctorKafkaNS),
+			port: "9093",
+			desc: "Kafka TLS",
+			ns:   doctorAppNS,
+		},
+		{
+			host: fmt.Sprintf("connect-cluster-connect-api.%s.svc.cluster.local", doctorConnectNS),
+			port: "8083",
+			desc: "Connect REST API",
+			ns:   doctorAppNS,
+		},
+		{
+			host: fmt.Sprintf("apicurio-apicurio-registry.%s.svc.cluster.local", doctorKafkaNS),
+			port: "80",
+			desc: "Schema Registry",
+			ns:   doctorAppNS,
+		},
+		{
+			host: fmt.Sprintf("postgresql.%s.svc.cluster.local", doctorDbNS),
+			port: "5432",
+			desc: "PostgreSQL",
+			ns:   doctorAppNS,
+		},
+	}
+
+	for _, t := range tcpTargets {
+		result := runTCPCheck(ctx, t.host, t.port, t.desc, t.ns)
+		checks = append(checks, result)
+		printNetworkCheck(result)
+	}
+
+	fmt.Println()
+
+	// ── Phase 3: NetworkPolicy Audit ──
+	fmt.Println(lipgloss.NewStyle().Bold(true).Foreground(clrCyan).Render("🛡️  NetworkPolicy Audit"))
+
+	namespaces := uniqueStrings([]string{doctorKafkaNS, doctorConnectNS, doctorAppNS, doctorDbNS})
+	for _, ns := range namespaces {
+		results := runNetPolAudit(ctx, ns)
+		checks = append(checks, results...)
+		for _, r := range results {
+			printNetworkCheck(r)
+		}
+	}
+
+	// ── Summary ──
+	fmt.Println()
+	fmt.Println(separator)
+
+	passed, warnings, failed := 0, 0, 0
+	for _, c := range checks {
+		switch c.Status {
+		case "pass":
+			passed++
+		case "warn":
+			warnings++
+		case "fail":
+			failed++
+		}
+	}
+	total := len(checks)
+	summaryParts := []string{fmt.Sprintf("%d/%d checks passed", passed, total)}
+	if warnings > 0 {
+		summaryParts = append(summaryParts, fmt.Sprintf("%d warning(s)", warnings))
+	}
+	if failed > 0 {
+		summaryParts = append(summaryParts, fmt.Sprintf("%d failed", failed))
+	}
+
+	summaryStyle := lipgloss.NewStyle().Bold(true).Foreground(clrGreen)
+	if failed > 0 {
+		summaryStyle = lipgloss.NewStyle().Bold(true).Foreground(clrRed)
+	} else if warnings > 0 {
+		summaryStyle = lipgloss.NewStyle().Bold(true).Foreground(clrOrange)
+	}
+
+	fmt.Println(summaryStyle.Render("📊 Summary: " + strings.Join(summaryParts, ", ")))
+	fmt.Println()
+
+	return nil
+}
+
+// ─── DNS Check ──────────────────────────────────────────────
+
+func runDNSCheck(ctx context.Context, host, sourceNS string) networkCheck {
+	podName := doctorPodName()
+	shellCmd := fmt.Sprintf("nslookup %s 2>&1 && echo DNS_OK || echo DNS_FAIL", host)
+
+	out, err := runEphemeralPod(ctx, podName, sourceNS, shellCmd)
+	if err != nil {
+		return networkCheck{
+			Category: "dns",
+			Name:     host,
+			Status:   "fail",
+			Detail:   fmt.Sprintf("Pod execution failed: %v", err),
+		}
+	}
+
+	if strings.Contains(out, "DNS_OK") {
+		return networkCheck{
+			Category: "dns",
+			Name:     host,
+			Status:   "pass",
+			Detail:   "",
+		}
+	}
+
+	return networkCheck{
+		Category: "dns",
+		Name:     host,
+		Status:   "fail",
+		Detail:   "Could not resolve hostname",
+	}
+}
+
+// ─── TCP Check ──────────────────────────────────────────────
+
+func runTCPCheck(ctx context.Context, host, port, desc, sourceNS string) networkCheck {
+	podName := doctorPodName()
+	shellCmd := fmt.Sprintf("nc -z -w 3 %s %s 2>&1 && echo TCP_OK || echo TCP_FAIL", host, port)
+
+	label := fmt.Sprintf("%s:%s (%s)", shortHost(host), port, desc)
+
+	out, err := runEphemeralPod(ctx, podName, sourceNS, shellCmd)
+	if err != nil {
+		return networkCheck{
+			Category: "tcp",
+			Name:     label,
+			Status:   "fail",
+			Detail:   fmt.Sprintf("Pod execution failed: %v", err),
+		}
+	}
+
+	if strings.Contains(out, "TCP_OK") {
+		return networkCheck{
+			Category: "tcp",
+			Name:     label,
+			Status:   "pass",
+			Detail:   "",
+		}
+	}
+
+	detail := "Connection refused"
+	if strings.Contains(out, "timed out") || strings.Contains(out, "timeout") {
+		detail = "Connection timed out"
+	}
+	return networkCheck{
+		Category: "tcp",
+		Name:     label,
+		Status:   "fail",
+		Detail:   detail,
+	}
+}
+
+// ─── NetworkPolicy Audit ────────────────────────────────────
+
+type k8sNetPolList struct {
+	Items []struct {
+		Metadata struct {
+			Name      string `json:"name"`
+			Namespace string `json:"namespace"`
+		} `json:"metadata"`
+	} `json:"items"`
+}
+
+func runNetPolAudit(ctx context.Context, ns string) []networkCheck {
+	checkCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	// List NetworkPolicies
+	out, err := exec.CommandContext(checkCtx, "kubectl", "get", "networkpolicy", "-n", ns, "-o", "json").Output()
+	if err != nil {
+		return []networkCheck{{
+			Category: "netpol",
+			Name:     fmt.Sprintf("%s/*", ns),
+			Status:   "pass",
+			Detail:   "No NetworkPolicies found (or namespace does not exist)",
+		}}
+	}
+
+	var list k8sNetPolList
+	if err := json.Unmarshal(out, &list); err != nil {
+		return []networkCheck{{
+			Category: "netpol",
+			Name:     fmt.Sprintf("%s/*", ns),
+			Status:   "warn",
+			Detail:   "Failed to parse NetworkPolicy list",
+		}}
+	}
+
+	if len(list.Items) == 0 {
+		return []networkCheck{{
+			Category: "netpol",
+			Name:     fmt.Sprintf("%s/*", ns),
+			Status:   "pass",
+			Detail:   "No NetworkPolicies found",
+		}}
+	}
+
+	var results []networkCheck
+	for _, item := range list.Items {
+		policyName := fmt.Sprintf("%s/%s", item.Metadata.Namespace, item.Metadata.Name)
+
+		// Fetch the raw YAML/JSON to check for kubernetes.io/metadata.name usage
+		polOut, polErr := exec.CommandContext(checkCtx, "kubectl", "get", "networkpolicy",
+			item.Metadata.Name, "-n", item.Metadata.Namespace, "-o", "json").Output()
+		if polErr != nil {
+			results = append(results, networkCheck{
+				Category: "netpol",
+				Name:     policyName,
+				Status:   "warn",
+				Detail:   "Could not inspect policy",
+			})
+			continue
+		}
+
+		raw := string(polOut)
+		if strings.Contains(raw, "kubernetes.io/metadata.name") {
+			results = append(results, networkCheck{
+				Category: "netpol",
+				Name:     policyName,
+				Status:   "warn",
+				Detail:   "uses kubernetes.io/metadata.name (may fail on some clusters)",
+			})
+		} else {
+			results = append(results, networkCheck{
+				Category: "netpol",
+				Name:     policyName,
+				Status:   "pass",
+				Detail:   "OK",
+			})
+		}
+	}
+
+	return results
+}
+
+// ─── Ephemeral pod runner ───────────────────────────────────
+
+func runEphemeralPod(ctx context.Context, podName, namespace, shellCmd string) (string, error) {
+	runCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	args := []string{
+		"run", "--rm", "-i", "--restart=Never",
+		"--image=busybox:1.36",
+		podName,
+		"-n", namespace,
+		"--", "sh", "-c", shellCmd,
+	}
+
+	cmd := exec.CommandContext(runCtx, "kubectl", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		// If the pod completed but had a non-zero exit, the output is still
+		// useful for parsing DNS_OK/TCP_OK markers.
+		if len(out) > 0 {
+			return string(out), nil
+		}
+		return "", fmt.Errorf("kubectl run failed: %w", err)
+	}
+
+	return string(out), nil
+}
+
+// ─── Output helpers ─────────────────────────────────────────
+
+func printNetworkCheck(c networkCheck) {
+	indent := "  "
+	switch c.Status {
+	case "pass":
+		icon := lipgloss.NewStyle().Foreground(clrGreen).Render("✅")
+		name := lipgloss.NewStyle().Foreground(clrText).Render(c.Name)
+		if c.Detail != "" && c.Detail != "OK" {
+			fmt.Printf("%s%s %s %s\n", indent, icon, name,
+				lipgloss.NewStyle().Foreground(clrDim).Italic(true).Render("— "+c.Detail))
+		} else {
+			fmt.Printf("%s%s %s\n", indent, icon, name)
+		}
+	case "fail":
+		icon := lipgloss.NewStyle().Foreground(clrRed).Render("❌")
+		name := lipgloss.NewStyle().Foreground(clrText).Render(c.Name)
+		fmt.Printf("%s%s %s\n", indent, icon, name)
+		if c.Detail != "" {
+			arrow := lipgloss.NewStyle().Foreground(clrDim).Render("→")
+			detail := lipgloss.NewStyle().Foreground(clrRed).Italic(true).Render(c.Detail)
+			fmt.Printf("%s   %s %s\n", indent, arrow, detail)
+		}
+	case "warn":
+		icon := lipgloss.NewStyle().Foreground(clrOrange).Render("⚠️ ")
+		name := lipgloss.NewStyle().Foreground(clrText).Render(c.Name)
+		detail := lipgloss.NewStyle().Foreground(clrOrange).Italic(true).Render(c.Detail)
+		fmt.Printf("%s%s%s %s\n", indent, icon, name, detail)
+	}
+}
+
+// ─── Utility helpers ────────────────────────────────────────
+
+// doctorPodName generates a unique ephemeral pod name.
+func doctorPodName() string {
+	return fmt.Sprintf("kates-doctor-%s", randomSuffix(6))
+}
+
+// randomSuffix returns a random lowercase alphanumeric string of length n.
+func randomSuffix(n int) string {
+	const letters = "abcdefghijklmnopqrstuvwxyz0123456789"
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+// shortHost extracts a readable short name from a FQDN.
+// "krafter-kafka-bootstrap.kafka.svc.cluster.local" → "kafka"
+// It uses the second part (namespace) of the service DNS name.
+func shortHost(fqdn string) string {
+	parts := strings.SplitN(fqdn, ".", 3)
+	if len(parts) >= 2 {
+		return parts[1]
+	}
+	return fqdn
+}
+
+// uniqueStrings deduplicates a string slice while preserving order.
+func uniqueStrings(input []string) []string {
+	seen := make(map[string]bool)
+	var result []string
+	for _, s := range input {
+		if !seen[s] {
+			seen[s] = true
+			result = append(result, s)
+		}
+	}
+	return result
+}

--- a/cli/cmd/helm_test_cmd.go
+++ b/cli/cmd/helm_test_cmd.go
@@ -152,6 +152,15 @@ func runHelmTests(cmd *cobra.Command, args []string) error {
 	// 5. Optional component filter
 	if component != "" {
 		releases = filterByComponent(releases, component)
+		// If filtering for 'connect' and no releases found, try auto-detecting the connect namespace
+		if len(releases) == 0 && component == "connect" {
+			detectedNS := detectConnectNamespace()
+			if detectedNS != ns {
+				connectReleases := discoverHelmReleases(detectedNS)
+				connectReleases = filterByComponent(connectReleases, component)
+				releases = append(releases, connectReleases...)
+			}
+		}
 	}
 
 	// 6. Discovery section

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -94,7 +94,6 @@ func runUpgrade() error {
 	}
 
 	// ── 6. Build ─────────────────────────────────────────────────────────────
-	fmt.Println("    ⚙  Building from source...")
 	buildDate := time.Now().UTC().Format(time.RFC3339)
 	ldflags := fmt.Sprintf("-s -w -X github.com/klster/kates-cli/cmd.Version=%s -X github.com/klster/kates-cli/cmd.Commit=%s -X github.com/klster/kates-cli/cmd.BuildDate=%s",
 		gitBranch+"-"+gitCommit, gitCommit, buildDate)
@@ -104,10 +103,41 @@ func runUpgrade() error {
 
 	buildCmd := exec.Command("go", "build", "-ldflags", ldflags, "-o", tmpBin, ".")
 	buildCmd.Dir = srcDir
-	buildCmd.Stdout = os.Stdout
-	buildCmd.Stderr = os.Stderr
-	if err := buildCmd.Run(); err != nil {
-		return fmt.Errorf("build failed: %w", err)
+	// Capture stderr for error reporting but don't print live
+	// (go build is noisy only on failure)
+	var buildStderr strings.Builder
+	buildCmd.Stderr = &buildStderr
+
+	// Spinner with elapsed time
+	spinFrames := []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+	buildStart := time.Now()
+	done := make(chan struct{})
+	go func() {
+		i := 0
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				elapsed := time.Since(buildStart).Round(time.Second)
+				fmt.Printf("\r    %s  Building from source... %s", spinFrames[i%len(spinFrames)], elapsed)
+				i++
+				time.Sleep(150 * time.Millisecond)
+			}
+		}
+	}()
+
+	buildErr := buildCmd.Run()
+	close(done)
+	// Clear the spinner line
+	fmt.Printf("\r%s\r", strings.Repeat(" ", 60))
+
+	if buildErr != nil {
+		fmt.Println("    ❌ Build failed")
+		if errOut := buildStderr.String(); errOut != "" {
+			fmt.Fprint(os.Stderr, errOut)
+		}
+		return fmt.Errorf("build failed: %w", buildErr)
 	}
 
 	// Verify the binary exists and is executable

--- a/docs/book/10-cli-reference.md
+++ b/docs/book/10-cli-reference.md
@@ -25,6 +25,27 @@ make cli-build
 
 Kates CLI uses a config file at `~/.kates.yaml` for managing server contexts.
 
+### Proxy Configuration
+
+The Kates CLI fully supports HTTP proxies. You can either use standard proxy environment variables or configure it persistently per context.
+
+**Option 1: Context Proxy (Recommended)**
+```bash
+# Configure a specific proxy for a single environment context
+kates ctx set prod --url https://kates.company.com --proxy http://proxy-server.internal:8080
+
+# If the proxy uses self-signed SSL interception, bypass certificate validation:
+kates ctx set prod --url https://kates.company.com --proxy http://proxy-server.internal:8080 --insecure
+```
+
+**Option 2: Global Environment Variables**
+The CLI natively respects standard OS proxy variables:
+```bash
+export HTTP_PROXY="http://proxy-server.internal:8080"
+export HTTPS_PROXY="http://proxy-server.internal:8080"
+export NO_PROXY="localhost,127.0.0.1"
+```
+
 ### Context Management
 
 ```bash

--- a/kates/Dockerfile
+++ b/kates/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the KATES CLI (Go)
-FROM golang:1.25-alpine AS cli-builder
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS cli-builder
 ENV GOTOOLCHAIN=auto
 WORKDIR /cli
 COPY cli/go.mod cli/go.sum ./
@@ -14,16 +14,18 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
   -o /kates .
 
 # Stage 2: Build the Java application
-FROM eclipse-temurin:25-jdk AS builder
+FROM --platform=$BUILDPLATFORM eclipse-temurin:25-jdk AS builder
 WORKDIR /build
 
 COPY kates/pom.xml .
 COPY kates/.mvn .mvn
 COPY kates/mvnw .
-RUN chmod +x mvnw && ./mvnw dependency:go-offline -B 2>/dev/null || true
+RUN --mount=type=cache,target=/root/.m2 \
+  chmod +x mvnw && ./mvnw dependency:go-offline -B 2>/dev/null || true
 
 COPY kates/src src
-RUN ./mvnw package -DskipTests -B
+RUN --mount=type=cache,target=/root/.m2 \
+  ./mvnw package -DskipTests -B
 
 # Stage 3: Runtime — Java app + CLI on PATH
 FROM eclipse-temurin:25-jre

--- a/kates/src/main/java/com/bmscomp/kates/resilience/ResilienceOrchestrator.java
+++ b/kates/src/main/java/com/bmscomp/kates/resilience/ResilienceOrchestrator.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
 
 import org.jboss.logging.Logger;
@@ -50,6 +51,7 @@ public class ResilienceOrchestrator {
     @Inject
     ProbeExecutor probeExecutor;
 
+    @ActivateRequestContext
     public ResilienceReport execute(ResilienceTestRequest request) {
         ResilienceReport report = new ResilienceReport();
 


### PR DESCRIPTION
# Kafka Connect Multi-Namespace Support & Deploy Reliability

> Deploy Kafka Connect in its own namespace with full cross-namespace orchestration, hardened deploy reliability, and polished UX.

## Motivation

Running Kafka Connect in the same namespace as the Kafka cluster creates tight coupling and makes it harder to manage RBAC, network policies, and resource quotas independently. This PR introduces first-class support for deploying Kafka Connect in a **dedicated `connect` namespace** while maintaining full connectivity to the Kafka cluster, schema registry, and database.

Along the way, several production-grade reliability issues were uncovered and fixed — silent deploy failures, stale Helm releases, and terminal rendering bugs.

---

## What Changed

### 1. Multi-Namespace Kafka Connect (`868f52b`, `ae90ccc`, `6d2eb16`, `b299d71`, `d59aadd`)

**The big feature.** Kafka Connect can now live in a separate namespace from the Kafka cluster.

```
┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐
│   kafka (ns)    │     │   connect (ns)   │     │  database (ns)  │
│                 │     │                  │     │                 │
│  Kafka Brokers  │◄────│  KafkaConnect    │────►│  PostgreSQL     │
│  Entity Operator│     │  Debezium CDC    │     │                 │
│  kafka-metrics  │────►│  kafka-metrics*  │     │                 │
│  kates-connect  │────►│  kates-connect*  │     │                 │
└─────────────────┘     └──────────────────┘     └─────────────────┘
                              * = copied cross-namespace
```

**CLI changes:**
- New `--connect-ns` flag (default: `connect`) on `kates deploy`
- Interactive form shows Connect/Database namespace inputs only when Kafka Connect is selected
- `kates connect` subcommands auto-detect the Connect namespace from the cluster

**Helm chart changes (`connect-cluster`):**
- New `kafka.namespace` value to specify where the Kafka cluster lives
- Cross-namespace RBAC: `Role` + `RoleBinding` in the kafka namespace for secret access
- Network policies scoped to the correct kafka namespace for egress
- `bootstrapServers` FQDN dynamically points to `krafter-kafka-bootstrap.<kafka-ns>.svc`

**Cross-namespace resource sync:**
- `kafka-metrics` ConfigMap copied to connect namespace (required by `metricsConfig`)
- `kates-connect` Secret copied for SASL authentication
- `connect-pg-credentials` Secret created in connect namespace for Debezium

---

### 2. Deploy Reliability Hardening (`0e2f630`)

Three production bugs that caused silent deploy failures:

#### ConfigMap Field-Manager Conflict
**Was:** Copying `kafka-metrics` via `kubectl get -o yaml | sed | kubectl apply` carried Helm ownership annotations (`meta.helm.sh/release-name`, `managedFields`), causing:
```
Error from server (Conflict): error when applying patch...
```
**Fix:** Extract only the data via `jsonpath`, construct a clean ConfigMap YAML, and fallback to `--server-side --force-conflicts` if standard apply fails.

#### Stale Helm Release False Positive
**Was:** `helm status` exits 0 for releases in **any** state (including `failed`). A crashed Connect deploy left a broken release that was treated as "deployed" on the next run.
**Fix:** Parse `helm status -o json` and check for `"status": "deployed"` explicitly (handles both compact and spaced JSON formats).

#### "Deployed" Without Pods
**Was:** Even a genuinely `deployed` Helm release can have zero running pods (e.g., Strimzi couldn't reconcile because ConfigMap was missing). Deploy showed "Ready" with no pods.
**Fix:** For Kafka Connect, verify that `strimzi.io/kind=KafkaConnect` pods actually exist before skipping re-install. If no pods, force `helm upgrade`.

---

### 3. Interactive Form Fix (`044b579`, `0e2f630`)

#### Missing Namespace Prompts
**Was:** The `huh` library's `WithHideFunc` at the group level didn't react to `MultiSelect` value binding changes within the same form. Selecting Monitoring + Chaos + Connect would only show 2 of the expected namespace prompts.

**Fix:** Split the interactive form into **two sequential `huh.Form` instances**:
1. **Form 1** — topology, schema registry, HA, component selection
2. **Form 2** — dynamically build namespace groups based on selected components

This ensures `components` is fully committed before namespace groups are evaluated.

---

### 4. UX Polish (`0e2f630`)

| Improvement | Before | After |
|---|---|---|
| **Build progress** | `Building from source...` (frozen) | Live spinner with elapsed time |
| **Table alignment** | Columns misaligned per row | Fixed 2-cell emoji icon slot |
| **Schema Registry** | Default: None | Default: **Apicurio** |
| **High Availability** | Default: No | Default: **Yes** |

#### Table Alignment Root Cause
`runewidth.StringWidth` miscounts emoji with VS16 variation selectors (e.g., `☸️` reports width 1, renders as 2). Fix: use `2 + 1 + visualWidth(s.Name)` instead of `visualWidth(icon + " " + name)`.

---

## Files Changed

```
 charts/connect-cluster/templates/_helpers.tpl       |  16 +-
 charts/connect-cluster/templates/networkpolicies.yaml |   4 +-
 charts/connect-cluster/templates/secret-reader-rbac.yaml |  31 +++ (NEW)
 charts/connect-cluster/values.yaml                  |   2 +
 cli/cmd/connect.go                                  |  29 ++-
 cli/cmd/deploy.go                                   | 215 +++++++++++++------
 cli/cmd/deploy_status.go                            |   7 +-
 cli/cmd/helm_test_cmd.go                            |   9 +
 cli/cmd/upgrade.go                                  |  40 +++-
 docs/book/10-cli-reference.md                       |  21 ++
 10 files changed, 312 insertions(+), 62 deletions(-)
```

## Testing

- `go build ./...` — passes
- `go vet ./cmd/` — passes
- All existing tests pass
- Manual end-to-end verified:
  - `kates deploy -i` — all namespace prompts appear correctly
  - `kates deploy` (isolated) — Connect deploys to `connect` namespace
  - `kates deploy` (re-run) — idempotent, no conflicts
  - `kates deploy status` — columns aligned
  - `kates upgrade` — spinner visible during build
  - `kates connect status` — auto-detects connect namespace

> **Note:** `TestDeployCommand_IsolatedTopology` has a pre-existing failure unrelated to this PR (test expects Connect in `kafka-sys` but default is `connect`).
