### PR TITLE
fix: remove duplicate kubectl apply for Kafka users/topics

### DIFF
--- a/charts/kafka-cluster/values.yaml
+++ b/charts/kafka-cluster/values.yaml
@@ -297,6 +297,14 @@ topics:
         cleanup.policy: delete
         retention.ms: "86400000"
         min.insync.replicas: "2"
+    # Test sink topic for Kafka Connect sink connector validation
+    - name: test-sink-topic
+      partitions: 3
+      replicas: 3
+      config:
+        retention.ms: "86400000"
+        min.insync.replicas: "2"
+        cleanup.policy: delete
 
 users:
   # -- Enable managed user provisioning

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -949,9 +948,11 @@ metadata:
 
 			}
 
-			dl.Println("    - Applying Kafka users and topics...")
-			applyManifestWithNamespace(ctx, "config/kafka/kafka-users.yaml", kafkaNS)
-			applyManifestWithNamespace(ctx, "config/kafka/kafka-topics.yaml", kafkaNS)
+			// Kafka users and topics are managed declaratively by the Helm chart
+			// (charts/kafka-cluster templates/users.yaml + templates/topics.yaml).
+			// Applying them again via raw manifests causes MethodNotAllowed (HTTP 405)
+			// field-ownership conflicts with Helm's server-side apply.
+			dl.Println("    - Kafka users and topics managed by Helm chart")
 
 			if !isTesting {
 				dl.Println("    - Waiting for Entity Operator to start...")
@@ -1534,21 +1535,6 @@ func cleanupStaleClusterResource(ctx context.Context, kind, name, expectedNS str
 		defer delCancel()
 		exec.CommandContext(delCtx, "kubectl", "delete", kind, name, "--ignore-not-found").Run()
 	}
-}
-
-// applyManifestWithNamespace reads a YAML file, strips any hardcoded
-// `namespace:` fields from metadata, and applies it to the given namespace.
-// This ensures manifests work correctly regardless of deployment topology.
-var nsLineRegex = regexp.MustCompile(`(?m)^\s+namespace:\s+\S+\s*$`)
-
-func applyManifestWithNamespace(ctx context.Context, file, namespace string) error {
-	data, err := os.ReadFile(file)
-	if err != nil {
-		return fmt.Errorf("failed to read %s: %w", file, err)
-	}
-	// Strip hardcoded namespace lines so -n flag takes effect
-	stripped := nsLineRegex.ReplaceAllString(string(data), "")
-	return runExecStdinFn(ctx, "kubectl", []string{"apply", "-f", "-", "-n", namespace}, stripped)
 }
 
 func sliceContains(s []string, v string) bool {


### PR DESCRIPTION
## Problem

During `kates deploy`, the TUI displayed red `MethodNotAllowed` errors for every KafkaUser and KafkaTopic resource:

```
Error from server (MethodNotAllowed): error when creating "STDIN": ...
```

## Root Cause

The Helm chart (`charts/kafka-cluster`) creates KafkaUser and KafkaTopic resources via **server-side apply** (field manager: `helm`). Immediately after, `deploy.go` re-applied the **same resources** from raw YAML manifests via **client-side apply** (`kubectl apply -f -`), causing field ownership conflicts that the API server rejects with HTTP 405.

## Changes

- **`cli/cmd/deploy.go`** — Remove the redundant `applyManifestWithNamespace` calls for `kafka-users.yaml` and `kafka-topics.yaml`. Clean up the now-dead `applyManifestWithNamespace` function, `nsLineRegex` variable, and unused `regexp` import.
- **`charts/kafka-cluster/values.yaml`** — Add `test-sink-topic` to the Helm chart's topic list (was previously only defined in the raw manifest, ensuring no topic is lost).

## Verification

- `go build ./...` ✅
- `go test ./cmd/ -run TestDeploy` ✅ (all deploy tests pass)