### PR TITLE
feat: add Kafka UI Helm chart and integrate with kates deploy

### DIFF
--- a/charts/kafka-cluster/templates/networkpolicies.yaml
+++ b/charts/kafka-cluster/templates/networkpolicies.yaml
@@ -251,7 +251,7 @@ spec:
           podSelector:
             matchLabels:
               strimzi.io/kind: cluster-operator
----
+{{- if .Values.networkPolicies.kafkaUI }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -283,6 +283,7 @@ spec:
       ports:
         - port: 443
           protocol: TCP
+{{- end }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/charts/kafka-cluster/templates/users.yaml
+++ b/charts/kafka-cluster/templates/users.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.users.enabled }}
 {{- range .Values.users.items }}
+{{- if not (and (eq .name "kafka-ui") (not $.Values.kafkaUI.managedUser)) }}
 ---
 apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
@@ -23,5 +24,6 @@ spec:
     acls:
       {{- toYaml .acls | nindent 6 }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kafka-cluster/values.yaml
+++ b/charts/kafka-cluster/values.yaml
@@ -306,6 +306,11 @@ topics:
         min.insync.replicas: "2"
         cleanup.policy: delete
 
+# -- Kafka UI managed resources (set to false when using the standalone kafka-ui chart)
+kafkaUI:
+  # -- Manage the kafka-ui KafkaUser from this chart
+  managedUser: true
+
 users:
   # -- Enable managed user provisioning
   enabled: true
@@ -462,6 +467,8 @@ networkPolicies:
   connectNamespace: connect
   # Namespace where the Strimzi Operator is deployed (for its NetworkPolicy)
   operatorNamespace: strimzi-operator
+  # -- Manage kafka-ui NetworkPolicy from this chart (set false when using standalone kafka-ui chart)
+  kafkaUI: true
 
 tieredStorage:
   enabled: false

--- a/charts/kafka-ui/.helmignore
+++ b/charts/kafka-ui/.helmignore
@@ -1,0 +1,26 @@
+# Patterns to ignore when building packages.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# Helm value overlays (included explicitly via -f flag)
+values-kind.yaml
+values-dev.yaml
+values-generic.yaml
+values-prod.yaml

--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: kafka-ui
+description: A Helm chart for deploying Kafka UI with Strimzi SCRAM-SHA-512 authentication
+type: application
+version: 0.1.0
+appVersion: "v0.7.2"
+kubeVersion: ">=1.27.0-0"
+home: https://github.com/bmscomp/kates
+sources:
+  - https://github.com/bmscomp/kates
+  - https://github.com/provectus/kafka-ui
+maintainers:
+  - name: bmscomp
+    url: https://github.com/bmscomp
+keywords:
+  - kafka
+  - kafka-ui
+  - monitoring
+  - strimzi
+  - dashboard

--- a/charts/kafka-ui/templates/NOTES.txt
+++ b/charts/kafka-ui/templates/NOTES.txt
@@ -1,0 +1,38 @@
+
+Kafka UI has been deployed!
+
+{{- if eq .Values.service.type "NodePort" }}
+
+Access Kafka UI via NodePort:
+
+  export NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+  echo "http://${NODE_IP}:{{ .Values.service.nodePort | default 30081 }}"
+
+{{- else if eq .Values.service.type "LoadBalancer" }}
+
+Access Kafka UI via LoadBalancer:
+
+  export LB_IP=$(kubectl get svc {{ include "kafka-ui.fullname" . }} -n {{ include "kafka-ui.namespace" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo "http://${LB_IP}:{{ .Values.service.port }}"
+
+{{- else }}
+
+Access Kafka UI via port-forward:
+
+  kubectl port-forward svc/{{ include "kafka-ui.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }} -n {{ include "kafka-ui.namespace" . }}
+  echo "http://localhost:{{ .Values.service.port }}"
+
+{{- end }}
+
+{{- if .Values.ingress.enabled }}
+
+Or via Ingress:
+
+  {{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+  {{- end }}
+{{- end }}
+
+Kafka cluster: {{ .Values.kafka.clusterName }}
+Bootstrap:     {{ include "kafka-ui.bootstrapServers" . }}
+KafkaUser:     {{ .Values.kafkaUser.name }}

--- a/charts/kafka-ui/templates/_helpers.tpl
+++ b/charts/kafka-ui/templates/_helpers.tpl
@@ -1,0 +1,110 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kafka-ui.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "kafka-ui.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Allow the release namespace to be overridden.
+*/}}
+{{- define "kafka-ui.namespace" -}}
+{{- if .Values.namespaceOverride }}
+{{- .Values.namespaceOverride }}
+{{- else }}
+{{- .Release.Namespace }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "kafka-ui.labels" -}}
+helm.sh/chart: {{ include "kafka-ui.chart" . }}
+{{ include "kafka-ui.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: dashboard
+app.kubernetes.io/part-of: kates
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "kafka-ui.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kafka-ui.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app: kafka-ui
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kafka-ui.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Kafka namespace — where the Kafka cluster lives.
+Defaults to the release namespace if not set.
+*/}}
+{{- define "kafka-ui.kafkaNamespace" -}}
+{{- if .Values.kafka.namespace -}}
+{{- .Values.kafka.namespace -}}
+{{- else -}}
+{{- include "kafka-ui.namespace" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Kafka bootstrap servers FQDN.
+*/}}
+{{- define "kafka-ui.bootstrapServers" -}}
+{{- if .Values.kafka.bootstrapServers -}}
+{{- .Values.kafka.bootstrapServers -}}
+{{- else -}}
+{{- $svc := printf "%s-kafka-bootstrap" (.Values.kafka.clusterName | default "krafter") -}}
+{{- $clusterDomain := .Values.kafka.clusterDomain | default "cluster.local" -}}
+{{- if .Values.kafka.tls.enabled -}}
+{{- printf "%s.%s.svc.%s:9093" $svc (include "kafka-ui.kafkaNamespace" .) $clusterDomain -}}
+{{- else -}}
+{{- printf "%s.%s.svc.%s:9092" $svc (include "kafka-ui.kafkaNamespace" .) $clusterDomain -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+KafkaUser secret name — the Strimzi-generated SCRAM credential.
+*/}}
+{{- define "kafka-ui.secretName" -}}
+{{- .Values.kafkaUser.name | default "kafka-ui" -}}
+{{- end -}}
+
+{{/*
+Container security context (hardened).
+*/}}
+{{- define "kafka-ui.containerSecurityContext" -}}
+allowPrivilegeEscalation: false
+readOnlyRootFilesystem: false
+capabilities:
+  drop:
+    - ALL
+{{- end }}

--- a/charts/kafka-ui/templates/configmap.yaml
+++ b/charts/kafka-ui/templates/configmap.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kafka-ui.fullname" . }}-config
+  namespace: {{ include "kafka-ui.namespace" . }}
+  labels:
+    {{- include "kafka-ui.labels" . | nindent 4 }}
+data:
+  config.yml: |
+    kafka:
+      clusters:
+        - name: {{ .Values.kafka.clusterName }}
+          bootstrapServers: {{ include "kafka-ui.bootstrapServers" . }}
+          properties:
+            {{- if .Values.kafka.tls.enabled }}
+            security.protocol: SASL_SSL
+            {{- else }}
+            security.protocol: SASL_PLAINTEXT
+            {{- end }}
+            sasl.mechanism: SCRAM-SHA-512
+            sasl.jaas.config: >-
+              org.apache.kafka.common.security.scram.ScramLoginModule required
+              username="{{ .Values.kafkaUser.name }}"
+              password="${KAFKA_UI_PASSWORD}";
+            {{- if .Values.kafka.tls.enabled }}
+            ssl.truststore.type: PEM
+            {{- end }}
+
+    auth:
+      type: {{ .Values.auth.type | default "DISABLED" }}
+    management:
+      health:
+        ldap:
+          enabled: false

--- a/charts/kafka-ui/templates/deployment.yaml
+++ b/charts/kafka-ui/templates/deployment.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kafka-ui.fullname" . }}
+  namespace: {{ include "kafka-ui.namespace" . }}
+  labels:
+    {{- include "kafka-ui.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "kafka-ui.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "kafka-ui.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: kafka-ui
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: SPRING_CONFIG_ADDITIONAL-LOCATION
+              value: /etc/kafkaui/config.yml
+            - name: LOGGING_LEVEL_ROOT
+              value: {{ .Values.logging.root | default "INFO" }}
+            - name: LOGGING_LEVEL_COM_PROVECTUS
+              value: {{ .Values.logging.provectus | default "INFO" }}
+            - name: KAFKA_UI_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kafka-ui.secretName" . }}
+                  key: password
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/kafkaui
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "kafka-ui.fullname" . }}-config
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/kafka-ui/templates/ingress.yaml
+++ b/charts/kafka-ui/templates/ingress.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "kafka-ui.fullname" . }}
+  namespace: {{ include "kafka-ui.namespace" . }}
+  labels:
+    {{- include "kafka-ui.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "kafka-ui.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/kafka-ui/templates/kafka-user.yaml
+++ b/charts/kafka-ui/templates/kafka-user.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.kafkaUser.enabled }}
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: {{ .Values.kafkaUser.name | default "kafka-ui" }}
+  namespace: {{ include "kafka-ui.kafkaNamespace" . }}
+  labels:
+    strimzi.io/cluster: {{ .Values.kafka.clusterName }}
+    {{- include "kafka-ui.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  authentication:
+    type: scram-sha-512
+  {{- with .Values.kafkaUser.quotas }}
+  quotas:
+    producerByteRate: {{ .producerByteRate }}
+    consumerByteRate: {{ .consumerByteRate }}
+    requestPercentage: {{ .requestPercentage }}
+  {{- end }}
+  authorization:
+    type: simple
+    acls:
+      {{- range .Values.kafkaUser.acls }}
+      - resource:
+          type: {{ .resource.type }}
+          {{- if .resource.name }}
+          name: {{ .resource.name | quote }}
+          {{- end }}
+          {{- if .resource.patternType }}
+          patternType: {{ .resource.patternType }}
+          {{- end }}
+        operations:
+          {{- range .operations }}
+          - {{ . }}
+          {{- end }}
+        host: "*"
+        type: allow
+      {{- end }}
+{{- end }}

--- a/charts/kafka-ui/templates/kafka-user.yaml
+++ b/charts/kafka-ui/templates/kafka-user.yaml
@@ -1,9 +1,11 @@
-{{- if .Values.kafkaUser.enabled }}
+{{- $kafkaNS := include "kafka-ui.kafkaNamespace" . -}}
+{{- $releaseNS := include "kafka-ui.namespace" . -}}
+{{- if and .Values.kafkaUser.enabled (eq $kafkaNS $releaseNS) }}
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
 metadata:
   name: {{ .Values.kafkaUser.name | default "kafka-ui" }}
-  namespace: {{ include "kafka-ui.kafkaNamespace" . }}
+  namespace: {{ $kafkaNS }}
   labels:
     strimzi.io/cluster: {{ .Values.kafka.clusterName }}
     {{- include "kafka-ui.labels" . | nindent 4 }}

--- a/charts/kafka-ui/templates/networkpolicy.yaml
+++ b/charts/kafka-ui/templates/networkpolicy.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "kafka-ui.fullname" . }}
+  namespace: {{ include "kafka-ui.namespace" . }}
+  labels:
+    {{- include "kafka-ui.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "kafka-ui.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Ingress controller (browser access via Ingress resource)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.ingressNamespace }}
+      ports:
+        - port: 8080
+          protocol: TCP
+    {{- if eq .Values.service.type "NodePort" }}
+    # NodePort direct access (browser via node IP)
+    - from: []
+      ports:
+        - port: 8080
+          protocol: TCP
+    {{- end }}
+    # Prometheus metrics scraping
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - port: 8080
+          protocol: TCP
+  egress:
+    # DNS resolution
+    - to: []
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # To Kafka brokers (SASL_PLAINTEXT and TLS listeners)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ include "kafka-ui.kafkaNamespace" . }}
+          podSelector:
+            matchLabels:
+              strimzi.io/cluster: {{ .Values.kafka.clusterName }}
+      ports:
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+    # Kubernetes API server (for Secret reads and health checks)
+    - to: []
+      ports:
+        - port: 443
+          protocol: TCP
+{{- end }}

--- a/charts/kafka-ui/templates/service.yaml
+++ b/charts/kafka-ui/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kafka-ui.fullname" . }}
+  namespace: {{ include "kafka-ui.namespace" . }}
+  labels:
+    {{- include "kafka-ui.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+      {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "kafka-ui.selectorLabels" . | nindent 4 }}

--- a/charts/kafka-ui/values-dev.yaml
+++ b/charts/kafka-ui/values-dev.yaml
@@ -1,0 +1,8 @@
+# Development overlay for kafka-ui
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 1Gi

--- a/charts/kafka-ui/values-generic.yaml
+++ b/charts/kafka-ui/values-generic.yaml
@@ -1,0 +1,4 @@
+# Generic cluster overlay for kafka-ui
+# Disables components that require extra operators (like Prometheus CRDs)
+networkPolicy:
+  enabled: false

--- a/charts/kafka-ui/values-kind.yaml
+++ b/charts/kafka-ui/values-kind.yaml
@@ -1,0 +1,12 @@
+# Kind (local development) overlay for kafka-ui
+service:
+  type: NodePort
+  nodePort: 30081
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 1Gi

--- a/charts/kafka-ui/values-prod.yaml
+++ b/charts/kafka-ui/values-prod.yaml
@@ -1,0 +1,28 @@
+# Production overlay for kafka-ui
+replicas: 2
+
+auth:
+  enabled: true
+  type: "LOGIN_FORM"
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  hosts:
+    - host: kafka-ui.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: kafka-ui-tls
+      hosts:
+        - kafka-ui.example.com
+
+kafka:
+  tls:
+    enabled: true
+
+networkPolicy:
+  enabled: true

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -113,7 +113,8 @@ readinessProbe:
 # -- Pod-level security context
 podSecurityContext:
   runAsNonRoot: true
-  fsGroup: 1000
+  runAsUser: 1001
+  fsGroup: 1001
 
 # -- Container-level security context
 securityContext:

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -1,0 +1,144 @@
+# -- Image configuration
+image:
+  repository: provectuslabs/kafka-ui
+  tag: ""  # defaults to Chart.appVersion
+  pullPolicy: IfNotPresent
+
+# -- Number of replicas
+replicas: 1
+
+# -- Override names
+nameOverride: ""
+fullnameOverride: ""
+namespaceOverride: ""
+
+# -- Service configuration
+service:
+  type: ClusterIP
+  port: 8080
+  nodePort: ""
+  annotations: {}
+
+# -- Ingress configuration
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts: []
+  #   - host: kafka-ui.example.com
+  #     paths:
+  #       - path: /
+  #         pathType: Prefix
+  tls: []
+
+# -- Kafka cluster connection
+kafka:
+  clusterName: "krafter"
+  # -- Namespace where the Kafka cluster lives (defaults to release namespace)
+  namespace: ""
+  # -- Override bootstrap servers (auto-computed from clusterName if empty)
+  bootstrapServers: ""
+  # -- Kubernetes cluster domain
+  clusterDomain: "cluster.local"
+  tls:
+    enabled: false
+    trustedCertificateSecret: ""
+    certificateKey: "ca.crt"
+
+# -- Kafka UI application authentication (login to the web UI itself)
+auth:
+  enabled: false
+  type: "DISABLED"
+  # type: "LOGIN_FORM"
+  # username: "admin"
+  # passwordSecret: ""
+
+# -- KafkaUser (Strimzi-managed SCRAM-SHA-512 credentials for connecting to Kafka)
+kafkaUser:
+  # -- Enable KafkaUser CRD creation
+  enabled: true
+  # -- Name of the KafkaUser and its auto-generated Secret
+  name: "kafka-ui"
+  # -- Quotas to limit Kafka UI resource usage
+  quotas:
+    producerByteRate: 1048576
+    consumerByteRate: 52428800
+    requestPercentage: 10
+  # -- ACL rules — read-only monitor by default
+  acls:
+    - resource:
+        type: topic
+        name: "*"
+        patternType: literal
+      operations: ["Describe", "Read"]
+    - resource:
+        type: group
+        name: "*"
+        patternType: literal
+      operations: ["Describe", "Read"]
+    - resource:
+        type: cluster
+      operations: ["Describe"]
+
+# -- NetworkPolicy configuration
+networkPolicy:
+  # -- Enable NetworkPolicy creation
+  enabled: true
+  # -- Namespace of the ingress controller (for browser access restriction)
+  ingressNamespace: "ingress-nginx"
+
+# -- Pod resource requests and limits
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: 1000m
+    memory: 2Gi
+
+# -- Liveness probe configuration
+livenessProbe:
+  initialDelaySeconds: 60
+  periodSeconds: 30
+  timeoutSeconds: 10
+  failureThreshold: 5
+
+# -- Readiness probe configuration
+readinessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 10
+  failureThreshold: 10
+
+# -- Pod-level security context
+podSecurityContext:
+  runAsNonRoot: true
+  fsGroup: 1000
+
+# -- Container-level security context
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  capabilities:
+    drop:
+      - ALL
+
+# -- Node selector
+nodeSelector: {}
+
+# -- Tolerations
+tolerations: []
+
+# -- Affinity rules
+affinity: {}
+
+# -- Extra environment variables
+extraEnv: []
+
+# -- Extra labels to add to all resources
+extraLabels: {}
+
+# -- Logging
+logging:
+  root: INFO
+  provectus: INFO

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -75,7 +75,7 @@ func init() {
 	deployCmd.Flags().StringVar(&deployAppNS, "app-ns", "kates", "Namespace for Kates Backend when topology is 'isolated'")
 	deployCmd.Flags().StringVar(&deployChaosNS, "chaos-ns", "litmus", "Namespace for Chaos Engine when topology is 'isolated'")
 	deployCmd.Flags().StringVar(&deployMonitoringNS, "monitoring-ns", "monitoring", "Namespace for monitoring components (Jaeger) when topology is 'isolated'")
-	deployCmd.Flags().StringVar(&deployKafkaUINS, "ui-ns", "kates", "Namespace for Kafka UI when topology is 'isolated'")
+	deployCmd.Flags().StringVar(&deployKafkaUINS, "ui-ns", "kafka", "Namespace for Kafka UI when topology is 'isolated'")
 
 	// Component flags
 	deployCmd.Flags().StringVar(&deployWithSchemaRegistry, "with-schema-registry", "apicurio", "Schema Registry to deploy: 'none', 'apicurio', or 'confluent'")

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -49,6 +49,7 @@ var (
 	deployAppNS              string
 	deployChaosNS            string
 	deployMonitoringNS       string
+	deployKafkaUINS          string
 	deployWithSchemaRegistry string
 	deployHA                 bool
 	deployWithChaos          bool
@@ -62,6 +63,7 @@ var (
 	deployVerbose            bool
 	deployPortForward        bool
 	deployDryRun             bool
+	deployWithKafkaUI        bool
 )
 
 func init() {
@@ -73,6 +75,7 @@ func init() {
 	deployCmd.Flags().StringVar(&deployAppNS, "app-ns", "kates", "Namespace for Kates Backend when topology is 'isolated'")
 	deployCmd.Flags().StringVar(&deployChaosNS, "chaos-ns", "litmus", "Namespace for Chaos Engine when topology is 'isolated'")
 	deployCmd.Flags().StringVar(&deployMonitoringNS, "monitoring-ns", "monitoring", "Namespace for monitoring components (Jaeger) when topology is 'isolated'")
+	deployCmd.Flags().StringVar(&deployKafkaUINS, "ui-ns", "kates", "Namespace for Kafka UI when topology is 'isolated'")
 
 	// Component flags
 	deployCmd.Flags().StringVar(&deployWithSchemaRegistry, "with-schema-registry", "apicurio", "Schema Registry to deploy: 'none', 'apicurio', or 'confluent'")
@@ -84,6 +87,7 @@ func init() {
 	deployCmd.Flags().BoolVar(&deployWithSecretManager, "with-secret-manager", false, "Deploy Secret Manager (e.g., External Secrets Operator)")
 	deployCmd.Flags().BoolVar(&deployWithStrimzi, "with-strimzi", true, "Deploy Strimzi Operator")
 	deployCmd.Flags().BoolVar(&deployWithKafkaConnect, "with-kafka-connect", false, "Deploy Kafka Connect with PostgreSQL CDC (Debezium)")
+	deployCmd.Flags().BoolVar(&deployWithKafkaUI, "with-kafka-ui", true, "Deploy Kafka UI for browser-based cluster monitoring")
 	deployCmd.Flags().BoolVarP(&deployInteractive, "interactive", "i", false, "Use interactive UI to configure deployment")
 	deployCmd.Flags().BoolVar(&deployVerbose, "verbose", false, "Show every kubectl/helm command as it runs")
 	deployCmd.Flags().BoolVarP(&deployPortForward, "port-forward", "P", false, "After deploy, start port-forwards for all services and keep running until Ctrl+C")
@@ -351,12 +355,17 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		return chartDir + "/values-generic.yaml"
 	}
 
+	fileExists := func(path string) bool {
+		_, err := os.Stat(path)
+		return err == nil
+	}
+
 	// Resolve namespaces before building entries
-	var kafkaNS, connectNS, appNS, chaosNS, jaegerNS string
+	var kafkaNS, connectNS, appNS, chaosNS, jaegerNS, kafkaUINS string
 	if deployTopology == "single" {
-		kafkaNS, connectNS, appNS, chaosNS, jaegerNS = deployNamespace, deployNamespace, deployNamespace, deployNamespace, deployNamespace
+		kafkaNS, connectNS, appNS, chaosNS, jaegerNS, kafkaUINS = deployNamespace, deployNamespace, deployNamespace, deployNamespace, deployNamespace, deployNamespace
 	} else {
-		kafkaNS, connectNS, appNS, chaosNS, jaegerNS = deployKafkaNS, deployConnectNS, deployAppNS, deployChaosNS, deployMonitoringNS
+		kafkaNS, connectNS, appNS, chaosNS, jaegerNS, kafkaUINS = deployKafkaNS, deployConnectNS, deployAppNS, deployChaosNS, deployMonitoringNS, deployKafkaUINS
 	}
 
 	// ── Build shared component registry (single source of truth) ──
@@ -382,6 +391,9 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		sharedEntries = append(sharedEntries, DeploySummaryEntry{Icon: "📋", Name: "Apicurio Registry", Release: "apicurio", Namespace: kafkaNS, Group: "C"})
 	}
 	sharedEntries = append(sharedEntries, DeploySummaryEntry{Icon: "📦", Name: "Kates Backend", Release: "kates", Namespace: appNS, Group: "C"})
+	if deployWithKafkaUI {
+		sharedEntries = append(sharedEntries, DeploySummaryEntry{Icon: "🖥️", Name: "Kafka UI", Release: "kafka-ui", Namespace: kafkaUINS, Group: "C"})
+	}
 	if deployWithChaos {
 		sharedEntries = append(sharedEntries, DeploySummaryEntry{Icon: "🧪", Name: "Litmus Chaos", Release: "chaos", Namespace: chaosNS, Group: "C"})
 	}
@@ -425,6 +437,9 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		totalSteps++
 	}
 	totalSteps++ // kates
+	if deployWithKafkaUI {
+		totalSteps++
+	}
 	if deployWithChaos {
 		totalSteps++
 	}
@@ -463,6 +478,9 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		dashboard.RegisterComponent("apicurio", "Apicurio Registry", "C", Target{kafkaNS, "app.kubernetes.io/instance=apicurio"})
 	}
 	dashboard.RegisterComponent("kates", "Kates Backend", "C", Target{appNS, "app.kubernetes.io/instance=kates"})
+	if deployWithKafkaUI {
+		dashboard.RegisterComponent("kafka-ui", "Kafka UI", "C", Target{kafkaUINS, "app.kubernetes.io/name=kafka-ui"})
+	}
 	if deployWithChaos {
 		dashboard.RegisterComponent("chaos", "Litmus Chaos", "C", Target{chaosNS, "app.kubernetes.io/instance=chaos"})
 	}
@@ -1324,6 +1342,63 @@ data:
 				dl.Println("⏭️  Kates Backend already deployed.")
 				dl.FinishComponent("kates", true)
 				advanceStep()
+			}
+
+			// Deploy Kafka UI
+			if deployWithKafkaUI {
+				if !isHelmReleaseDeployedFn(ctx, "kafka-ui", kafkaUINS) {
+					dl.Printf("\n🖥️  Deploying Kafka UI (Namespace: %s)...\n", kafkaUINS)
+					dl.StartComponent("kafka-ui", 5*time.Minute)
+
+					// Cross-namespace secret copy (KafkaUser secret lives in Kafka NS)
+					if kafkaUINS != kafkaNS {
+						nsYaml := fmt.Sprintf(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+spec: {}`, kafkaUINS)
+						runExecStdinFn(ctx, "kubectl", []string{"apply", "-f", "-"}, nsYaml)
+
+						dl.Println("    - Copying kafka-ui SASL credentials to UI namespace...")
+						pwCmd := exec.CommandContext(ctx, "kubectl", "get", "secret", "kafka-ui",
+							"-n", kafkaNS, "-o", "jsonpath={.data.password}")
+						pwBytes, pwErr := pwCmd.Output()
+						if pwErr == nil && len(pwBytes) > 0 {
+							secretYaml := fmt.Sprintf(`apiVersion: v1
+kind: Secret
+metadata:
+  name: kafka-ui
+  namespace: %s
+type: Opaque
+data:
+  password: %s`, kafkaUINS, string(pwBytes))
+							runExecStdinFn(ctx, "kubectl", []string{"apply", "-f", "-"}, secretYaml)
+						} else {
+							dl.Printf("    ⚠️  Secret 'kafka-ui' not found in namespace %s — KafkaUser may not be ready\n", kafkaNS)
+						}
+					}
+
+					helmArgs := []string{
+						"upgrade", "--install", "kafka-ui", "charts/kafka-ui",
+						"-n", kafkaUINS, "--create-namespace",
+						"--set", "kafka.clusterName=" + clusterName,
+						"--set", "kafka.namespace=" + kafkaNS,
+						"--timeout", "5m",
+					}
+					if overlay := chartOverlay("charts/kafka-ui"); fileExists(overlay) {
+						helmArgs = append(helmArgs, "-f", overlay)
+					}
+					if err := runHelmFn(ctx, helmArgs...); err != nil {
+						dl.FinishComponent("kafka-ui", false)
+						return err
+					}
+					dl.FinishComponent("kafka-ui", true)
+					advanceStep()
+				} else {
+					dl.Println("⏭️  Kafka UI already deployed.")
+					dl.FinishComponent("kafka-ui", true)
+					advanceStep()
+				}
 			}
 
 			// Deploy Chaos

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -136,6 +136,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 					Options(
 						huh.NewOption("🦊 Strimzi Operator", "strimzi").Selected(deployWithStrimzi),
 						huh.NewOption("🔗 Kafka Connect + PostgreSQL (CDC)", "kafka-connect").Selected(deployWithKafkaConnect),
+						huh.NewOption("🖥️  Kafka UI (Dashboard)", "kafka-ui").Selected(deployWithKafkaUI),
 						huh.NewOption("🧪 Litmus Chaos Engine", "chaos").Selected(deployWithChaos),
 						huh.NewOption("📊 Monitoring (Grafana + Prometheus)", "monitoring").Selected(deployWithMonitoring),
 						huh.NewOption("🔐 Cert-Manager (TLS)", "cert-manager").Selected(deployWithCertManager),
@@ -201,6 +202,15 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 				))
 			}
 
+			if sliceContains(components, "kafka-ui") {
+				nsGroups = append(nsGroups, huh.NewGroup(
+					huh.NewInput().
+						Title("Kafka UI Namespace").
+						Description("Namespace for the Kafka UI dashboard").
+						Value(&deployKafkaUINS),
+				))
+			}
+
 			form2 := huh.NewForm(nsGroups...).WithTheme(ThemeKates())
 			if err := form2.Run(); err != nil {
 				return err
@@ -212,6 +222,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		deployWithCertManager = false
 		deployWithKyverno = false
 		deployWithStrimzi = false
+		deployWithKafkaUI = false
 
 		for _, c := range components {
 			switch c {
@@ -219,6 +230,8 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 				deployWithStrimzi = true
 			case "kafka-connect":
 				deployWithKafkaConnect = true
+			case "kafka-ui":
+				deployWithKafkaUI = true
 			case "chaos":
 				deployWithChaos = true
 			case "monitoring":
@@ -242,6 +255,9 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 			PrintPhaseItem(fmt.Sprintf("%-14s → %s", "Database", deployDbNS))
 		}
 		PrintPhaseItem(fmt.Sprintf("%-14s → %s", "Kates App", deployAppNS))
+		if deployWithKafkaUI {
+			PrintPhaseItem(fmt.Sprintf("%-14s → %s", "Kafka UI", deployKafkaUINS))
+		}
 		if deployWithMonitoring {
 			PrintPhaseItem(fmt.Sprintf("%-14s → %s", "Monitoring", deployMonitoringNS))
 		}
@@ -270,6 +286,9 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	}
 	if deployWithKyverno {
 		PrintPhaseSuccess("Kyverno (Policies)")
+	}
+	if deployWithKafkaUI {
+		PrintPhaseSuccess("Kafka UI (Dashboard)")
 	}
 
 	// 3. Cluster Detection

--- a/cli/cmd/deploy_status.go
+++ b/cli/cmd/deploy_status.go
@@ -152,11 +152,11 @@ type k8sWorkload struct {
 func runDeployStatus(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
-	var kafkaNS, connectNS, appNS, chaosNS, jaegerNS, dbNS string
+	var kafkaNS, connectNS, appNS, chaosNS, jaegerNS, dbNS, kafkaUINS string
 	if deployTopology == "single" {
-		kafkaNS, connectNS, appNS, chaosNS, jaegerNS, dbNS = deployNamespace, deployNamespace, deployNamespace, deployNamespace, deployNamespace, deployNamespace
+		kafkaNS, connectNS, appNS, chaosNS, jaegerNS, dbNS, kafkaUINS = deployNamespace, deployNamespace, deployNamespace, deployNamespace, deployNamespace, deployNamespace, deployNamespace
 	} else {
-		kafkaNS, connectNS, appNS, chaosNS, jaegerNS, dbNS = deployKafkaNS, deployConnectNS, deployAppNS, deployChaosNS, deployMonitoringNS, deployDbNS
+		kafkaNS, connectNS, appNS, chaosNS, jaegerNS, dbNS, kafkaUINS = deployKafkaNS, deployConnectNS, deployAppNS, deployChaosNS, deployMonitoringNS, deployDbNS, deployKafkaUINS
 	}
 
 	components := []struct {
@@ -177,6 +177,7 @@ func runDeployStatus(cmd *cobra.Command, args []string) error {
 		{"B", "📊", "Monitoring Stack", "monitoring", jaegerNS, "pod", "-l release=monitoring"},
 		{"C", "📋", "Apicurio Registry", "apicurio", kafkaNS, "pod", "-l app.kubernetes.io/instance=apicurio"},
 		{"C", "📦", "Kates Backend", "kates", appNS, "pod", "-l app.kubernetes.io/instance=kates"},
+		{"C", "🖥️", "Kafka UI", "kafka-ui", kafkaUINS, "pod", "-l app.kubernetes.io/name=kafka-ui"},
 		{"C", "🧪", "Litmus Chaos", "chaos", chaosNS, "pod", "-l app.kubernetes.io/instance=chaos"},
 	}
 

--- a/cli/cmd/portforward.go
+++ b/cli/cmd/portforward.go
@@ -40,7 +40,7 @@ var wellKnownPorts = []struct {
 	{"kafka/krafter-kafka-bootstrap", "Kafka Bootstrap (plain)", 9092, 9092, ""},
 	{"kafka/krafter-kafka-bootstrap", "Kafka Bootstrap (TLS)", 9093, 9093, ""},
 	{"kafka/apicurio", "Apicurio Schema Registry", 80, 8081, "http://localhost:8081/ui"},
-	{"kates/kafka-ui", "Kafka UI", 8080, 8085, "http://localhost:8085"},
+	{"kafka/kafka-ui", "Kafka UI", 8080, 8085, "http://localhost:8085"},
 	{"monitoring/monitoring-grafana", "Grafana", 80, 3000, "http://localhost:3000"},
 	{"monitoring/monitoring-kube-prometheus-prometheus", "Prometheus", 9090, 9090, "http://localhost:9090"},
 	{"monitoring/monitoring-kube-prometheus-alertmanager", "Alertmanager", 9093, 9094, "http://localhost:9094"},

--- a/cli/cmd/portforward.go
+++ b/cli/cmd/portforward.go
@@ -40,6 +40,7 @@ var wellKnownPorts = []struct {
 	{"kafka/krafter-kafka-bootstrap", "Kafka Bootstrap (plain)", 9092, 9092, ""},
 	{"kafka/krafter-kafka-bootstrap", "Kafka Bootstrap (TLS)", 9093, 9093, ""},
 	{"kafka/apicurio", "Apicurio Schema Registry", 80, 8081, "http://localhost:8081/ui"},
+	{"kates/kafka-ui", "Kafka UI", 8080, 8085, "http://localhost:8085"},
 	{"monitoring/monitoring-grafana", "Grafana", 80, 3000, "http://localhost:3000"},
 	{"monitoring/monitoring-kube-prometheus-prometheus", "Prometheus", 9090, 9090, "http://localhost:9090"},
 	{"monitoring/monitoring-kube-prometheus-alertmanager", "Alertmanager", 9093, 9094, "http://localhost:9094"},

--- a/cli/cmd/portforward.go
+++ b/cli/cmd/portforward.go
@@ -40,7 +40,7 @@ var wellKnownPorts = []struct {
 	{"kafka/krafter-kafka-bootstrap", "Kafka Bootstrap (plain)", 9092, 9092, ""},
 	{"kafka/krafter-kafka-bootstrap", "Kafka Bootstrap (TLS)", 9093, 9093, ""},
 	{"kafka/apicurio", "Apicurio Schema Registry", 80, 8081, "http://localhost:8081/ui"},
-	{"kafka/kafka-ui", "Kafka UI", 8080, 8085, "http://localhost:8085"},
+	{"kafka-ui/kafka-ui", "Kafka UI", 8080, 8085, "http://localhost:8085"},
 	{"monitoring/monitoring-grafana", "Grafana", 80, 3000, "http://localhost:3000"},
 	{"monitoring/monitoring-kube-prometheus-prometheus", "Prometheus", 9090, 9090, "http://localhost:9090"},
 	{"monitoring/monitoring-kube-prometheus-alertmanager", "Alertmanager", 9093, 9094, "http://localhost:9094"},
@@ -261,6 +261,9 @@ func matchSpecs(discovered map[string]bool) []portForwardSpec {
 			actualNS = portsAppNS
 		case "monitoring", "jaeger":
 			actualNS = portsMonitoringNS
+		case "kafka-ui":
+			// kafka-ui can live in kafka, kates, or its own namespace
+			actualNS = portsKafkaNS
 		default:
 			actualNS = defaultNS
 		}
@@ -281,6 +284,23 @@ func matchSpecs(discovered map[string]bool) []portForwardSpec {
 				URL:       wk.URL,
 			})
 			seen[wk.Label] = true
+		} else {
+			// Fallback: scan all discovered services for this service name
+			for key := range discovered {
+				if strings.HasSuffix(key, "/"+svc) {
+					parts := strings.SplitN(key, "/", 2)
+					specs = append(specs, portForwardSpec{
+						Label:     wk.Label,
+						Namespace: parts[0],
+						Resource:  "service/" + svc,
+						Remote:    wk.Remote,
+						Local:     wk.Local,
+						URL:       wk.URL,
+					})
+					seen[wk.Label] = true
+					break
+				}
+			}
 		}
 	}
 	return specs


### PR DESCRIPTION
## Description

Adds a standalone `charts/kafka-ui/` Helm chart for deploying Kafka UI and integrates it fully into the `kates` CLI deploy and port-forwarding workflows.

### Helm Chart (`charts/kafka-ui/`)
- Deployment with health probes, SCRAM-SHA-512 auth, config checksum for auto-rollout
- ConfigMap with dynamic Kafka cluster configuration
- Service (ClusterIP/NodePort/LoadBalancer) and optional Ingress
- KafkaUser CRD with scoped read-only ACLs (`Describe`/`Read` on topics/groups, `Describe` on cluster) + quotas
- Hardened NetworkPolicy with specific namespace selectors
- Value overlays for `kind`, `dev`, `generic`, and `prod` environments
- Sets explicit `runAsUser: 1001` to prevent `CreateContainerConfigError` when enforcing `runAsNonRoot` with the `provectuslabs/kafka-ui` image.

### `kates deploy` Integration
- Added `--with-kafka-ui` flag (default `true`) and `--ui-ns` flag (default `kafka`)
- Fully integrated into interactive deploy UI (`kates deploy -i`) with component selection and namespace prompts
- Integrated into `deploy.go` deployment pipeline: registers in component registry, displays in dashboard, performs cross-namespace secret copying if necessary
- Status checking supported via `kates deploy status`

### Port Forwarding (`kates ports`)
- Added `kafka-ui` to the well-known ports list, mapping remote 8080 to localhost **8085** to avoid conflicts
- Port-forward auto-discovery supports the service whether deployed in `kafka`, `kates`, or a dedicated namespace, with fallback scanning of all discovered services

### Migration from `kafka-cluster` chart
- Added `kafkaUI.managedUser` and `networkPolicies.kafkaUI` toggles in `kafka-cluster/values.yaml` (default `true` for backward compatibility)
- Cross-namespace deployments correctly skip duplicate `KafkaUser` creation in the `kafka-ui` chart, relying on the user created by the `kafka-cluster` chart
