### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/charts/kafka-cluster/values.yaml
+++ b/charts/kafka-cluster/values.yaml
@@ -481,7 +481,7 @@ tieredStorage:
 
 crdUpgrade:
   enabled: true
-  image: "bitnami/kubectl:latest"
+  image: "soldevelo/kubectl:latest"
 
 dashboards:
   enabled: true

--- a/charts/kates-chaos/templates/gameday.yaml
+++ b/charts/kates-chaos/templates/gameday.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: {{ include "kates-chaos.fullname" . }}-experiment-installer
       containers:
         - name: gameday
-          image: {{ .Values.gameday.image | default "bitnami/kubectl:1.33" }}
+          image: {{ .Values.gameday.image | default "soldevelo/kubectl:1.33" }}
           imagePullPolicy: IfNotPresent
           command: ["/bin/sh"]
           args:

--- a/config/litmus/experiments/consumer-latency-probe.yaml
+++ b/config/litmus/experiments/consumer-latency-probe.yaml
@@ -83,7 +83,7 @@ spec:
                 criteria: contains
                 value: "PASS"
               source:
-                image: bitnami/kubectl:latest
+                image: soldevelo/kubectl:latest
                 hostNetwork: false
 ---
 # Consumer latency monitoring ConfigMap

--- a/config/litmus/experiments/isr-health-probe.yaml
+++ b/config/litmus/experiments/isr-health-probe.yaml
@@ -56,7 +56,7 @@ spec:
                 criteria: contains
                 value: "PASS"
               source:
-                image: bitnami/kubectl:latest
+                image: soldevelo/kubectl:latest
                 hostNetwork: false
           
           # Min ISR check - ensure partitions can still accept writes
@@ -88,7 +88,7 @@ spec:
                 criteria: "<="
                 value: "5"  # Allow up to 5 unavailable during chaos
               source:
-                image: bitnami/kubectl:latest
+                image: soldevelo/kubectl:latest
                 hostNetwork: false
 ---
 # ISR health monitoring ConfigMap

--- a/config/litmus/experiments/kafka-chaos-cronjob.yaml
+++ b/config/litmus/experiments/kafka-chaos-cronjob.yaml
@@ -58,7 +58,7 @@ spec:
       # Pre-flight check
       - name: preflight-check
         container:
-          image: bitnami/kubectl:latest
+          image: soldevelo/kubectl:latest
           imagePullPolicy: IfNotPresent
           command: ["/bin/bash"]
           args:
@@ -96,7 +96,7 @@ spec:
             - name: experiment
             - name: duration
         container:
-          image: bitnami/kubectl:latest
+          image: soldevelo/kubectl:latest
           imagePullPolicy: IfNotPresent
           command: ["/bin/bash"]
           args:
@@ -142,7 +142,7 @@ spec:
       # Verify cluster recovery
       - name: verify-cluster
         container:
-          image: bitnami/kubectl:latest
+          image: soldevelo/kubectl:latest
           imagePullPolicy: IfNotPresent
           command: ["/bin/bash"]
           args:

--- a/config/litmus/experiments/kafka-gameday-workflow.yaml
+++ b/config/litmus/experiments/kafka-gameday-workflow.yaml
@@ -192,7 +192,7 @@ spec:
           - name: experiment-type
           - name: extra-env
       container:
-        image: bitnami/kubectl:latest
+        image: soldevelo/kubectl:latest
         imagePullPolicy: IfNotPresent
         command: ["/bin/bash"]
         args:
@@ -255,7 +255,7 @@ spec:
         parameters:
           - name: phase
       container:
-        image: bitnami/kubectl:latest
+        image: soldevelo/kubectl:latest
         imagePullPolicy: IfNotPresent
         command: ["/bin/bash"]
         args:
@@ -300,7 +300,7 @@ spec:
         parameters:
           - name: phase
       container:
-        image: bitnami/kubectl:latest
+        image: soldevelo/kubectl:latest
         imagePullPolicy: IfNotPresent
         command: ["/bin/bash"]
         args:
@@ -333,7 +333,7 @@ spec:
     # Final report
     - name: chaos-report
       container:
-        image: bitnami/kubectl:latest
+        image: soldevelo/kubectl:latest
         imagePullPolicy: IfNotPresent
         command: ["/bin/bash"]
         args:

--- a/config/litmus/experiments/kates-chaos-integration-job.yaml
+++ b/config/litmus/experiments/kates-chaos-integration-job.yaml
@@ -18,7 +18,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: chaos-runner
-          image: bitnami/kubectl:latest
+          image: soldevelo/kubectl:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: KATES_API_URL

--- a/config/litmus/experiments/producer-throughput-probe.yaml
+++ b/config/litmus/experiments/producer-throughput-probe.yaml
@@ -45,7 +45,7 @@ spec:
                 criteria: ">="
                 value: "10.0"  # Minimum 10 records/sec
               source:
-                image: bitnami/kubectl:latest
+                image: soldevelo/kubectl:latest
                 hostNetwork: false
 ---
 # Standalone producer throughput ConfigMap for reuse


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/kubectl:latest` → [`soldevelo/kubectl:latest`](https://hub.docker.com/r/soldevelo/kubectl)
- `bitnami/kubectl:1.33` → [`soldevelo/kubectl:1.33`](https://hub.docker.com/r/soldevelo/kubectl)