### PR TITLE
feat(strimzi): enforce strict network policies, isolate connect tests, and fix cli alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,30 @@ All images are defined in `images.env` — the single source of truth.
 make registry-status                   # Check registry contents
 ```
 
+Behind a corporate proxy, define `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`
+either in your shell or in `proxy/proxy.conf` before running
+`./scripts/load-images-to-kind.sh`. The script now forwards these variables into
+Kind node `ctr pull` commands.
+
+If you do not use the load script, run `make cluster` (or
+`./scripts/start-cluster.sh`) after setting proxy variables. Cluster startup now
+reconciles containerd proxy settings on all Kind nodes so normal pod image pulls
+work through the proxy as well.
+
+You can also pass proxy params directly:
+
+```bash
+./scripts/start-cluster.sh \
+  --http-proxy http://proxy.example.com:8080 \
+  --https-proxy http://proxy.example.com:8080 \
+  --no-proxy "localhost,127.0.0.1,.svc,.cluster.local"
+```
+
+Note: loopback proxies from environment/proxy.conf (for example
+`http://127.0.0.1:9000`) are ignored by default because Kind nodes cannot reach
+their own loopback as your host proxy. If you pass a loopback URL explicitly
+via `--http-proxy/--https-proxy`, it is rewritten to `host.docker.internal`.
+
 ---
 
 ## Makefile Targets

--- a/charts/connect-cluster/templates/networkpolicies.yaml
+++ b/charts/connect-cluster/templates/networkpolicies.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.networkPolicy.enabled }}
 {{- $clusterName := include "connect-cluster.fullname" . -}}
 {{- $namespace := include "connect-cluster.namespace" . -}}
+{{- $connectPodName := printf "%s-connect" $clusterName -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -11,7 +12,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      strimzi.io/name: {{ $clusterName }}
+      strimzi.io/name: {{ $connectPodName }}
   policyTypes:
     - Ingress
     - Egress
@@ -32,7 +33,7 @@ spec:
               app.kubernetes.io/name: kates
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: kafka
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.strimziOperatorNamespace | default (include "connect-cluster.kafkaNamespace" .) }}
           podSelector:
             matchLabels:
               strimzi.io/kind: cluster-operator
@@ -49,10 +50,20 @@ spec:
           protocol: UDP
         - port: 53
           protocol: TCP
+    # Allow worker-to-worker REST traffic (leader forwarding and task assignment)
+    - to:
+        - podSelector:
+            matchLabels:
+              strimzi.io/cluster: {{ $clusterName }}
+              strimzi.io/kind: KafkaConnect
+              strimzi.io/name: {{ $connectPodName }}
+      ports:
+        - port: 8083
+          protocol: TCP
     - to:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: kafka
+              kubernetes.io/metadata.name: {{ include "connect-cluster.kafkaNamespace" . }}
           podSelector:
             matchLabels:
               strimzi.io/cluster: {{ .Values.kafka.clusterName }}
@@ -65,7 +76,7 @@ spec:
     - to:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: kafka
+              kubernetes.io/metadata.name: {{ .Values.schemaRegistry.namespace | default (include "connect-cluster.kafkaNamespace" .) }}
           podSelector:
             matchLabels:
               app.kubernetes.io/name: apicurio-registry
@@ -121,7 +132,7 @@ spec:
               kubernetes.io/metadata.name: {{ include "connect-cluster.namespace" $ }}
           podSelector:
             matchLabels:
-              strimzi.io/name: {{ $clusterName }}
+              strimzi.io/name: {{ $connectPodName }}
       ports:
         - port: {{ .port | default 5432 }}
           protocol: TCP

--- a/charts/connect-cluster/templates/tests/test-connectors.yaml
+++ b/charts/connect-cluster/templates/tests/test-connectors.yaml
@@ -1,0 +1,44 @@
+{{- if gt (len (default (list) .Values.testConnectors)) 0 }}
+{{- $globalAutoRestart := .Values.autoRestart }}
+{{- range .Values.testConnectors }}
+---
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaConnector
+metadata:
+  name: {{ .name }}
+  namespace: {{ include "connect-cluster.namespace" $ }}
+  labels:
+    {{- include "connect-cluster.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: test-connector
+    kates.io/connector-name: {{ .name }}
+    strimzi.io/cluster: {{ include "connect-cluster.fullname" $ }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-weight: "5"
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+    {{- range $k, $v := .annotations }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+spec:
+  class: {{ .class }}
+  tasksMax: {{ .tasksMax | default 1 }}
+  {{- if .state }}
+  state: {{ .state }}
+  {{- end }}
+  autoRestart:
+    {{- if .autoRestart }}
+    enabled: {{ .autoRestart.enabled | default true }}
+    maxRestarts: {{ .autoRestart.maxRestarts | default ($globalAutoRestart.maxRestarts | default 10) }}
+    {{- else }}
+    enabled: {{ $globalAutoRestart.enabled | default true }}
+    maxRestarts: {{ $globalAutoRestart.maxRestarts | default 10 }}
+    {{- end }}
+  {{- with .config }}
+  config:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/connect-cluster/templates/tests/test-topics.yaml
+++ b/charts/connect-cluster/templates/tests/test-topics.yaml
@@ -1,0 +1,29 @@
+{{- if gt (len (default (list) .Values.testTopics)) 0 }}
+{{- range .Values.testTopics }}
+---
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: {{ .name }}
+  namespace: {{ include "connect-cluster.namespace" $ }}
+  labels:
+    {{- include "connect-cluster.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: test-topic
+    strimzi.io/cluster: {{ include "connect-cluster.fullname" $ }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-weight: "4"
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+spec:
+  topicName: {{ .topicName }}
+  partitions: {{ .partitions | default 1 }}
+  replicas: {{ .replicas | default 1 }}
+  {{- with .config }}
+  config:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/connect-cluster/templates/validate-connectors.yaml
+++ b/charts/connect-cluster/templates/validate-connectors.yaml
@@ -2,7 +2,8 @@
   Helm pre-install/pre-upgrade hook that validates connector configurations.
   Catches missing required fields before they reach the Strimzi operator.
 */ -}}
-{{- if gt (len (default (list) .Values.connectors)) 0 }}
+{{- $allConnectors := concat (default (list) .Values.connectors) (default (list) .Values.testConnectors) }}
+{{- if gt (len $allConnectors) 0 }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -24,7 +25,7 @@ data:
     echo "=== Kafka Connect Connector Validation ==="
     echo ""
 
-    {{- range $i, $connector := .Values.connectors }}
+    {{- range $i, $connector := $allConnectors }}
     echo "▸ Validating connector: {{ $connector.name }}"
 
     # Required: name must be a valid Kubernetes name

--- a/charts/connect-cluster/values.yaml
+++ b/charts/connect-cluster/values.yaml
@@ -120,6 +120,8 @@ resources:
 schemaRegistry:
   enabled: false
   serviceName: apicurio-apicurio-registry
+  # -- Namespace where the Schema Registry is deployed (leave empty if same as Kafka)
+  namespace: ""
   port: 80
   path: /apis/ccompat/v7
 
@@ -134,6 +136,8 @@ schemaRegistry:
 # ── Network Policy ──────────────────────────────────────────────────────────
 networkPolicy:
   enabled: true
+  # -- Namespace where the Strimzi Operator is deployed (leave empty if same as Kafka)
+  strimziOperatorNamespace: ""
   kafkaPorts:
     - 9092
     - 9093
@@ -226,24 +230,83 @@ autoRestart:
   maxRestarts: 10
 
 connectors: []
-  # - name: cdc-orders
-  #   class: io.debezium.connector.postgresql.PostgresConnector
-  #   tasksMax: 1
-  #   state: running          # running | paused | stopped
-  #   autoRestart:            # per-connector override (optional)
-  #     enabled: true
-  #     maxRestarts: 20
-  #   config:
-  #     database.hostname: postgresql.database.svc
-  #     database.port: "5432"
-  #     database.user: "${file:/mnt/pg-credentials/username}"
-  #     database.password: "${file:/mnt/pg-credentials/password}"
-  #     database.dbname: orders
-  #     topic.prefix: cdc.orders
-  #     schema.include.list: public
-  #     plugin.name: pgoutput
-  #     slot.name: debezium_orders
 
+# ── Test Connectors ─────────────────────────────────────────────────────────
+# These connectors are ONLY deployed when running `helm test`, and they are
+# automatically deleted when the test succeeds. Use this for testing/examples.
+testConnectors:
+  - name: debezium-postgres-source-working-example
+    class: io.debezium.connector.postgresql.PostgresConnector
+    tasksMax: 1
+    config:
+      database.hostname: "postgresql.database.svc"
+      database.port: "5432"
+      database.user: "${secrets:connect/connect-pg-credentials:username}"
+      database.password: "${secrets:connect/connect-pg-credentials:password}"
+      database.dbname: "orders"
+      topic.prefix: "cdc"
+      schema.include.list: "public"
+      table.include.list: "public.demo_orders"
+      plugin.name: "pgoutput"
+      publication.name: "dbz_demo_orders_pub"
+      publication.autocreate.mode: "filtered"
+      slot.name: "debezium_demo_orders"
+      snapshot.mode: "initial"
+      decimal.handling.mode: "double"
+      tombstones.on.delete: "false"
+      schema.history.internal.kafka.bootstrap.servers: "krafter-kafka-bootstrap.kafka.svc:9092"
+      schema.history.internal.kafka.security.protocol: "SASL_PLAINTEXT"
+      schema.history.internal.kafka.sasl.mechanism: "SCRAM-SHA-512"
+      schema.history.internal.kafka.sasl.jaas.config: "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"kates-connect\" password=\"${secrets:connect/kates-connect:password}\";"
+      schema.history.internal.kafka.topic: "cdc-schema-history"
+
+  - name: jdbc-sink-from-cdc-working-example
+    class: io.debezium.connector.jdbc.JdbcSinkConnector
+    tasksMax: 1
+    config:
+      topics: "cdc.public.demo_orders"
+      connection.url: "jdbc:postgresql://postgresql.database.svc:5432/orders"
+      connection.username: "${secrets:connect/connect-pg-credentials:username}"
+      connection.password: "${secrets:connect/connect-pg-credentials:password}"
+      table.name.format: "demo_orders_replica"
+      insert.mode: "upsert"
+      primary.key.mode: "record_key"
+      primary.key.fields: "id"
+      delete.enabled: "true"
+      schema.evolution: "basic"
+
+  - name: jdbc-sink-working-example
+    class: io.debezium.connector.jdbc.JdbcSinkConnector
+    tasksMax: 1
+    config:
+      topics: "kates-results"
+      connection.url: "jdbc:postgresql://postgresql.database.svc:5432/orders"
+      connection.username: "${secrets:connect/connect-pg-credentials:username}"
+      connection.password: "${secrets:connect/connect-pg-credentials:password}"
+      insert.mode: "insert"
+      auto.create: "true"
+      auto.evolve: "true"
+      delete.enabled: "false"
+
+  - name: jdbc-source-working-example
+    class: io.aiven.connect.jdbc.JdbcSourceConnector
+    tasksMax: 1
+    config:
+      connection.url: "jdbc:postgresql://postgresql.database.svc:5432/orders"
+      connection.user: "${secrets:connect/connect-pg-credentials:username}"
+      connection.password: "${secrets:connect/connect-pg-credentials:password}"
+      mode: "bulk"
+      query: "SELECT table_name FROM information_schema.tables WHERE table_schema='public'"
+      topic.prefix: "kates-jdbc-source-"
+      poll.interval.ms: "30000"
+
+testTopics:
+  - name: cdc-public-demo-orders
+    topicName: cdc.public.demo_orders
+    partitions: 3
+    replicas: 3
+    config:
+      min.insync.replicas: "2"
 # ── RBAC ────────────────────────────────────────────────────────────────────
 serviceAccount:
   # -- Create a dedicated ServiceAccount for Connect pods

--- a/charts/kafka-cluster/templates/networkpolicies.yaml
+++ b/charts/kafka-cluster/templates/networkpolicies.yaml
@@ -2,6 +2,8 @@
 {{- $clusterName := include "kafka-cluster.clusterName" . -}}
 {{- $namespace := include "kafka-cluster.namespace" . -}}
 {{- $monitoringNs := .Values.networkPolicies.monitoringNamespace -}}
+{{- $operatorNamespace := .Values.networkPolicies.operatorNamespace | default "strimzi-operator" -}}
+{{- $kafkaUINamespace := .Values.networkPolicies.kafkaUINamespace | default "kafka-ui" -}}
 {{- if .Values.networkPolicies.defaultDeny }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -90,13 +92,19 @@ spec:
               app: kafka-ui
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: kafka
+              kubernetes.io/metadata.name: {{ $kafkaUINamespace }}
+          podSelector:
+            matchLabels:
+              app: kafka-ui
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicies.apicurioNamespace | default .Release.Namespace }}
           podSelector:
             matchLabels:
               app.kubernetes.io/name: apicurio-registry
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: connect
+              kubernetes.io/metadata.name: {{ .Values.networkPolicies.connectNamespace | default "connect" }}
           podSelector:
             matchLabels:
               strimzi.io/kind: KafkaConnect
@@ -131,6 +139,22 @@ spec:
               kubernetes.io/metadata.name: monitoring
       ports:
         - port: 9404
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $operatorNamespace }}
+          podSelector:
+            matchLabels:
+              strimzi.io/kind: cluster-operator
+      ports:
+        - port: 9091
+          protocol: TCP
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+        - port: 2181
           protocol: TCP
   egress:
     - to:
@@ -193,7 +217,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: strimzi-operator
-  namespace: {{ .Values.networkPolicies.operatorNamespace | default "strimzi-operator" }}
+  namespace: {{ $operatorNamespace }}
   labels:
     {{- include "kafka-cluster.labels" . | nindent 4 }}
 spec:
@@ -204,12 +228,9 @@ spec:
     - Ingress
     - Egress
   ingress:
-    # Metrics from monitoring namespace + health probes from kubelet
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: monitoring
-      ports:
+    # Keep open for kubelet probes and metrics scraping.
+    # Kubelet probes originate from node network, not pod namespaces.
+    - ports:
         - port: 8080
           protocol: TCP
   egress:
@@ -231,26 +252,41 @@ spec:
     - to:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: kafka
+              kubernetes.io/metadata.name: {{ $namespace }}
           podSelector:
             matchLabels:
               strimzi.io/cluster: {{ $clusterName }}
+      ports:
+        - port: 9090
+          protocol: TCP
+        - port: 9091
+          protocol: TCP
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+        - port: 2181
+          protocol: TCP
     # Allow egress to Kafka Connect pods across all namespaces
     - to:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: connect
+              kubernetes.io/metadata.name: {{ .Values.networkPolicies.connectNamespace | default "connect" }}
           podSelector:
             matchLabels:
               strimzi.io/kind: KafkaConnect
+      ports:
+        - port: 8083
+          protocol: TCP
     # Allow egress to its own namespace pods
     - to:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: strimzi-operator
+              kubernetes.io/metadata.name: {{ $operatorNamespace }}
           podSelector:
             matchLabels:
               strimzi.io/kind: cluster-operator
+---
 {{- if .Values.networkPolicies.kafkaUI }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/charts/kafka-cluster/templates/nodepool-brokers.yaml
+++ b/charts/kafka-cluster/templates/nodepool-brokers.yaml
@@ -24,9 +24,9 @@ spec:
         {{- end }}
         deleteClaim: {{ $.Values.brokerDefaults.deleteClaim }}
   jvmOptions:
-    {{- toYaml $.Values.brokerDefaults.jvmOptions | nindent 4 }}
+    {{- toYaml (default $.Values.brokerDefaults.jvmOptions .jvmOptions) | nindent 4 }}
   resources:
-    {{- toYaml $.Values.brokerDefaults.resources | nindent 4 }}
+    {{- toYaml (default $.Values.brokerDefaults.resources .resources) | nindent 4 }}
   template:
     pod:
       {{- if .zone }}
@@ -93,4 +93,3 @@ spec:
       securityContext:
         {{- include "kafka-cluster.containerSecurityContext" $ | nindent 8 }}
 {{- end }}
-

--- a/charts/kafka-cluster/values.schema.json
+++ b/charts/kafka-cluster/values.schema.json
@@ -113,7 +113,9 @@
           "zone": { "type": "string" },
           "replicas": { "type": "integer", "minimum": 1, "maximum": 100 },
           "storageSize": { "type": "string", "pattern": "^[0-9]+(Gi|Ti|Mi)$" },
-          "storageClass": { "type": "string" }
+          "storageClass": { "type": "string" },
+          "resources": { "$ref": "#/$defs/resources" },
+          "jvmOptions": { "$ref": "#/$defs/jvmOptions" }
         }
       }
     },

--- a/charts/kafka-cluster/values.yaml
+++ b/charts/kafka-cluster/values.yaml
@@ -151,6 +151,18 @@ brokerPools: []
   #   replicas: 1
   #   storageSize: 100Gi
   #   storageClass: "std-room-ext"
+  #   # Optional per-pool overrides (fallback to brokerDefaults when omitted)
+  #   resources:
+  #     requests:
+  #       cpu: 1500m
+  #       memory: 8Gi
+  #     limits:
+  #       cpu: 1500m
+  #       memory: 8Gi
+  #   jvmOptions:
+  #     -Xms: 2048m
+  #     -Xmx: 2048m
+  #     gcLoggingEnabled: true
 
 brokerDefaults:
   deleteClaim: false
@@ -465,8 +477,12 @@ networkPolicies:
   monitoringNamespace: kafka
   # Namespace where Kafka Connect is deployed (for cross-namespace ingress)
   connectNamespace: connect
-  # Namespace where the Strimzi Operator is deployed (for its NetworkPolicy)
-  operatorNamespace: strimzi-operator
+  # Namespace where standalone Kafka UI is deployed
+  kafkaUINamespace: kafka-ui
+  # Namespace where the Strimzi Operator is deployed (leave empty for "strimzi-operator")
+  operatorNamespace: ""
+  # Namespace where Apicurio Registry is deployed (leave empty for Release.Namespace)
+  apicurioNamespace: ""
   # -- Manage kafka-ui NetworkPolicy from this chart (set false when using standalone kafka-ui chart)
   kafkaUI: true
 
@@ -609,7 +625,7 @@ strimzi-kafka-operator:
     namespace: kafka
     label: grafana_dashboard
     labelValue: "1"
-  generateNetworkPolicy: true
+  generateNetworkPolicy: false
   generatePodDisruptionBudget: true
 
 lifecycle:

--- a/charts/kafka-ui/templates/kafka-user.yaml
+++ b/charts/kafka-ui/templates/kafka-user.yaml
@@ -1,7 +1,7 @@
 {{- $kafkaNS := include "kafka-ui.kafkaNamespace" . -}}
 {{- $releaseNS := include "kafka-ui.namespace" . -}}
 {{- if and .Values.kafkaUser.enabled (eq $kafkaNS $releaseNS) }}
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
 metadata:
   name: {{ .Values.kafkaUser.name | default "kafka-ui" }}

--- a/charts/kafka-ui/values-kind.yaml
+++ b/charts/kafka-ui/values-kind.yaml
@@ -3,6 +3,10 @@ service:
   type: NodePort
   nodePort: 30081
 
+kafkaUser:
+  # Managed by the krafter chart in this stack; avoid Helm ownership conflicts.
+  enabled: false
+
 resources:
   requests:
     cpu: 100m

--- a/charts/kates/README.md
+++ b/charts/kates/README.md
@@ -37,6 +37,7 @@ All configuration is in [values.yaml](values.yaml). Key sections:
 | `image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `replicaCount` | `1` | Number of Kates pods |
 | `kafka.bootstrapServers` | `krafter-kafka-bootstrap.kafka.svc:9092` | Kafka bootstrap address |
+| `kafka.topicNamespace` | `""` | Namespace for CDC test `KafkaTopic` CRs (`""` = auto-detect) |
 | `engine.defaultBackend` | `native` | Benchmark engine (`native` or `trogdor`) |
 
 ### Networking

--- a/charts/kates/templates/configmap.yaml
+++ b/charts/kates/templates/configmap.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "kates.labels" . | nindent 4 }}
 data:
   KATES_KAFKA_BOOTSTRAP_SERVERS: {{ .Values.kafka.bootstrapServers | quote }}
+  KATES_CDC_TOPIC_NAMESPACE: {{ .Values.kafka.topicNamespace | quote }}
   KATES_KAFKA_SECURITY_PROTOCOL: {{ .Values.kafka.security.protocol | quote }}
   {{- if .Values.kafka.sasl.enabled }}
   KATES_KAFKA_SASL_MECHANISM: {{ .Values.kafka.sasl.mechanism | quote }}

--- a/charts/kates/values-kind.yaml
+++ b/charts/kates/values-kind.yaml
@@ -2,7 +2,6 @@
 # Usage: helm upgrade --install ... -f values-dev.yaml -f values-kind.yaml
 
 image:
-  # Kind requires pre-loaded images, so Never pull from registry
   pullPolicy: IfNotPresent
 
 resources:

--- a/charts/kates/values.schema.json
+++ b/charts/kates/values.schema.json
@@ -322,6 +322,7 @@
                     "type": "string",
                     "minLength": 0
                 },
+                "topicNamespace": { "type": "string" },
                 "clientRack": { "type": "string" },
                 "security": {
                     "type": "object",

--- a/charts/kates/values.yaml
+++ b/charts/kates/values.yaml
@@ -271,6 +271,8 @@ initContainers:
 kafka:
   # -- Kafka bootstrap servers
   bootstrapServers: "krafter-kafka-bootstrap.kafka.svc:9092"
+  # -- Namespace where CDC integration test KafkaTopic CRs are managed (empty = auto-detect)
+  topicNamespace: ""
   # -- Client rack ID for rack-aware consumption
   clientRack: ""
   # -- Security protocol

--- a/charts/monitoring/templates/networkpolicy-prometheus-kafka-egress.yaml
+++ b/charts/monitoring/templates/networkpolicy-prometheus-kafka-egress.yaml
@@ -1,0 +1,39 @@
+{{- $networkPolicy := .Values.networkPolicy | default (dict) }}
+{{- $prometheusKafkaEgress := $networkPolicy.prometheusKafkaEgress | default (dict) }}
+{{- $enabled := $prometheusKafkaEgress.enabled | default true }}
+{{- if $enabled }}
+{{- $kafkaNamespace := $prometheusKafkaEgress.kafkaNamespace | default .Values.kafkaNamespace }}
+{{- $ports := $prometheusKafkaEgress.ports | default (list 9404) }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-prometheus-kafka-egress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kates-monitoring.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $kafkaNamespace | quote }}
+          podSelector:
+            matchExpressions:
+              - key: strimzi.io/kind
+                operator: In
+                values:
+                  - Kafka
+                  - KafkaConnect
+                  - KafkaMirrorMaker
+                  - KafkaMirrorMaker2
+      ports:
+{{- range $ports }}
+        - protocol: TCP
+          port: {{ . }}
+{{- end }}
+{{- end }}

--- a/charts/monitoring/values-generic.yaml
+++ b/charts/monitoring/values-generic.yaml
@@ -34,20 +34,19 @@ kube-prometheus-stack:
       image:
         tag: v3.9.1
         pullPolicy: Always
-      replicas: 2
+      replicas: 1
       resources:
         requests:
-          cpu: 500m
+          cpu: 200m
           memory: 1Gi
         limits:
-          cpu: 2
+          cpu: 1
           memory: 4Gi
       retention: 30d
       storageSpec:
         volumeClaimTemplate:
           spec:
             accessModes: ["ReadWriteOnce"]
-            storageClassName: ""
             resources:
               requests:
                 storage: 50Gi
@@ -69,7 +68,6 @@ kube-prometheus-stack:
         volumeClaimTemplate:
           spec:
             accessModes: ["ReadWriteOnce"]
-            storageClassName: ""
             resources:
               requests:
                 storage: 5Gi
@@ -89,6 +87,7 @@ kube-prometheus-stack:
       pullPolicy: Always
 
   prometheus-node-exporter:
+    hostNetwork: false
     image:
       tag: v1.8.2
       pullPolicy: Always

--- a/charts/monitoring/values.yaml
+++ b/charts/monitoring/values.yaml
@@ -92,6 +92,16 @@ chaosAlerts:
 # Kafka namespace for PromQL expressions
 kafkaNamespace: kafka
 
+# NetworkPolicy exceptions for clusters with namespace default-deny
+networkPolicy:
+  prometheusKafkaEgress:
+    enabled: true
+    # Namespace containing Strimzi Kafka pods exposing tcp-prometheus on 9404
+    kafkaNamespace: kafka
+    # Ports Prometheus is allowed to scrape on Kafka-related pods
+    ports:
+      - 9404
+
 # Kates dashboards
 dashboards:
   enabled: true

--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -30,8 +30,15 @@ type ClientOptions struct {
 }
 
 func NewWithOptions(opts ClientOptions) *Client {
+	proxyFn := http.ProxyFromEnvironment
+	if shouldBypassProxy(opts.BaseURL) {
+		// Local endpoints should bypass env proxies by default to avoid
+		// accidental routing through corporate/local proxy daemons.
+		proxyFn = nil
+	}
+
 	transport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+		Proxy: proxyFn,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 15 * time.Second,
@@ -57,6 +64,27 @@ func NewWithOptions(opts ClientOptions) *Client {
 		},
 		MaxRetries: 3,
 	}
+}
+
+func shouldBypassProxy(baseURL string) bool {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return false
+	}
+
+	host := strings.TrimSpace(u.Hostname())
+	if host == "" {
+		return false
+	}
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback()
 }
 
 func New(baseURL string) *Client {

--- a/cli/client/client_test.go
+++ b/cli/client/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -42,6 +43,78 @@ func TestNew(t *testing.T) {
 	}
 	if c.HTTPClient == nil {
 		t.Error("HTTPClient should not be nil")
+	}
+}
+
+func TestNewWithOptions_BypassesProxyForLoopbackBaseURL(t *testing.T) {
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:9000")
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:9000")
+	t.Setenv("ALL_PROXY", "http://127.0.0.1:9000")
+	t.Setenv("NO_PROXY", "")
+	t.Setenv("no_proxy", "")
+
+	c := NewWithOptions(ClientOptions{BaseURL: "http://localhost:8080"})
+	transport, ok := c.HTTPClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", c.HTTPClient.Transport)
+	}
+	if transport.Proxy != nil {
+		t.Fatal("proxy function should be nil for loopback base URL")
+	}
+}
+
+func TestNewWithOptions_UsesEnvProxyForNonLoopbackBaseURL(t *testing.T) {
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:9000")
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:9000")
+	t.Setenv("ALL_PROXY", "http://127.0.0.1:9000")
+	t.Setenv("NO_PROXY", "")
+	t.Setenv("no_proxy", "")
+
+	c := NewWithOptions(ClientOptions{BaseURL: "https://kates.example.com"})
+	transport, ok := c.HTTPClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", c.HTTPClient.Transport)
+	}
+	if transport.Proxy == nil {
+		t.Fatal("proxy function should not be nil for non-loopback base URL")
+	}
+
+	req := &http.Request{URL: &url.URL{Scheme: "https", Host: "kates.example.com"}}
+	proxyURL, err := transport.Proxy(req)
+	if err != nil {
+		t.Fatalf("proxy lookup error: %v", err)
+	}
+	if proxyURL == nil {
+		t.Fatal("expected env proxy URL, got nil")
+	}
+	if proxyURL.String() != "http://127.0.0.1:9000" {
+		t.Fatalf("proxy URL = %q, want %q", proxyURL.String(), "http://127.0.0.1:9000")
+	}
+}
+
+func TestNewWithOptions_ExplicitProxyOverridesLoopbackBypass(t *testing.T) {
+	c := NewWithOptions(ClientOptions{
+		BaseURL:  "http://127.0.0.1:8080",
+		ProxyURL: "http://proxy.internal:8080",
+	})
+	transport, ok := c.HTTPClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", c.HTTPClient.Transport)
+	}
+	if transport.Proxy == nil {
+		t.Fatal("proxy function should not be nil when explicit proxy is set")
+	}
+
+	req := &http.Request{URL: &url.URL{Scheme: "http", Host: "127.0.0.1:8080"}}
+	proxyURL, err := transport.Proxy(req)
+	if err != nil {
+		t.Fatalf("proxy lookup error: %v", err)
+	}
+	if proxyURL == nil {
+		t.Fatal("expected explicit proxy URL, got nil")
+	}
+	if proxyURL.String() != "http://proxy.internal:8080" {
+		t.Fatalf("proxy URL = %q, want %q", proxyURL.String(), "http://proxy.internal:8080")
 	}
 }
 

--- a/cli/cmd/connect.go
+++ b/cli/cmd/connect.go
@@ -2,10 +2,14 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
+	"strconv"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 )
@@ -39,16 +43,71 @@ var connectConnectorsCmd = &cobra.Command{
 	Use:   "connectors",
 	Short: "List all KafkaConnector CRs",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		argsCmd := []string{"get", "kafkaconnector", "-n", connectNamespace}
 		if outputMode == "json" {
-			argsCmd = append(argsCmd, "-o", "json")
+			out, err := exec.CommandContext(context.Background(), "kubectl", "get", "kafkaconnector", "-n", connectNamespace, "-o", "json").Output()
+			if err != nil {
+				return fmt.Errorf("failed to get kafkaconnector: %w", err)
+			}
+			fmt.Print(string(out))
+			return nil
 		}
-		out, err := exec.CommandContext(context.Background(), "kubectl", argsCmd...).Output()
+
+		out, err := exec.CommandContext(context.Background(), "kubectl", "get", "kafkaconnector", "-n", connectNamespace, "-o", "json").Output()
 		if err != nil {
 			return fmt.Errorf("failed to get kafkaconnector: %w", err)
 		}
-		fmt.Print(string(out))
-		return nil
+
+		var list kafkaConnectorList
+		if err := json.Unmarshal(out, &list); err != nil {
+			// Keep old behavior as fallback when JSON parsing fails.
+			fallback, fbErr := exec.CommandContext(context.Background(), "kubectl", "get", "kafkaconnector", "-n", connectNamespace).Output()
+			if fbErr != nil {
+				return fmt.Errorf("failed to parse connector output (%v) and fallback list failed: %w", err, fbErr)
+			}
+			fmt.Print(string(fallback))
+			return nil
+		}
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "NAME\tCLUSTER\tCONNECTOR CLASS\tMAX TASKS\tREADY\tRUNNING TASKS\tTASK STATES")
+		for _, item := range list.Items {
+			running := 0
+			statesSet := map[string]struct{}{}
+			for _, task := range item.Status.ConnectorStatus.Tasks {
+				if strings.EqualFold(task.State, "RUNNING") {
+					running++
+				}
+				if task.State != "" {
+					statesSet[task.State] = struct{}{}
+				}
+			}
+			states := make([]string, 0, len(statesSet))
+			for s := range statesSet {
+				states = append(states, s)
+			}
+			sort.Strings(states)
+			taskStates := "-"
+			if len(states) > 0 {
+				taskStates = strings.Join(states, ",")
+			}
+
+			maxTasks := item.Spec.TasksMax
+			runningTasks := strconv.Itoa(running)
+			if maxTasks > 0 {
+				runningTasks = fmt.Sprintf("%d/%d", running, maxTasks)
+			}
+
+			fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\t%s\t%s\n",
+				item.Metadata.Name,
+				item.Metadata.Labels["strimzi.io/cluster"],
+				item.Spec.Class,
+				maxTasks,
+				isReadyConditionTrue(item.Status.Conditions),
+				runningTasks,
+				taskStates,
+			)
+		}
+		return w.Flush()
 	},
 }
 
@@ -77,15 +136,45 @@ var connectTasksCmd = &cobra.Command{
 	Short: "Show task-level status for a connector",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		out, err := exec.CommandContext(context.Background(), "kubectl", "get", "kafkaconnector", args[0], "-n", connectNamespace, "-o", "jsonpath={.status.connectorStatus.tasks}").Output()
+		out, err := exec.CommandContext(context.Background(), "kubectl", "get", "kafkaconnector", args[0], "-n", connectNamespace, "-o", "json").Output()
 		if err != nil {
 			return fmt.Errorf("failed to get tasks for connector %s: %w", args[0], err)
 		}
-		if string(out) == "" {
-			fmt.Println("No tasks found or connector status unavailable.")
+
+		var connector kafkaConnector
+		if err := json.Unmarshal(out, &connector); err != nil {
+			return fmt.Errorf("failed to parse connector %s status: %w", args[0], err)
+		}
+
+		tasks := connector.Status.ConnectorStatus.Tasks
+		if outputMode == "json" {
+			b, err := json.Marshal(tasks)
+			if err != nil {
+				return fmt.Errorf("failed to marshal tasks: %w", err)
+			}
+			fmt.Println(string(b))
 			return nil
 		}
-		fmt.Println(string(out))
+
+		if len(tasks) == 0 {
+			connectorState := connector.Status.ConnectorStatus.Connector.State
+			if connectorState == "" {
+				connectorState = "UNKNOWN"
+			}
+			fmt.Printf("No tasks currently reported for connector %s (connector state: %s, ready: %s).\n",
+				args[0],
+				connectorState,
+				isReadyConditionTrue(connector.Status.Conditions),
+			)
+			return nil
+		}
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "ID\tSTATE\tWORKER ID\tVERSION")
+		for _, task := range tasks {
+			fmt.Fprintf(w, "%d\t%s\t%s\t%s\n", task.ID, task.State, task.WorkerID, task.Version)
+		}
+		w.Flush()
 		return nil
 	},
 }
@@ -292,4 +381,49 @@ func detectConnectNamespace() string {
 		return envNS
 	}
 	return "kafka"
+}
+
+type kafkaConnectorList struct {
+	Items []kafkaConnector `json:"items"`
+}
+
+type kafkaConnector struct {
+	Metadata struct {
+		Name   string            `json:"name"`
+		Labels map[string]string `json:"labels"`
+	} `json:"metadata"`
+	Spec struct {
+		Class    string `json:"class"`
+		TasksMax int    `json:"tasksMax"`
+	} `json:"spec"`
+	Status struct {
+		Conditions      []statusCondition `json:"conditions"`
+		ConnectorStatus struct {
+			Connector struct {
+				State string `json:"state"`
+			} `json:"connector"`
+			Tasks []connectorTask `json:"tasks"`
+		} `json:"connectorStatus"`
+	} `json:"status"`
+}
+
+type statusCondition struct {
+	Type   string `json:"type"`
+	Status string `json:"status"`
+}
+
+type connectorTask struct {
+	ID       int    `json:"id"`
+	State    string `json:"state"`
+	WorkerID string `json:"worker_id"`
+	Version  string `json:"version"`
+}
+
+func isReadyConditionTrue(conditions []statusCondition) string {
+	for _, c := range conditions {
+		if c.Type == "Ready" {
+			return c.Status
+		}
+	}
+	return "Unknown"
 }

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -734,10 +734,38 @@ spec:
 					}
 
 					// Wait for Kyverno CRDs before anything downstream tries to use them.
+					// `kubectl wait --for=condition=Established` can fail early on some
+					// clusters with transient "no .status.conditions" races right after CRD
+					// creation. Poll explicitly and tolerate empty status until established.
 					dl.Println("    - Waiting for Kyverno CRDs to be established...")
-					return runExecFn(gCtx, "kubectl", "wait", "--for=condition=Established",
-						"crd", "clusterpolicies.kyverno.io",
-						"--timeout=180s")
+					kyvernoCRDs := []string{
+						"clusterpolicies.kyverno.io",
+						"policies.kyverno.io",
+					}
+					deadline := time.Now().Add(180 * time.Second)
+					for _, crd := range kyvernoCRDs {
+						for {
+							out, checkErr := exec.CommandContext(gCtx,
+								"kubectl", "get", "crd", crd,
+								"-o", "jsonpath={.status.conditions[?(@.type==\"Established\")].status}",
+							).Output()
+							if checkErr == nil && strings.Contains(string(out), "True") {
+								break
+							}
+							if time.Now().After(deadline) {
+								if checkErr != nil {
+									return fmt.Errorf("kyverno CRD %s did not become Established: %w", crd, checkErr)
+								}
+								return fmt.Errorf("kyverno CRD %s did not become Established before timeout", crd)
+							}
+							select {
+							case <-gCtx.Done():
+								return gCtx.Err()
+							case <-time.After(2 * time.Second):
+							}
+						}
+					}
+					return nil
 				})
 			}
 
@@ -1060,11 +1088,38 @@ metadata:
 					}
 
 					dl.Println("    - Copying kates-connect credentials to connect namespace...")
-					pwCmd := exec.CommandContext(ctx, "kubectl", "get", "secret", "kates-connect",
-						"-n", kafkaNS, "-o", "jsonpath={.data.password}")
-					pwBytes, pwErr := pwCmd.Output()
+					var pwBytes []byte
+					var jaasBytes []byte
+					secretDeadline := time.Now().Add(2 * time.Minute)
+					for {
+						pwOut, pwErr := exec.CommandContext(ctx, "kubectl", "get", "secret", "kates-connect",
+							"-n", kafkaNS, "-o", "jsonpath={.data.password}").Output()
+						if pwErr == nil && len(strings.TrimSpace(string(pwOut))) > 0 {
+							pwBytes = bytes.TrimSpace(pwOut)
+							jaasOut, jaasErr := exec.CommandContext(ctx, "kubectl", "get", "secret", "kates-connect",
+								"-n", kafkaNS, "-o", "jsonpath={.data.sasl\\.jaas\\.config}").Output()
+							if jaasErr == nil {
+								jaasBytes = bytes.TrimSpace(jaasOut)
+							}
+							break
+						}
+						if time.Now().After(secretDeadline) {
+							break
+						}
+						select {
+						case <-ctx.Done():
+							return ctx.Err()
+						case <-time.After(5 * time.Second):
+						}
+					}
 
-					if pwErr == nil && len(pwBytes) > 0 {
+					if len(pwBytes) > 0 {
+						var dataLines strings.Builder
+						dataLines.WriteString(fmt.Sprintf("  password: %s\n", string(pwBytes)))
+						if len(jaasBytes) > 0 {
+							dataLines.WriteString(fmt.Sprintf("  sasl.jaas.config: %s\n", string(jaasBytes)))
+						}
+
 						connectSecretYaml := fmt.Sprintf(`apiVersion: v1
 kind: Secret
 metadata:
@@ -1072,10 +1127,10 @@ metadata:
   namespace: %s
 type: Opaque
 data:
-  password: %s`, connectNS, string(pwBytes))
+%s`, connectNS, dataLines.String())
 						runExecStdinFn(ctx, "kubectl", []string{"apply", "-f", "-"}, connectSecretYaml)
 					} else {
-						dl.Printf("    ⚠️  Secret 'kates-connect' not found in namespace %s — KafkaUser may not be ready\n", kafkaNS)
+						dl.Printf("    ⚠️  Secret 'kates-connect' not found in namespace %s after waiting — KafkaUser may not be ready\n", kafkaNS)
 					}
 				}
 
@@ -1344,6 +1399,7 @@ data:
 					"-f", valuesFile,
 					"-f", chartOverlay("charts/kates"),
 					"--set", "kafka.bootstrapServers="+bootstrap,
+					"--set", "kafka.topicNamespace="+kafkaNS,
 					"--set", fmt.Sprintf("monitoring.enabled=%t", deployWithMonitoring),
 					"--timeout", "8m"); err != nil {
 					return err

--- a/cli/cmd/deploy_status.go
+++ b/cli/cmd/deploy_status.go
@@ -43,6 +43,7 @@ func init() {
 	deployStatusCmd.Flags().StringVar(&deployAppNS, "app-ns", "kates", "Namespace for Kates Backend when topology is 'isolated'")
 	deployStatusCmd.Flags().StringVar(&deployChaosNS, "chaos-ns", "litmus", "Namespace for Chaos Engine when topology is 'isolated'")
 	deployStatusCmd.Flags().StringVar(&deployMonitoringNS, "monitoring-ns", "monitoring", "Namespace for monitoring components when topology is 'isolated'")
+	deployStatusCmd.Flags().StringVar(&deployKafkaUINS, "ui-ns", "kafka", "Namespace for Kafka UI when topology is 'isolated'")
 
 	deployStatusCmd.Flags().BoolVarP(&deployStatusInteractive, "interactive", "i", false, "Enable interactive Bubble Tea status loader")
 	deployStatusCmd.Flags().StringVarP(&deployStatusOutput, "output", "o", "table", "Output format: table or json")
@@ -149,6 +150,12 @@ type k8sWorkload struct {
 	} `json:"status"`
 }
 
+type helmStatusRelease struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Status    string `json:"status"`
+}
+
 func runDeployStatus(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
@@ -158,6 +165,8 @@ func runDeployStatus(cmd *cobra.Command, args []string) error {
 	} else {
 		kafkaNS, connectNS, appNS, chaosNS, jaegerNS, dbNS, kafkaUINS = deployKafkaNS, deployConnectNS, deployAppNS, deployChaosNS, deployMonitoringNS, deployDbNS, deployKafkaUINS
 	}
+
+	helmIndex := loadHelmReleaseIndex(ctx)
 
 	components := []struct {
 		Group     string
@@ -224,9 +233,9 @@ func runDeployStatus(cmd *cobra.Command, args []string) error {
 				Release:   c.Release,
 				Namespace: c.Namespace,
 			}
-			st.HelmStatus = getHelmStatus(ctx, c.Release, c.Namespace)
+			st.HelmStatus, st.Namespace = getHelmStatusWithNamespace(ctx, helmIndex, c.Release, c.Namespace)
 			if st.HelmStatus == "deployed" {
-				st.Health, st.Details = getHealthStatus(ctx, c.Kind, c.Resource, c.Namespace)
+				st.Health, st.Details = getHealthStatus(ctx, c.Kind, c.Resource, st.Namespace)
 			} else {
 				st.Health = "N/A"
 				st.Details = "Not deployed"
@@ -244,8 +253,61 @@ func runDeployStatus(cmd *cobra.Command, args []string) error {
 
 // ── V1 Existing Logic (Retained for default sequential flow) ──
 
+func loadHelmReleaseIndex(ctx context.Context) map[string][]helmStatusRelease {
+	checkCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(checkCtx, "helm", "list", "-A", "-o", "json")
+	out, err := cmd.Output()
+	if err != nil || len(out) == 0 {
+		return nil
+	}
+
+	var releases []helmStatusRelease
+	if err := json.Unmarshal(out, &releases); err != nil {
+		return nil
+	}
+
+	index := make(map[string][]helmStatusRelease, len(releases))
+	for _, rel := range releases {
+		index[rel.Name] = append(index[rel.Name], rel)
+	}
+	return index
+}
+
+func lookupHelmRelease(index map[string][]helmStatusRelease, release, namespace string) (status, resolvedNamespace string, ok bool) {
+	if index == nil {
+		return "", namespace, false
+	}
+
+	releases, exists := index[release]
+	if !exists || len(releases) == 0 {
+		return "", namespace, false
+	}
+
+	for _, rel := range releases {
+		if rel.Namespace == namespace {
+			return strings.ToLower(rel.Status), namespace, true
+		}
+	}
+
+	// Fallback: if a release name is unique cluster-wide, trust that namespace.
+	if len(releases) == 1 {
+		return strings.ToLower(releases[0].Status), releases[0].Namespace, true
+	}
+
+	return "", namespace, false
+}
+
+func getHelmStatusWithNamespace(ctx context.Context, index map[string][]helmStatusRelease, release, namespace string) (status, resolvedNamespace string) {
+	if st, ns, ok := lookupHelmRelease(index, release, namespace); ok {
+		return st, ns
+	}
+	return getHelmStatus(ctx, release, namespace), namespace
+}
+
 func getHelmStatus(ctx context.Context, release, namespace string) string {
-	checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	checkCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(checkCtx, "helm", "status", release, "-n", namespace)
 	if err := cmd.Run(); err == nil {
@@ -317,7 +379,7 @@ func getHealthStatus(ctx context.Context, kind, resource, namespace string) (str
 // ── V2 Enhanced Logic (Used in Interactive and JSON output modes) ──
 
 func getHelmStatusV2(ctx context.Context, release, namespace string) string {
-	checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	checkCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(checkCtx, "helm", "status", release, "-n", namespace)
 	if err := cmd.Run(); err == nil {
@@ -530,6 +592,7 @@ func runJSONStatus(ctx context.Context, components []struct {
 }) ([]ComponentStatus, error) {
 	var wg sync.WaitGroup
 	statuses := make([]ComponentStatus, len(components))
+	helmIndex := loadHelmReleaseIndex(ctx)
 
 	for i, c := range components {
 		wg.Add(1)
@@ -550,9 +613,9 @@ func runJSONStatus(ctx context.Context, components []struct {
 				Release:   comp.Release,
 				Namespace: comp.Namespace,
 			}
-			st.HelmStatus = getHelmStatusV2(ctx, comp.Release, comp.Namespace)
+			st.HelmStatus, st.Namespace = getHelmStatusWithNamespace(ctx, helmIndex, comp.Release, comp.Namespace)
 			if st.HelmStatus == "deployed" {
-				st.Health, st.Details, st.RawDetails = getHealthStatusV2(ctx, comp.Kind, comp.Resource, comp.Namespace)
+				st.Health, st.Details, st.RawDetails = getHealthStatusV2(ctx, comp.Kind, comp.Resource, st.Namespace)
 			} else {
 				st.Health = "N/A"
 				st.Details = "Not deployed"
@@ -648,7 +711,11 @@ func (m interactiveStatusModel) View() string {
 			prevGroup = c.Group
 		}
 
-		compName := c.Icon + " " + c.Name
+		iconStr := c.Icon
+		if visualWidth(iconStr) == 1 {
+			iconStr += " "
+		}
+		compName := iconStr + " " + c.Name
 		nameStyle := lipgloss.NewStyle().Foreground(clrText)
 		var statusStr string
 
@@ -691,6 +758,7 @@ func runInteractiveStatus(ctx context.Context, components []struct {
 }) ([]ComponentStatus, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	helmIndex := loadHelmReleaseIndex(ctx)
 
 	s := spinner.New()
 	s.Spinner = spinner.Dot
@@ -727,9 +795,9 @@ func runInteractiveStatus(ctx context.Context, components []struct {
 				Release:   comp.Release,
 				Namespace: comp.Namespace,
 			}
-			st.HelmStatus = getHelmStatusV2(ctx, comp.Release, comp.Namespace)
+			st.HelmStatus, st.Namespace = getHelmStatusWithNamespace(ctx, helmIndex, comp.Release, comp.Namespace)
 			if st.HelmStatus == "deployed" {
-				st.Health, st.Details, st.RawDetails = getHealthStatusV2(ctx, comp.Kind, comp.Resource, comp.Namespace)
+				st.Health, st.Details, st.RawDetails = getHealthStatusV2(ctx, comp.Kind, comp.Resource, st.Namespace)
 			} else {
 				st.Health = "N/A"
 				st.Details = "Not deployed"
@@ -796,7 +864,11 @@ func RenderStatusDashboard(statuses []ComponentStatus) {
 }
 
 func printStatusRow(s ComponentStatus) {
-	nameStr := s.Icon + " " + s.Name
+	iconStr := s.Icon
+	if visualWidth(iconStr) == 1 {
+		iconStr += " "
+	}
+	nameStr := iconStr + " " + s.Name
 	// Emoji icons render as 2 cells in terminals, but runewidth often
 	// miscounts them (e.g. ☸️ with VS16 reports width 1 instead of 2).
 	// Use a fixed 2-cell icon slot + 1 space + text width for padding.

--- a/cli/cmd/deploy_status_test.go
+++ b/cli/cmd/deploy_status_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"os"
 	"strings"
@@ -37,9 +38,15 @@ func TestDeployStatusCommand(t *testing.T) {
 		t.Errorf("Expected output to contain 'Kates Deployment Status', got: \n%s", output)
 	}
 
-	// Verify the correct namespace is populated
-	if !strings.Contains(output, "kates-test-ns") {
-		t.Errorf("Expected output to contain namespace 'kates-test-ns', got: \n%s", output)
+	// Verify the expected namespace is populated.
+	// In clusters where a release name is unique, deploy status resolves and shows the
+	// discovered Helm namespace instead of the requested one.
+	expectedNamespace := "kates-test-ns"
+	if st, ns, ok := lookupHelmRelease(loadHelmReleaseIndex(context.Background()), "kates", expectedNamespace); ok && st == "deployed" {
+		expectedNamespace = ns
+	}
+	if !strings.Contains(output, expectedNamespace) {
+		t.Errorf("Expected output to contain namespace %q, got: \n%s", expectedNamespace, output)
 	}
 
 	// Verify some component groups are present
@@ -243,4 +250,49 @@ func TestParseWorkloadHealth(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLookupHelmRelease(t *testing.T) {
+	index := map[string][]helmStatusRelease{
+		"monitoring": {
+			{Name: "monitoring", Namespace: "monitoring", Status: "deployed"},
+		},
+		"kafka-ui": {
+			{Name: "kafka-ui", Namespace: "kafka-ui", Status: "deployed"},
+		},
+		"shared": {
+			{Name: "shared", Namespace: "ns-a", Status: "deployed"},
+			{Name: "shared", Namespace: "ns-b", Status: "deployed"},
+		},
+	}
+
+	t.Run("exact namespace match", func(t *testing.T) {
+		status, ns, ok := lookupHelmRelease(index, "monitoring", "monitoring")
+		if !ok {
+			t.Fatal("expected exact release lookup to succeed")
+		}
+		if status != "deployed" || ns != "monitoring" {
+			t.Fatalf("unexpected lookup result: status=%q ns=%q", status, ns)
+		}
+	})
+
+	t.Run("unique release fallback to discovered namespace", func(t *testing.T) {
+		status, ns, ok := lookupHelmRelease(index, "kafka-ui", "kafka")
+		if !ok {
+			t.Fatal("expected unique release fallback lookup to succeed")
+		}
+		if status != "deployed" || ns != "kafka-ui" {
+			t.Fatalf("unexpected lookup result: status=%q ns=%q", status, ns)
+		}
+	})
+
+	t.Run("ambiguous release without exact namespace", func(t *testing.T) {
+		_, ns, ok := lookupHelmRelease(index, "shared", "missing-ns")
+		if ok {
+			t.Fatal("expected ambiguous release lookup to fail without exact namespace")
+		}
+		if ns != "missing-ns" {
+			t.Fatalf("expected unresolved namespace to remain unchanged, got %q", ns)
+		}
+	})
 }

--- a/cli/cmd/portforward.go
+++ b/cli/cmd/portforward.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"strings"
@@ -153,13 +155,18 @@ func runPorts(ctx context.Context) {
 			pfArg,
 			"-n", spec.Namespace,
 		)
+		// Detach from the current process group so forwards survive after
+		// `kates ports` exits and the shell returns to prompt.
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 		devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
 		if err == nil {
 			cmd.Stdout = devNull
 			cmd.Stderr = devNull
 		}
 		cmd.Stdin = nil
-		_ = cmd.Start()
+		if err := cmd.Start(); err == nil && cmd.Process != nil {
+			_ = cmd.Process.Release()
+		}
 	}
 
 	// Verify reachability
@@ -170,6 +177,9 @@ func runPorts(ctx context.Context) {
 	errStyle := lipgloss.NewStyle().Foreground(theme.Error).Bold(true)
 
 	allOk := true
+	katesAPIForwardActive := false
+	katesAPINS := ""
+	katesAPILocalPort := 0
 	for _, spec := range specs {
 		addr := fmt.Sprintf("127.0.0.1:%d", spec.Local)
 		success := false
@@ -182,6 +192,11 @@ func runPorts(ctx context.Context) {
 		}
 
 		if success {
+			if spec.Label == "Kates REST API" {
+				katesAPIForwardActive = true
+				katesAPINS = spec.Namespace
+				katesAPILocalPort = spec.Local
+			}
 			fmt.Printf("    %s  %-26s  localhost:%-5d  %s\n",
 				okStyle.Render("✔"),
 				spec.Label,
@@ -199,6 +214,12 @@ func runPorts(ctx context.Context) {
 		}
 	}
 
+	// Keep local CLI context in sync with the forwarded API endpoint so follow-up
+	// commands (health/resilience/tests) work without manual ctx/api-key edits.
+	if katesAPIForwardActive {
+		syncContextToPortForward(ctx, katesAPINS, katesAPILocalPort)
+	}
+
 	fmt.Println()
 	if allOk {
 		fmt.Printf("    %s %s\n", okStyle.Render("✓"), boldStyle.Render("Port forwards established successfully!"))
@@ -207,6 +228,205 @@ func runPorts(ctx context.Context) {
 		fmt.Printf("    %s %s\n", errStyle.Render("⚠"), boldStyle.Render("Some port forwards failed to establish."))
 		fmt.Printf("      %s\n\n", output.DimStyle.Render("Check if the pods are ready or run 'kates clean' to reset."))
 	}
+}
+
+func syncContextToPortForward(ctx context.Context, appNS string, localPort int) {
+	endpoint := fmt.Sprintf("http://localhost:%d", localPort)
+	cfg := loadConfig()
+	ctxName := resolveContextName(cfg)
+	existingKey := ""
+	if existing, ok := cfg.Contexts[ctxName]; ok {
+		existingKey = strings.TrimSpace(existing.APIKey)
+	}
+
+	apiKey, source, keyErr := resolveWorkingAPIKey(ctx, endpoint, appNS, existingKey)
+	cfg = applyPortForwardContext(cfg, ctxName, endpoint, apiKey)
+	if err := saveConfig(cfg); err != nil {
+		fmt.Printf("    %s Failed to persist context sync: %v\n", output.WarningStyle.Render("⚠"), err)
+		return
+	}
+
+	if apiKey != "" {
+		if source == "" {
+			source = "resolved"
+		}
+		fmt.Printf("    %s Synced context %q → %s (API key source: %s)\n", output.SuccessStyle.Render("✓"), ctxName, endpoint, source)
+		return
+	}
+
+	fmt.Printf("    %s Synced context %q → %s\n", output.SuccessStyle.Render("✓"), ctxName, endpoint)
+	if keyErr != nil {
+		fmt.Printf("      %s\n", output.DimStyle.Render("API key was not refreshed automatically (secret not found or not readable)."))
+	}
+}
+
+func resolveContextName(cfg Config) string {
+	name := cfg.CurrentContext
+	if contextFlag != "" {
+		name = contextFlag
+	}
+	if strings.TrimSpace(name) == "" {
+		return "local"
+	}
+	return name
+}
+
+func resolveWorkingAPIKey(ctx context.Context, endpoint, namespace, existingKey string) (string, string, error) {
+	secretKey, secretErr := fetchKatesAPIKey(ctx, namespace)
+	if secretKey != "" && isAPIKeyAccepted(endpoint, secretKey) {
+		return secretKey, "secret", nil
+	}
+
+	podKey, podErr := fetchKatesAPIKeyFromRunningPod(ctx, namespace)
+	if podKey != "" && isAPIKeyAccepted(endpoint, podKey) {
+		return podKey, "running-pod", nil
+	}
+
+	if strings.TrimSpace(existingKey) != "" && isAPIKeyAccepted(endpoint, existingKey) {
+		return existingKey, "existing-context", nil
+	}
+
+	// Best-effort fallback when validation cannot succeed (e.g., API temporarily down).
+	if secretKey != "" {
+		if secretErr != nil {
+			return secretKey, "secret-unverified", secretErr
+		}
+		return secretKey, "secret-unverified", nil
+	}
+	if podKey != "" {
+		if podErr != nil {
+			return podKey, "running-pod-unverified", podErr
+		}
+		return podKey, "running-pod-unverified", nil
+	}
+	if strings.TrimSpace(existingKey) != "" {
+		return existingKey, "existing-context-unverified", nil
+	}
+
+	if secretErr != nil {
+		return "", "", secretErr
+	}
+	if podErr != nil {
+		return "", "", podErr
+	}
+	return "", "", fmt.Errorf("no usable API key source")
+}
+
+func fetchKatesAPIKey(ctx context.Context, namespace string) (string, error) {
+	checkCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(
+		checkCtx,
+		"kubectl",
+		"get", "secret", "kates-api-key",
+		"-n", namespace,
+		"-o", "go-template={{index .data \"api-key\"}}",
+	).Output()
+	if err != nil {
+		return "", err
+	}
+
+	encoded := strings.TrimSpace(string(out))
+	if encoded == "" {
+		return "", fmt.Errorf("secret kates-api-key has empty api-key")
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", err
+	}
+	apiKey := strings.TrimSpace(string(decoded))
+	if apiKey == "" {
+		return "", fmt.Errorf("decoded api-key is empty")
+	}
+	return apiKey, nil
+}
+
+func fetchKatesAPIKeyFromRunningPod(ctx context.Context, namespace string) (string, error) {
+	checkCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	podOut, err := exec.CommandContext(
+		checkCtx,
+		"kubectl",
+		"get", "pods",
+		"-n", namespace,
+		"-l", "app.kubernetes.io/instance=kates",
+		"-o", "jsonpath={.items[0].metadata.name}",
+	).Output()
+	if err != nil {
+		return "", err
+	}
+
+	podName := strings.TrimSpace(string(podOut))
+	if podName == "" {
+		return "", fmt.Errorf("no running kates pod found in namespace %q", namespace)
+	}
+
+	out, err := exec.CommandContext(
+		checkCtx,
+		"kubectl", "exec",
+		"-n", namespace,
+		podName,
+		"--",
+		"printenv", "KATES_API_KEY",
+	).Output()
+	if err != nil {
+		return "", err
+	}
+
+	key := strings.TrimSpace(string(out))
+	if key == "" {
+		return "", fmt.Errorf("running pod %q has empty KATES_API_KEY", podName)
+	}
+	return key, nil
+}
+
+func isAPIKeyAccepted(endpoint, apiKey string) bool {
+	if strings.TrimSpace(endpoint) == "" || strings.TrimSpace(apiKey) == "" {
+		return false
+	}
+
+	checkURL := strings.TrimRight(endpoint, "/") + "/api/health"
+	req, err := http.NewRequest(http.MethodGet, checkURL, nil)
+	if err != nil {
+		return false
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+func applyPortForwardContext(cfg Config, ctxName, endpoint, apiKey string) Config {
+	if cfg.Contexts == nil {
+		cfg.Contexts = map[string]Context{}
+	}
+	if strings.TrimSpace(ctxName) == "" {
+		ctxName = "local"
+	}
+
+	active := cfg.Contexts[ctxName]
+	if active.Output == "" {
+		active.Output = "table"
+	}
+	if endpoint != "" {
+		active.URL = endpoint
+	}
+	if apiKey != "" {
+		active.APIKey = apiKey
+	}
+
+	cfg.Contexts[ctxName] = active
+	cfg.CurrentContext = ctxName
+	return cfg
 }
 
 // discoverServices returns a set of "namespace/service-name" strings for all

--- a/cli/cmd/portforward_test.go
+++ b/cli/cmd/portforward_test.go
@@ -1,0 +1,88 @@
+package cmd
+
+import "testing"
+
+func TestApplyPortForwardContext_UpdatesExistingContext(t *testing.T) {
+	cfg := Config{
+		CurrentContext: "local",
+		Contexts: map[string]Context{
+			"local": {
+				URL:      "http://localhost:30083",
+				Output:   "json",
+				APIKey:   "old-key",
+				ProxyURL: "http://proxy:8080",
+				Insecure: true,
+			},
+		},
+	}
+
+	updated := applyPortForwardContext(cfg, "local", "http://localhost:8080", "new-key")
+	got := updated.Contexts["local"]
+
+	if updated.CurrentContext != "local" {
+		t.Fatalf("CurrentContext = %q, want %q", updated.CurrentContext, "local")
+	}
+	if got.URL != "http://localhost:8080" {
+		t.Fatalf("URL = %q, want %q", got.URL, "http://localhost:8080")
+	}
+	if got.APIKey != "new-key" {
+		t.Fatalf("APIKey = %q, want %q", got.APIKey, "new-key")
+	}
+	if got.Output != "json" {
+		t.Fatalf("Output = %q, want %q", got.Output, "json")
+	}
+	if got.ProxyURL != "http://proxy:8080" {
+		t.Fatalf("ProxyURL = %q, want %q", got.ProxyURL, "http://proxy:8080")
+	}
+	if !got.Insecure {
+		t.Fatal("Insecure should remain true")
+	}
+}
+
+func TestApplyPortForwardContext_CreatesMissingContext(t *testing.T) {
+	cfg := Config{
+		CurrentContext: "",
+		Contexts:       map[string]Context{},
+	}
+
+	updated := applyPortForwardContext(cfg, "", "http://localhost:8080", "key-1")
+	got, ok := updated.Contexts["local"]
+	if !ok {
+		t.Fatal("expected local context to be created")
+	}
+	if updated.CurrentContext != "local" {
+		t.Fatalf("CurrentContext = %q, want %q", updated.CurrentContext, "local")
+	}
+	if got.URL != "http://localhost:8080" {
+		t.Fatalf("URL = %q, want %q", got.URL, "http://localhost:8080")
+	}
+	if got.APIKey != "key-1" {
+		t.Fatalf("APIKey = %q, want %q", got.APIKey, "key-1")
+	}
+	if got.Output != "table" {
+		t.Fatalf("Output = %q, want %q", got.Output, "table")
+	}
+}
+
+func TestApplyPortForwardContext_KeepExistingAPIKeyWhenNewOneEmpty(t *testing.T) {
+	cfg := Config{
+		CurrentContext: "local",
+		Contexts: map[string]Context{
+			"local": {
+				URL:    "http://localhost:30083",
+				Output: "table",
+				APIKey: "existing",
+			},
+		},
+	}
+
+	updated := applyPortForwardContext(cfg, "local", "http://localhost:8080", "")
+	got := updated.Contexts["local"]
+
+	if got.APIKey != "existing" {
+		t.Fatalf("APIKey = %q, want %q", got.APIKey, "existing")
+	}
+	if got.URL != "http://localhost:8080" {
+		t.Fatalf("URL = %q, want %q", got.URL, "http://localhost:8080")
+	}
+}

--- a/cli/pkg/detect/valuesgen.go
+++ b/cli/pkg/detect/valuesgen.go
@@ -399,6 +399,76 @@ func (g *ValuesGenerator) Generate() *GeneratedValues {
 					},
 				},
 				{
+					Name: "kafka-ui",
+					Authentication: GenUserAuth{
+						Type: "scram-sha-512",
+					},
+					Quotas: &GenUserQuotas{
+						ProducerByteRate:  1048576,
+						ConsumerByteRate:  52428800,
+						RequestPercentage: 10,
+					},
+					Authorization: &GenUserAuthz{
+						Type: "simple",
+						Acls: []GenAcl{
+							{
+								Resource: GenAclResource{
+									Type:        "topic",
+									Name:        "*",
+									PatternType: "literal",
+								},
+								Operations: []string{"Describe", "Read"},
+							},
+							{
+								Resource: GenAclResource{
+									Type:        "group",
+									Name:        "*",
+									PatternType: "literal",
+								},
+								Operations: []string{"Describe", "Read"},
+							},
+							{
+								Resource: GenAclResource{
+									Type: "cluster",
+								},
+								Operations: []string{"Describe"},
+							},
+						},
+					},
+				},
+				{
+					Name: "apicurio-registry",
+					Authentication: GenUserAuth{
+						Type: "scram-sha-512",
+					},
+					Quotas: &GenUserQuotas{
+						ProducerByteRate:  10485760,
+						ConsumerByteRate:  20971520,
+						RequestPercentage: 15,
+					},
+					Authorization: &GenUserAuthz{
+						Type: "simple",
+						Acls: []GenAcl{
+							{
+								Resource: GenAclResource{
+									Type:        "topic",
+									Name:        "__apicurio",
+									PatternType: "prefix",
+								},
+								Operations: []string{"Read", "Write", "Create", "Describe"},
+							},
+							{
+								Resource: GenAclResource{
+									Type:        "group",
+									Name:        "apicurio",
+									PatternType: "prefix",
+								},
+								Operations: []string{"Read", "Describe"},
+							},
+						},
+					},
+				},
+				{
 					Name: "kates-connect",
 					Authentication: GenUserAuth{
 						Type: "scram-sha-512",
@@ -463,6 +533,14 @@ func (g *ValuesGenerator) Generate() *GeneratedValues {
 								Resource: GenAclResource{
 									Type:        "group",
 									Name:        "kates-connect",
+									PatternType: "prefix",
+								},
+								Operations: []string{"Read", "Describe"},
+							},
+							{
+								Resource: GenAclResource{
+									Type:        "group",
+									Name:        "connect-",
 									PatternType: "prefix",
 								},
 								Operations: []string{"Read", "Describe"},

--- a/config/cluster.yaml
+++ b/config/cluster.yaml
@@ -25,10 +25,6 @@ nodes:
     topology.kubernetes.io/zone: alpha
     node.kubernetes.io/instance-type: custom-3vcpu-6gb
     node.kubernetes.io/local-storage: 30gb
-  extraMounts:
-  - hostPath: proxy/proxy.conf
-    containerPath: /etc/systemd/system/containerd.service.d/proxy.conf
-    readOnly: true
 - role: worker
   # Use Kubernetes v1.31.4 — v1.33+ fails with cgroup v2 on arm64
   image: kindest/node:v1.31.4
@@ -43,10 +39,6 @@ nodes:
     topology.kubernetes.io/zone: sigma
     node.kubernetes.io/instance-type: custom-3vcpu-6gb
     node.kubernetes.io/local-storage: 30gb
-  extraMounts:
-  - hostPath: proxy/proxy.conf
-    containerPath: /etc/systemd/system/containerd.service.d/proxy.conf
-    readOnly: true
 - role: worker
   # Use Kubernetes v1.31.4 — v1.33+ fails with cgroup v2 on arm64
   image: kindest/node:v1.31.4
@@ -61,7 +53,3 @@ nodes:
     topology.kubernetes.io/zone: gamma
     node.kubernetes.io/instance-type: custom-3vcpu-6gb
     node.kubernetes.io/local-storage: 30gb
-  extraMounts:
-  - hostPath: proxy/proxy.conf
-    containerPath: /etc/systemd/system/containerd.service.d/proxy.conf
-    readOnly: true

--- a/config/kafka/strimzi-values.yaml
+++ b/config/kafka/strimzi-values.yaml
@@ -50,5 +50,5 @@ dashboards:
   label: grafana_dashboard
   labelValue: "1"
 
-generateNetworkPolicy: true
+generateNetworkPolicy: false
 generatePodDisruptionBudget: true

--- a/docs/book/12-deployment.md
+++ b/docs/book/12-deployment.md
@@ -412,8 +412,25 @@ Phases: pre-flight → baseline → chaos-inject → observe → recover → pos
 make registry-status
 
 # Manually pull and load
-./pull-images.sh
-./load-images-to-kind.sh
+./scripts/pull-images.sh
+./scripts/load-images-to-kind.sh
+```
+
+If you're behind an HTTP/HTTPS proxy, set `HTTP_PROXY`, `HTTPS_PROXY`, and
+`NO_PROXY` in your shell or `proxy/proxy.conf` before running
+`./scripts/load-images-to-kind.sh`.
+
+If you are not using `load-images-to-kind.sh`, run `./scripts/start-cluster.sh`
+(or `make cluster`) after setting proxy variables. This reconciles containerd
+proxy settings on Kind nodes so regular Kubernetes image pulls use the proxy.
+
+Direct proxy flags are supported too:
+
+```bash
+./scripts/start-cluster.sh \
+  --http-proxy http://proxy.example.com:8080 \
+  --https-proxy http://proxy.example.com:8080 \
+  --no-proxy "localhost,127.0.0.1,.svc,.cluster.local"
 ```
 
 ### Kafka Pods Not Starting

--- a/docs/kafka-connect.md
+++ b/docs/kafka-connect.md
@@ -80,6 +80,17 @@ ghcr.io/bmscomp/connect:abc1234        # commit SHA
 
 ## Usage with Strimzi
 
+## Tutorials and Working Examples
+
+- End-to-end tutorial (CDC + JDBC examples): [`docs/tutorials/09-kafka-connect-working-examples.md`](tutorials/09-kafka-connect-working-examples.md)
+- Existing quick runbook: [`docs/tutorials/kafka-connect-simple-source-sink-demo.md`](tutorials/kafka-connect-simple-source-sink-demo.md)
+- Example manifests:
+  - `config/kafka-connect/working-example-cdc-topic.yaml`
+  - `config/kafka-connect/working-example-debezium-postgres-source.yaml`
+  - `config/kafka-connect/working-example-jdbc-sink-from-cdc.yaml`
+  - `config/kafka-connect/working-example-jdbc-sink.yaml`
+  - `config/kafka-connect/working-example-jdbc-source.yaml`
+
 ### Using the pre-built image (recommended)
 
 ```yaml

--- a/docs/tutorials/09-kafka-connect-working-examples.md
+++ b/docs/tutorials/09-kafka-connect-working-examples.md
@@ -1,0 +1,163 @@
+# 09: Kafka Connect Working Examples (CDC + JDBC)
+
+This tutorial turns the working example manifests in `config/kafka-connect` into an end-to-end guide you can run in a real cluster.
+
+## What You Will Deploy
+
+| Manifest | Purpose |
+|---|---|
+| `config/kafka-connect/working-example-cdc-topic.yaml` | Creates the CDC topic `cdc.public.demo_orders` |
+| `config/kafka-connect/working-example-debezium-postgres-source.yaml` | Debezium source: PostgreSQL `public.demo_orders` -> Kafka |
+| `config/kafka-connect/working-example-jdbc-sink-from-cdc.yaml` | JDBC sink: `cdc.public.demo_orders` -> PostgreSQL `demo_orders_replica` |
+| `config/kafka-connect/working-example-jdbc-sink.yaml` | Generic JDBC sink from `kates-results` |
+| `config/kafka-connect/working-example-jdbc-source.yaml` | Generic JDBC source template (Aiven JDBC source plugin) |
+
+## Prerequisites
+
+```bash
+export CONNECT_NS=connect
+export KAFKA_NS=kafka
+export DB_NS=database
+export CONNECT_CLUSTER=connect-cluster
+export KAFKA_CLUSTER=krafter
+```
+
+Verify required resources:
+
+```bash
+kubectl get kafkaconnect -n "${CONNECT_NS}"
+kubectl get secret connect-pg-credentials -n "${CONNECT_NS}"
+kubectl get secret kates-connect -n "${CONNECT_NS}"
+kubectl get pods -n "${DB_NS}"
+```
+
+Required secrets in `CONNECT_NS`:
+- `connect-pg-credentials` with keys `username`, `password`
+- `kates-connect` with key `password`
+
+## Namespace and Cluster Name Customization
+
+The manifests are committed with defaults:
+- Connect namespace: `connect`
+- Kafka namespace: `kafka`
+- Connect cluster label: `strimzi.io/cluster: connect-cluster`
+- Kafka cluster label: `strimzi.io/cluster: krafter`
+- Secret references: `${secrets:connect/...}`
+
+If your environment differs (for example Connect runs in `kafka` or another namespace), copy the files and update:
+- `metadata.namespace`
+- `metadata.labels["strimzi.io/cluster"]`
+- Secret references from `${secrets:connect/...}` to `${secrets:<your-connect-namespace>/...}`
+
+## Part A: CDC Pipeline (Topic + Debezium Source + JDBC Sink)
+
+### 1) Create Source and Sink Tables
+
+```bash
+kubectl exec -n "${DB_NS}" postgresql-0 -- /bin/bash -lc \
+  "PGPASSWORD=postgres /opt/bitnami/postgresql/bin/psql -h 127.0.0.1 -U postgres -d orders -c \
+  \"ALTER ROLE debezium WITH REPLICATION LOGIN;\""
+
+kubectl exec -n "${DB_NS}" postgresql-0 -- /bin/bash -lc \
+  "PGPASSWORD=debezium /opt/bitnami/postgresql/bin/psql -h 127.0.0.1 -U debezium -d orders -c \
+  \"CREATE TABLE IF NOT EXISTS public.demo_orders (id INTEGER PRIMARY KEY, customer_name TEXT NOT NULL, amount NUMERIC(10,2) NOT NULL, created_at TIMESTAMPTZ DEFAULT now());\""
+
+kubectl exec -n "${DB_NS}" postgresql-0 -- /bin/bash -lc \
+  "PGPASSWORD=debezium /opt/bitnami/postgresql/bin/psql -h 127.0.0.1 -U debezium -d orders -c \
+  \"CREATE TABLE IF NOT EXISTS public.demo_orders_replica (id INTEGER PRIMARY KEY, customer_name TEXT NOT NULL, amount NUMERIC(10,2) NOT NULL, created_at TIMESTAMPTZ);\""
+```
+
+### 2) Apply CDC Topic and Connectors
+
+```bash
+# Migrated to helm test: helm test connect-cluster -n connect
+# Migrated to helm test: helm test connect-cluster -n connect
+# Migrated to helm test: helm test connect-cluster -n connect
+```
+
+### 3) Wait Until Ready
+
+```bash
+kubectl wait -n "${KAFKA_NS}" --for=condition=Ready kafkatopic/cdc-public-demo-orders --timeout=180s
+kubectl wait -n "${CONNECT_NS}" --for=condition=Ready kafkaconnector/debezium-postgres-source-working-example --timeout=300s
+kubectl wait -n "${CONNECT_NS}" --for=condition=Ready kafkaconnector/jdbc-sink-from-cdc-working-example --timeout=300s
+kubectl get kafkaconnector -n "${CONNECT_NS}"
+```
+
+### 4) Insert Test Data
+
+```bash
+kubectl exec -n "${DB_NS}" postgresql-0 -- /bin/bash -lc \
+  "PGPASSWORD=debezium /opt/bitnami/postgresql/bin/psql -h 127.0.0.1 -U debezium -d orders -c \
+  \"INSERT INTO public.demo_orders (id, customer_name, amount) VALUES (1001, 'alice', 42.50) ON CONFLICT (id) DO UPDATE SET customer_name = EXCLUDED.customer_name, amount = EXCLUDED.amount;\""
+```
+
+### 5) Verify Replication to Sink Table
+
+```bash
+kubectl exec -n "${DB_NS}" postgresql-0 -- /bin/bash -lc \
+  "PGPASSWORD=debezium /opt/bitnami/postgresql/bin/psql -h 127.0.0.1 -U debezium -d orders -c \
+  \"SELECT id, customer_name, amount FROM public.demo_orders_replica WHERE id = 1001;\""
+```
+
+Expected result: one row for `id=1001` in `demo_orders_replica`.
+
+## Part B: Generic JDBC Sink Example
+
+Apply the standalone sink example:
+
+```bash
+# Migrated to helm test: helm test connect-cluster -n connect
+kubectl wait -n "${CONNECT_NS}" --for=condition=Ready kafkaconnector/jdbc-sink-working-example --timeout=300s
+kubectl describe kafkaconnector -n "${CONNECT_NS}" jdbc-sink-working-example
+```
+
+Notes:
+- This connector consumes `kates-results` by default.
+- It is useful as a baseline JDBC sink template when you want automatic table creation/evolution.
+
+## Part C: Generic JDBC Source Example
+
+Apply the source template:
+
+```bash
+# Migrated to helm test: helm test connect-cluster -n connect
+kubectl wait -n "${CONNECT_NS}" --for=condition=Ready kafkaconnector/jdbc-source-working-example --timeout=300s
+kubectl describe kafkaconnector -n "${CONNECT_NS}" jdbc-source-working-example
+```
+
+Important:
+- This requires plugin class `io.aiven.connect.jdbc.JdbcSourceConnector` in your Connect image.
+- If the plugin is missing, connector status will show class-not-found or failed state.
+
+## Troubleshooting
+
+Quick checks:
+
+```bash
+kubectl get kafkaconnector -n "${CONNECT_NS}"
+kubectl describe kafkaconnector -n "${CONNECT_NS}" debezium-postgres-source-working-example
+kubectl describe kafkaconnector -n "${CONNECT_NS}" jdbc-sink-from-cdc-working-example
+kubectl logs -n "${CONNECT_NS}" -l strimzi.io/name="${CONNECT_CLUSTER}-connect" --tail=200
+```
+
+Most common issues:
+- Wrong namespace or cluster label in manifest metadata
+- Secret references still pointing to `connect` after namespace change
+- Missing JDBC source plugin class for `working-example-jdbc-source.yaml`
+
+## Cleanup
+
+```bash
+kubectl delete kafkaconnector -n "${CONNECT_NS}" \
+  debezium-postgres-source-working-example \
+  jdbc-sink-from-cdc-working-example \
+  jdbc-sink-working-example \
+  jdbc-source-working-example --ignore-not-found
+
+kubectl delete kafkatopic -n "${KAFKA_NS}" cdc-public-demo-orders --ignore-not-found
+
+kubectl exec -n "${DB_NS}" postgresql-0 -- /bin/bash -lc \
+  "PGPASSWORD=postgres /opt/bitnami/postgresql/bin/psql -h 127.0.0.1 -U postgres -d orders -c \
+  \"DROP TABLE IF EXISTS public.demo_orders_replica; DROP TABLE IF EXISTS public.demo_orders;\""
+```

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -14,6 +14,8 @@ Hands-on tutorials for learning Kates — from your first test to advanced chaos
 | 6 | [CI/CD Integration](06-cicd-integration.md) | Advanced | 30 min |
 | 7 | [Kyverno & Security](07-kyverno-security.md) | Intermediate | 30 min |
 | 8 | [Deploy, Detect & Clean](08-deploy-and-detect.md) | Beginner → Intermediate | 25 min |
+| 9 | [Kafka Connect Working Examples (CDC + JDBC)](09-kafka-connect-working-examples.md) | Intermediate | 35 min |
+| 10 | [Kafka Connect Source/Sink Quick Runbook](kafka-connect-simple-source-sink-demo.md) | Intermediate | 15 min |
 
 ## Prerequisites
 

--- a/docs/tutorials/kafka-connect-simple-source-sink-demo.md
+++ b/docs/tutorials/kafka-connect-simple-source-sink-demo.md
@@ -1,0 +1,103 @@
+# Kafka Connect Source/Sink Demo Plan (Default Cluster Context)
+
+For the full tutorial that documents all working Kafka Connect examples (CDC topic, Debezium source, JDBC sink from CDC, generic JDBC sink, and generic JDBC source), use:
+
+- [09-kafka-connect-working-examples.md](09-kafka-connect-working-examples.md)
+
+This runbook demonstrates a full end-to-end flow:
+- Insert one row in PostgreSQL
+- Verify Debezium source connector publishes to Kafka topic
+- Verify JDBC sink connector writes to a replica table
+
+## 1. Preconditions
+
+```bash
+kubectl config current-context
+kubectl get kafkaconnect connect-cluster -n connect
+kubectl get pods -n connect
+kubectl get pods -n database
+```
+
+Expected:
+- Context is the default admin context (for example `kubernetes-admin@taz-tls-int-10`)
+- `connect-cluster` is `Ready=True`
+- Connect and PostgreSQL pods are running
+
+## 2. Create/Verify Source Table
+
+```bash
+kubectl exec -n database postgresql-0 -- /bin/bash -lc \
+  "PGPASSWORD=postgres /opt/bitnami/postgresql/bin/psql -h 127.0.0.1 -U postgres -d orders -c \
+  \"ALTER ROLE debezium WITH REPLICATION LOGIN;\""
+
+kubectl exec -n database postgresql-0 -- /bin/bash -lc \
+  "PGPASSWORD=debezium /opt/bitnami/postgresql/bin/psql -h 127.0.0.1 -U debezium -d orders -c \
+  \"CREATE TABLE IF NOT EXISTS public.demo_orders (id INTEGER PRIMARY KEY, customer_name TEXT NOT NULL, amount NUMERIC(10,2) NOT NULL, created_at TIMESTAMPTZ DEFAULT now());\""
+```
+
+## 3. Apply Demo Resources
+
+```bash
+# Migrated to helm test: helm test connect-cluster -n connect
+# Migrated to helm test: helm test connect-cluster -n connect
+# Migrated to helm test: helm test connect-cluster -n connect
+```
+
+## 4. Wait for Connectors to be Ready
+
+```bash
+kubectl wait -n connect --for=condition=Ready kafkaconnector/debezium-postgres-source-working-example --timeout=5m
+kubectl wait -n connect --for=condition=Ready kafkaconnector/jdbc-sink-from-cdc-working-example --timeout=5m
+kubectl get kafkaconnector -n connect
+```
+
+## 5. Insert a Record in Source DB
+
+```bash
+kubectl exec -n database postgresql-0 -- /bin/bash -lc \
+  "PGPASSWORD=debezium /opt/bitnami/postgresql/bin/psql -h 127.0.0.1 -U debezium -d orders -c \
+  \"INSERT INTO public.demo_orders (id, customer_name, amount) VALUES (1001, 'alice', 42.50) ON CONFLICT (id) DO UPDATE SET customer_name = EXCLUDED.customer_name, amount = EXCLUDED.amount;\""
+```
+
+## 6. Verify Message in Kafka Topic
+
+```bash
+kubectl get kafkaconnector debezium-postgres-source-working-example -n connect \
+  -o jsonpath='{.status.topics}{"\n"}{.status.connectorStatus.tasks[0].state}{"\n"}'
+
+kubectl get kafkaconnector jdbc-sink-from-cdc-working-example -n connect \
+  -o jsonpath='{.status.topics}{"\n"}{.status.connectorStatus.tasks[0].state}{"\n"}'
+```
+
+Expected:
+- Both connectors show `RUNNING`
+- `status.topics` includes `cdc.public.demo_orders`
+
+## 7. Verify Sink Table Received the Row
+
+```bash
+kubectl exec -n database postgresql-0 -- /bin/bash -lc \
+  "PGPASSWORD=debezium /opt/bitnami/postgresql/bin/psql -h 127.0.0.1 -U debezium -d orders -c \
+  \"SELECT id, customer_name, amount FROM public.demo_orders_replica WHERE id = 1001;\""
+```
+
+Expected:
+- Row exists in `demo_orders_replica` with the same values
+
+## 8. Optional Cleanup
+
+```bash
+kubectl delete kafkaconnector -n connect debezium-postgres-source-working-example jdbc-sink-from-cdc-working-example
+kubectl delete kafkatopic -n kafka cdc-public-demo-orders
+kubectl exec -n database postgresql-0 -- /bin/bash -lc \
+  "PGPASSWORD=postgres /opt/bitnami/postgresql/bin/psql -h 127.0.0.1 -U postgres -d orders -c \
+  \"DROP TABLE IF EXISTS public.demo_orders_replica; DROP TABLE IF EXISTS public.demo_orders;\""
+```
+
+## Extra JDBC Source Example
+
+The repository also includes a JDBC source connector template:
+
+- `config/kafka-connect/working-example-jdbc-source.yaml`
+
+Use it only after adding a compatible JDBC source plugin class (`io.aiven.connect.jdbc.JdbcSourceConnector`) to the Connect image.

--- a/kates/src/main/java/com/bmscomp/kates/engine/CdcIntegrationService.java
+++ b/kates/src/main/java/com/bmscomp/kates/engine/CdcIntegrationService.java
@@ -7,10 +7,13 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -36,8 +39,16 @@ import com.bmscomp.kates.domain.TestResult;
 public class CdcIntegrationService {
 
     private static final Logger LOG = Logger.getLogger(CdcIntegrationService.class);
-    private static final String SOURCE_CONNECTOR_NAME = "integration-test-source";
-    private static final String SINK_CONNECTOR_NAME = "integration-test-sink";
+    private static final String SOURCE_CONNECTOR_PREFIX = "integration-test-source-";
+    private static final String SINK_CONNECTOR_PREFIX = "integration-test-sink-";
+    private static final String SOURCE_TABLE_PREFIX = "connect_test_src_";
+    private static final String SINK_TABLE_PREFIX = "connect_test_sink_";
+    private static final String SLOT_PREFIX = "connect_test_src_slot_";
+    private static final String TOPIC_RESOURCE_PREFIX = "cdc.public.connect-test-src-";
+    private static final String TOPIC_NAME_PREFIX = "cdc.public.";
+    private static final int K8S_NAME_MAX_LENGTH = 63;
+    private static final int POSTGRES_IDENTIFIER_MAX_LENGTH = 63;
+    private static final int RUN_TOKEN_MAX_LENGTH = 32;
     private static final CustomResourceDefinitionContext CONNECTOR_CRD = new CustomResourceDefinitionContext.Builder()
             .withGroup("kafka.strimzi.io")
             .withVersion("v1")
@@ -68,12 +79,20 @@ public class CdcIntegrationService {
     @org.eclipse.microprofile.config.inject.ConfigProperty(name = "kates.kafka.sasl.password")
     java.util.Optional<String> kafkaPassword;
 
+    @org.eclipse.microprofile.config.inject.ConfigProperty(name = "kates.cdc.topic-namespace")
+    Optional<String> configuredCdcTopicNamespace;
+
+    @org.eclipse.microprofile.config.inject.ConfigProperty(name = "kates.topology.kafka-namespace", defaultValue = "kafka")
+    String kafkaNamespace;
+
     public CompletableFuture<BenchmarkStatus> runCdcTest(BenchmarkTask task, java.util.function.BiConsumer<String, Map<String, Long>> progressCallback) {
         return CompletableFuture.supplyAsync(() -> {
             TestResult.TaskStatus endState = TestResult.TaskStatus.RUNNING;
             String errorMsg = null;
             int recordsProcessed = 0;
             Map<String, Long> phaseDurations = new LinkedHashMap<>();
+            List<String> topicNamespacesForCleanup = new ArrayList<>();
+            CdcRunResources runResources = createRunResources(UUID.randomUUID().toString());
 
             String connectNamespace = "kafka"; // Default
             String testDbNS = "database"; // Default
@@ -85,11 +104,19 @@ public class CdcIntegrationService {
                 if (progressCallback != null) progressCallback.accept("DB_SETUP", phaseDurations);
                 Instant phaseStart = Instant.now();
 
-                // Auto-discover PostgreSQL namespace
-                var pgServices = kubernetesClient.services().inAnyNamespace().withLabel("app.kubernetes.io/name", "postgresql").list().getItems();
-                if (!pgServices.isEmpty()) {
-                    testDbNS = pgServices.get(0).getMetadata().getNamespace();
-                    LOG.info("Auto-discovered PostgreSQL namespace: " + testDbNS);
+                // Auto-discover PostgreSQL namespace (best effort).
+                // Some clusters grant namespace-scoped RBAC only; in that case keep the default namespace.
+                try {
+                    var pgServices = kubernetesClient.services().inAnyNamespace()
+                            .withLabel("app.kubernetes.io/name", "postgresql")
+                            .list()
+                            .getItems();
+                    if (!pgServices.isEmpty()) {
+                        testDbNS = pgServices.get(0).getMetadata().getNamespace();
+                        LOG.info("Auto-discovered PostgreSQL namespace: " + testDbNS);
+                    }
+                } catch (Exception e) {
+                    LOG.warn("Failed to auto-discover PostgreSQL namespace; using default namespace " + testDbNS, e);
                 }
 
                 // Auto-discover KafkaConnect namespace and cluster name
@@ -126,24 +153,29 @@ public class CdcIntegrationService {
                 }
                 String dbPassword = new String(java.util.Base64.getDecoder().decode(encodedPassword));
 
-                // Setup Test Tables & Insert Record
+                // Setup test tables (record insert happens after connectors are ready to avoid sink offset race).
                 String uuidStr = "test-" + UUID.randomUUID().toString();
                 String jdbcUrl = "jdbc:postgresql://postgresql." + testDbNS + ".svc:5432/postgres";
+                LOG.infof(
+                        "CDC test run token=%s sourceConnector=%s sinkConnector=%s topic=%s sourceTable=%s sinkTable=%s slot=%s",
+                        runResources.runToken(),
+                        runResources.sourceConnectorName(),
+                        runResources.sinkConnectorName(),
+                        runResources.topicName(),
+                        runResources.sourceTable(),
+                        runResources.sinkTable(),
+                        runResources.slotName());
 
                 LOG.info("Connecting to PostgreSQL at " + jdbcUrl);
                 try (Connection conn = DriverManager.getConnection(jdbcUrl, "postgres", dbPassword);
                      Statement stmt = conn.createStatement()) {
 
-                    stmt.execute("CREATE TABLE IF NOT EXISTS connect_test_src (id serial primary key, test_uuid varchar(255))");
-                    stmt.execute("CREATE TABLE IF NOT EXISTS connect_test_sink (id serial primary key, test_uuid varchar(255))");
-
-                    // Use parameterized query to prevent SQL injection
-                    try (PreparedStatement ps = conn.prepareStatement(
-                            "INSERT INTO connect_test_src (test_uuid) VALUES (?)")) {
-                        ps.setString(1, uuidStr);
-                        ps.executeUpdate();
-                    }
-                    LOG.info("Inserted test record with UUID: " + uuidStr);
+                    // Reset test tables on each run to avoid stale rows/constraints from prior failed runs.
+                    stmt.execute("DROP TABLE IF EXISTS " + runResources.sourceTable());
+                    stmt.execute("DROP TABLE IF EXISTS " + runResources.sinkTable());
+                    stmt.execute("CREATE TABLE " + runResources.sourceTable() + " (id serial primary key, test_uuid varchar(255))");
+                    // Keep sink table non-unique so at-least-once/replayed events never fail the sink task.
+                    stmt.execute("CREATE TABLE " + runResources.sinkTable() + " (id integer, test_uuid varchar(255))");
                 }
                 phaseDurations.put("DB_SETUP", Duration.between(phaseStart, Instant.now()).toMillis());
 
@@ -151,27 +183,47 @@ public class CdcIntegrationService {
                 if (progressCallback != null) progressCallback.accept("TOPIC_CREATE", phaseDurations);
                 phaseStart = Instant.now();
                 LOG.info("Creating KafkaTopic for CDC...");
-                String topicYaml = String.format("""
-                        apiVersion: kafka.strimzi.io/v1
-                        kind: KafkaTopic
-                        metadata:
-                          name: cdc.public.connect-test-src
-                          namespace: %s
-                          labels:
-                            strimzi.io/cluster: %s
-                        spec:
-                          topicName: cdc.public.connect_test_src
-                          partitions: 1
-                          replicas: 1
-                          config:
-                            retention.ms: 7200000
-                            segment.bytes: 1073741824
-                        """, connectNamespace, kafkaClusterName);
+                final List<String> topicNamespaceCandidates = resolveTopicNamespaceCandidates(connectNamespace);
+                topicNamespacesForCleanup = new ArrayList<>(topicNamespaceCandidates);
 
-                kubernetesClient.genericKubernetesResources(TOPIC_CRD)
-                        .inNamespace(connectNamespace)
-                        .load(new java.io.ByteArrayInputStream(topicYaml.getBytes()))
-                        .createOrReplace();
+                String selectedTopicNamespace = null;
+                for (String topicNamespace : topicNamespaceCandidates) {
+                    String topicYaml = String.format("""
+                            apiVersion: kafka.strimzi.io/v1
+                            kind: KafkaTopic
+                            metadata:
+                              name: %s
+                              namespace: %s
+                              labels:
+                                strimzi.io/cluster: %s
+                            spec:
+                              topicName: %s
+                              partitions: 1
+                              replicas: 1
+                              config:
+                                retention.ms: 7200000
+                                segment.bytes: 1073741824
+                            """, runResources.topicResourceName(), topicNamespace, kafkaClusterName, runResources.topicName());
+
+                    kubernetesClient.genericKubernetesResources(TOPIC_CRD)
+                            .inNamespace(topicNamespace)
+                            .load(new java.io.ByteArrayInputStream(topicYaml.getBytes()))
+                            .createOrReplace();
+
+                    if (waitForTopicReady(topicNamespace, runResources.topicResourceName(), Duration.ofSeconds(20))) {
+                        selectedTopicNamespace = topicNamespace;
+                        break;
+                    }
+
+                    LOG.warnf("KafkaTopic %s did not become Ready in namespace %s; trying next candidate",
+                            runResources.topicName(), topicNamespace);
+                }
+
+                if (selectedTopicNamespace == null) {
+                    throw new IllegalStateException("KafkaTopic " + runResources.topicName()
+                            + " did not become Ready in any namespace. Tried: " + topicNamespaceCandidates);
+                }
+                LOG.infof("KafkaTopic %s resolved in namespace %s", runResources.topicName(), selectedTopicNamespace);
                 phaseDurations.put("TOPIC_CREATE", Duration.between(phaseStart, Instant.now()).toMillis());
 
                 // ── Phase: SOURCE_DEPLOY ─────────────────────────────────────
@@ -200,15 +252,22 @@ public class CdcIntegrationService {
                             database.dbname: postgres
                             topic.prefix: cdc
                             plugin.name: pgoutput
-                            slot.name: connect_test_src_slot
-                            table.include.list: public.connect_test_src
+                            slot.name: %s
+                            table.include.list: public.%s
                             transforms: unwrap
                             transforms.unwrap.type: io.debezium.transforms.ExtractNewRecordState
                             key.converter: org.apache.kafka.connect.json.JsonConverter
                             key.converter.schemas.enable: true
                             value.converter: org.apache.kafka.connect.json.JsonConverter
                             value.converter.schemas.enable: true
-                        """, SOURCE_CONNECTOR_NAME, connectNamespace, connectName, testDbNS, dbPassword);
+                        """,
+                        runResources.sourceConnectorName(),
+                        connectNamespace,
+                        connectName,
+                        testDbNS,
+                        dbPassword,
+                        runResources.slotName(),
+                        runResources.sourceTable());
 
                 kubernetesClient.genericKubernetesResources(CONNECTOR_CRD)
                         .inNamespace(connectNamespace)
@@ -235,11 +294,12 @@ public class CdcIntegrationService {
                             connection.url: jdbc:postgresql://postgresql.%s.svc:5432/postgres
                             connection.username: postgres
                             connection.password: %s
-                            topics: cdc.public.connect_test_src
-                            table.name.format: connect_test_sink
+                            topics: %s
+                            table.name.format: %s
                             insert.mode: insert
                             auto.create: false
                             auto.evolve: false
+                            consumer.override.auto.offset.reset: latest
                             transforms: dropDeleted
                             transforms.dropDeleted.type: org.apache.kafka.connect.transforms.ReplaceField$Value
                             transforms.dropDeleted.blacklist: __deleted
@@ -247,7 +307,14 @@ public class CdcIntegrationService {
                             key.converter.schemas.enable: true
                             value.converter: org.apache.kafka.connect.json.JsonConverter
                             value.converter.schemas.enable: true
-                        """, SINK_CONNECTOR_NAME, connectNamespace, connectName, testDbNS, dbPassword);
+                        """,
+                        runResources.sinkConnectorName(),
+                        connectNamespace,
+                        connectName,
+                        testDbNS,
+                        dbPassword,
+                        runResources.topicName(),
+                        runResources.sinkTable());
 
                 kubernetesClient.genericKubernetesResources(CONNECTOR_CRD)
                         .inNamespace(connectNamespace)
@@ -265,7 +332,7 @@ public class CdcIntegrationService {
                     if (!sourceReady) {
                         GenericKubernetesResource srcCr = kubernetesClient.genericKubernetesResources(CONNECTOR_CRD)
                                 .inNamespace(connectNamespace)
-                                .withName(SOURCE_CONNECTOR_NAME)
+                                .withName(runResources.sourceConnectorName())
                                 .get();
                         // Check for permanent failure first
                         String srcFailure = extractConnectorFailure(srcCr);
@@ -277,7 +344,7 @@ public class CdcIntegrationService {
                     if (!sinkReady) {
                         GenericKubernetesResource sinkCr = kubernetesClient.genericKubernetesResources(CONNECTOR_CRD)
                                 .inNamespace(connectNamespace)
-                                .withName(SINK_CONNECTOR_NAME)
+                                .withName(runResources.sinkConnectorName())
                                 .get();
                         String sinkFailure = extractConnectorFailure(sinkCr);
                         if (sinkFailure != null) {
@@ -297,6 +364,14 @@ public class CdcIntegrationService {
                 }
                 phaseDurations.put("CONNECTOR_READY", Duration.between(phaseStart, Instant.now()).toMillis());
 
+                // Insert a fresh row after both connectors are Ready so sink consumers with latest offsets never miss it.
+                try (Connection conn = DriverManager.getConnection(jdbcUrl, "postgres", dbPassword);
+                     PreparedStatement ps = conn.prepareStatement("INSERT INTO " + runResources.sourceTable() + " (test_uuid) VALUES (?)")) {
+                    ps.setString(1, uuidStr);
+                    ps.executeUpdate();
+                    LOG.info("Inserted test record with UUID after connectors ready: " + uuidStr);
+                }
+
                 // ── Phase: KAFKA_VERIFY ──────────────────────────────────────
                 if (progressCallback != null) progressCallback.accept("KAFKA_VERIFY", phaseDurations);
                 phaseStart = Instant.now();
@@ -305,7 +380,7 @@ public class CdcIntegrationService {
                 Properties props = getKafkaConsumerProperties(kafkaClusterName);
 
                 try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(props)) {
-                    consumer.subscribe(Collections.singletonList("cdc.public.connect_test_src"));
+                    consumer.subscribe(Collections.singletonList(runResources.topicName()));
 
                     Instant start = Instant.now();
                     while (Duration.between(start, Instant.now()).getSeconds() < 90) {
@@ -336,7 +411,7 @@ public class CdcIntegrationService {
                 try (Connection conn = DriverManager.getConnection(jdbcUrl, "postgres", dbPassword)) {
                     // Use parameterized query to prevent SQL injection
                     try (PreparedStatement ps = conn.prepareStatement(
-                            "SELECT test_uuid FROM connect_test_sink WHERE test_uuid = ?")) {
+                            "SELECT test_uuid FROM " + runResources.sinkTable() + " WHERE test_uuid = ?")) {
                         ps.setString(1, uuidStr);
 
                         Instant start = Instant.now();
@@ -369,7 +444,7 @@ public class CdcIntegrationService {
                 // ── Phase: CLEANUP ───────────────────────────────────────────
                 if (progressCallback != null) progressCallback.accept("CLEANUP", phaseDurations);
                 Instant cleanupStart = Instant.now();
-                cleanupTestResources(connectNamespace, testDbNS);
+                cleanupTestResources(connectNamespace, testDbNS, topicNamespacesForCleanup, runResources);
                 phaseDurations.put("CLEANUP", Duration.between(cleanupStart, Instant.now()).toMillis());
             }
 
@@ -387,12 +462,12 @@ public class CdcIntegrationService {
      * Cleans up all test resources: connectors, topics, and database tables.
      * Each cleanup step is isolated so a failure in one does not prevent others.
      */
-    private void cleanupTestResources(String connectNamespace, String testDbNS) {
+    private void cleanupTestResources(String connectNamespace, String testDbNS, List<String> topicNamespaces, CdcRunResources runResources) {
         LOG.info("Cleaning up Integration CDC test resources");
         try {
             kubernetesClient.genericKubernetesResources(CONNECTOR_CRD)
                     .inNamespace(connectNamespace)
-                    .withName(SOURCE_CONNECTOR_NAME)
+                    .withName(runResources.sourceConnectorName())
                     .delete();
         } catch (Exception e) {
             LOG.warn("Failed to delete source connector", e);
@@ -400,18 +475,31 @@ public class CdcIntegrationService {
         try {
             kubernetesClient.genericKubernetesResources(CONNECTOR_CRD)
                     .inNamespace(connectNamespace)
-                    .withName(SINK_CONNECTOR_NAME)
+                    .withName(runResources.sinkConnectorName())
                     .delete();
         } catch (Exception e) {
             LOG.warn("Failed to delete sink connector", e);
         }
-        try {
-            kubernetesClient.genericKubernetesResources(TOPIC_CRD)
-                    .inNamespace(connectNamespace)
-                    .withName("cdc.public.connect-test-src")
-                    .delete();
-        } catch (Exception e) {
-            LOG.warn("Failed to delete CDC KafkaTopic", e);
+        LinkedHashSet<String> topicNamespacesToCleanup = new LinkedHashSet<>();
+        if (topicNamespaces != null) {
+            for (String ns : topicNamespaces) {
+                if (ns != null && !ns.isBlank()) {
+                    topicNamespacesToCleanup.add(ns.trim());
+                }
+            }
+        }
+        if (topicNamespacesToCleanup.isEmpty()) {
+            topicNamespacesToCleanup.add(connectNamespace);
+        }
+        for (String topicNamespace : topicNamespacesToCleanup) {
+            try {
+                kubernetesClient.genericKubernetesResources(TOPIC_CRD)
+                        .inNamespace(topicNamespace)
+                        .withName(runResources.topicResourceName())
+                        .delete();
+            } catch (Exception e) {
+                LOG.warn("Failed to delete CDC KafkaTopic from namespace " + topicNamespace, e);
+            }
         }
 
         try {
@@ -421,13 +509,116 @@ public class CdcIntegrationService {
                 String jdbcUrl = "jdbc:postgresql://postgresql." + testDbNS + ".svc:5432/postgres";
                 try (Connection conn = DriverManager.getConnection(jdbcUrl, "postgres", dbPassword);
                      Statement stmt = conn.createStatement()) {
-                    stmt.execute("DROP TABLE IF EXISTS connect_test_src");
-                    stmt.execute("DROP TABLE IF EXISTS connect_test_sink");
+                    stmt.execute("DROP TABLE IF EXISTS " + runResources.sourceTable());
+                    stmt.execute("DROP TABLE IF EXISTS " + runResources.sinkTable());
                 }
             }
         } catch (Exception e) {
             LOG.warn("Failed to drop test tables", e);
         }
+    }
+
+    static CdcRunResources createRunResources(String tokenSeed) {
+        String runToken = sanitizeRunToken(tokenSeed);
+        String sourceTable = buildName(SOURCE_TABLE_PREFIX, runToken, POSTGRES_IDENTIFIER_MAX_LENGTH);
+        return new CdcRunResources(
+                runToken,
+                buildName(SOURCE_CONNECTOR_PREFIX, runToken, K8S_NAME_MAX_LENGTH),
+                buildName(SINK_CONNECTOR_PREFIX, runToken, K8S_NAME_MAX_LENGTH),
+                sourceTable,
+                buildName(SINK_TABLE_PREFIX, runToken, POSTGRES_IDENTIFIER_MAX_LENGTH),
+                buildName(SLOT_PREFIX, runToken, POSTGRES_IDENTIFIER_MAX_LENGTH),
+                TOPIC_NAME_PREFIX + sourceTable,
+                buildName(TOPIC_RESOURCE_PREFIX, runToken, K8S_NAME_MAX_LENGTH));
+    }
+
+    private static String sanitizeRunToken(String tokenSeed) {
+        StringBuilder sanitized = new StringBuilder(RUN_TOKEN_MAX_LENGTH);
+        String source = tokenSeed != null ? tokenSeed : "";
+        for (int i = 0; i < source.length() && sanitized.length() < RUN_TOKEN_MAX_LENGTH; i++) {
+            char c = Character.toLowerCase(source.charAt(i));
+            if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) {
+                sanitized.append(c);
+            }
+        }
+
+        if (sanitized.length() > 0) {
+            return sanitized.toString();
+        }
+        return UUID.randomUUID().toString().replace("-", "");
+    }
+
+    private static String buildName(String prefix, String token, int maxLength) {
+        if (prefix.length() + token.length() <= maxLength) {
+            return prefix + token;
+        }
+        int remaining = Math.max(1, maxLength - prefix.length());
+        return prefix + token.substring(0, remaining);
+    }
+
+    static record CdcRunResources(
+            String runToken,
+            String sourceConnectorName,
+            String sinkConnectorName,
+            String sourceTable,
+            String sinkTable,
+            String slotName,
+            String topicName,
+            String topicResourceName) {
+    }
+
+    private List<String> resolveTopicNamespaceCandidates(String connectNamespace) {
+        String configuredNamespace = configuredCdcTopicNamespace
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .orElse("");
+        if (!configuredNamespace.isEmpty()) {
+            LOG.infof("Using configured CDC topic namespace: %s", configuredNamespace);
+            return List.of(configuredNamespace);
+        }
+
+        LinkedHashSet<String> candidates = new LinkedHashSet<>();
+        if (connectNamespace != null && !connectNamespace.isBlank()) {
+            candidates.add(connectNamespace.trim());
+        }
+        if (kafkaNamespace != null && !kafkaNamespace.isBlank()) {
+            candidates.add(kafkaNamespace.trim());
+        }
+        if (candidates.isEmpty()) {
+            candidates.add("kafka");
+        }
+        return new ArrayList<>(candidates);
+    }
+
+    private boolean waitForTopicReady(String namespace, String topicResourceName, Duration timeout) throws InterruptedException {
+        Instant deadline = Instant.now().plus(timeout);
+        while (Instant.now().isBefore(deadline)) {
+            GenericKubernetesResource topicCr = kubernetesClient.genericKubernetesResources(TOPIC_CRD)
+                    .inNamespace(namespace)
+                    .withName(topicResourceName)
+                    .get();
+            if (isTopicReady(topicCr)) {
+                return true;
+            }
+            Thread.sleep(1000);
+        }
+        return false;
+    }
+
+    @SuppressWarnings("unchecked")
+    private boolean isTopicReady(GenericKubernetesResource cr) {
+        if (cr != null && cr.getAdditionalProperties().containsKey("status")) {
+            java.util.Map<String, Object> crStatus = (java.util.Map<String, Object>) cr.getAdditionalProperties().get("status");
+            if (crStatus.containsKey("conditions")) {
+                java.util.List<java.util.Map<String, Object>> conditions = (java.util.List<java.util.Map<String, Object>>) crStatus.get("conditions");
+                for (java.util.Map<String, Object> cond : conditions) {
+                    if ("Ready".equals(cond.get("type")) && "True".equals(cond.get("status"))) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     @SuppressWarnings("unchecked")

--- a/kates/src/test/java/com/bmscomp/kates/engine/CdcIntegrationServiceTest.java
+++ b/kates/src/test/java/com/bmscomp/kates/engine/CdcIntegrationServiceTest.java
@@ -1,0 +1,64 @@
+package com.bmscomp.kates.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+class CdcIntegrationServiceTest {
+
+    @Test
+    void createRunResourcesUsesDistinctNamesAcrossRuns() {
+        CdcIntegrationService.CdcRunResources first = CdcIntegrationService.createRunResources("run-alpha");
+        CdcIntegrationService.CdcRunResources second = CdcIntegrationService.createRunResources("run-beta");
+
+        assertNotEquals(first.sourceConnectorName(), second.sourceConnectorName());
+        assertNotEquals(first.sinkConnectorName(), second.sinkConnectorName());
+        assertNotEquals(first.sourceTable(), second.sourceTable());
+        assertNotEquals(first.sinkTable(), second.sinkTable());
+        assertNotEquals(first.slotName(), second.slotName());
+        assertNotEquals(first.topicName(), second.topicName());
+        assertNotEquals(first.topicResourceName(), second.topicResourceName());
+    }
+
+    @Test
+    void createRunResourcesProducesSafeNamesWithBounds() {
+        String noisyToken = "RUN-ID__WITH.invalid/chars-and-super-long-0123456789abcdefghijklmnopqrstuvwxyz";
+        CdcIntegrationService.CdcRunResources resources = CdcIntegrationService.createRunResources(noisyToken);
+
+        Pattern k8sNamePattern = Pattern.compile("^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$");
+        Pattern postgresIdentifierPattern = Pattern.compile("^[a-z][a-z0-9_]*$");
+
+        assertTrue(resources.runToken().matches("^[a-z0-9]+$"));
+        assertTrue(resources.runToken().length() <= 32);
+
+        assertTrue(resources.sourceConnectorName().length() <= 63);
+        assertTrue(resources.sinkConnectorName().length() <= 63);
+        assertTrue(resources.topicResourceName().length() <= 63);
+        assertTrue(k8sNamePattern.matcher(resources.sourceConnectorName()).matches());
+        assertTrue(k8sNamePattern.matcher(resources.sinkConnectorName()).matches());
+        assertTrue(k8sNamePattern.matcher(resources.topicResourceName()).matches());
+
+        assertTrue(resources.sourceTable().length() <= 63);
+        assertTrue(resources.sinkTable().length() <= 63);
+        assertTrue(resources.slotName().length() <= 63);
+        assertTrue(postgresIdentifierPattern.matcher(resources.sourceTable()).matches());
+        assertTrue(postgresIdentifierPattern.matcher(resources.sinkTable()).matches());
+        assertTrue(postgresIdentifierPattern.matcher(resources.slotName()).matches());
+
+        assertEquals("cdc.public." + resources.sourceTable(), resources.topicName());
+        assertFalse(resources.topicResourceName().contains("_"));
+    }
+
+    @Test
+    void createRunResourcesFallsBackToGeneratedTokenWhenInputIsInvalid() {
+        CdcIntegrationService.CdcRunResources resources = CdcIntegrationService.createRunResources("---////___");
+
+        assertEquals(32, resources.runToken().length());
+        assertTrue(resources.runToken().matches("^[a-z0-9]+$"));
+    }
+}

--- a/scripts/deploy-kafka-generic.sh
+++ b/scripts/deploy-kafka-generic.sh
@@ -19,18 +19,21 @@ CHART_DIR="${ROOT_DIR}/charts/kafka-cluster"
 RELEASE_NAME="kafka-cluster"
 NAMESPACE="kafka"
 DETECTED_VALUES="${ROOT_DIR}/.build/values-detected.yaml"
+AUTO_OVERLAY=""
 
 # Parse arguments
 AUTO_APPROVE=false
 EXTRA_VALUES=""
 SKIP_TESTS=false
+RUN_TESTS=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --yes|-y)       AUTO_APPROVE=true; shift ;;
         --values|-f)    EXTRA_VALUES="$2"; shift 2 ;;
         --skip-tests)   SKIP_TESTS=true; shift ;;
+        --run-tests)    RUN_TESTS=true; SKIP_TESTS=false; shift ;;
         -h|--help)
-            echo "Usage: $0 [--yes] [--values extra.yaml] [--skip-tests]"
+            echo "Usage: $0 [--yes] [--values extra.yaml] [--skip-tests] [--run-tests]"
             echo ""
             echo "Deploy Kafka to any Kubernetes cluster using auto-detected configuration."
             echo ""
@@ -38,6 +41,7 @@ while [[ $# -gt 0 ]]; do
             echo "  -y, --yes          Skip review prompt (non-interactive)"
             echo "  -f, --values FILE  Merge additional values overlay on top of detected values"
             echo "  --skip-tests       Skip Helm test after deployment"
+            echo "  --run-tests        Force Helm tests even when auto-skip would apply (e.g. Kind)"
             echo "  -h, --help         Show this help"
             exit 0
             ;;
@@ -83,6 +87,36 @@ if [ -n "${EXTRA_VALUES}" ]; then
         error "Extra values file not found: ${EXTRA_VALUES}"
         exit 1
     fi
+fi
+
+# Resolve environment/provider overlay automatically.
+# Priority: explicit ENV (from Makefile) -> detected provider.
+TARGET_ENV="${ENV:-}"
+if [ -z "${TARGET_ENV}" ]; then
+    TARGET_ENV=$(awk '/^# Provider:/{print $3; exit}' "${DETECTED_VALUES}" 2>/dev/null || true)
+fi
+
+if [ -n "${TARGET_ENV}" ]; then
+    if [ -f "${CHART_DIR}/values-${TARGET_ENV}.yaml" ]; then
+        AUTO_OVERLAY="${CHART_DIR}/values-${TARGET_ENV}.yaml"
+    elif [ "${TARGET_ENV}" = "kind" ] && [ -f "${CHART_DIR}/values-kind.yaml" ]; then
+        AUTO_OVERLAY="${CHART_DIR}/values-kind.yaml"
+    elif [ "${TARGET_ENV}" = "generic" ] && [ -f "${CHART_DIR}/values-generic.yaml" ]; then
+        AUTO_OVERLAY="${CHART_DIR}/values-generic.yaml"
+    fi
+fi
+
+if [ -n "${AUTO_OVERLAY}" ]; then
+    info "Auto overlay: ${AUTO_OVERLAY} (env/provider=${TARGET_ENV})"
+fi
+
+# In many corporate Kind setups, Helm test images from GHCR fail certificate
+# validation. Keep deployment green by skipping tests by default on Kind unless
+# explicitly forced with --run-tests.
+if [ "${TARGET_ENV}" = "kind" ] && [ "${SKIP_TESTS}" != true ] && [ "${RUN_TESTS}" != true ]; then
+    warn "Kind environment detected — skipping Helm tests by default"
+    warn "Use --run-tests to force Helm tests on Kind"
+    SKIP_TESTS=true
 fi
 
 if [ "${AUTO_APPROVE}" != true ]; then
@@ -160,6 +194,7 @@ done
 
 # Build values chain
 VALUES_ARGS=(-f "${DETECTED_VALUES}")
+[ -n "${AUTO_OVERLAY}" ] && VALUES_ARGS+=(-f "${AUTO_OVERLAY}")
 [ -n "${EXTRA_VALUES}" ] && VALUES_ARGS+=(-f "${EXTRA_VALUES}")
 
 info "  Release:    ${RELEASE_NAME}"

--- a/scripts/load-images-to-kind.sh
+++ b/scripts/load-images-to-kind.sh
@@ -18,19 +18,66 @@ bold "Loading Images into Kind Cluster"
 info "Platform: ${PLATFORM}"
 echo ""
 
+# Source proxy configuration if present (KEY=VALUE format).
+# This keeps behavior aligned with start-cluster.sh.
+if [ -f "${SCRIPT_DIR}/../proxy/proxy.conf" ]; then
+    info "Loading proxy configuration from proxy/proxy.conf"
+    set -a
+    source "${SCRIPT_DIR}/../proxy/proxy.conf"
+    set +a
+fi
+
+_first_non_empty() {
+    local first="${1:-}"
+    local second="${2:-}"
+    if [ -n "${first}" ]; then
+        echo "${first}"
+    else
+        echo "${second}"
+    fi
+}
+
+HTTP_PROXY_VALUE="$(_first_non_empty "${HTTP_PROXY:-}" "${http_proxy:-}")"
+HTTPS_PROXY_VALUE="$(_first_non_empty "${HTTPS_PROXY:-}" "${https_proxy:-}")"
+NO_PROXY_VALUE="$(_first_non_empty "${NO_PROXY:-}" "${no_proxy:-}")"
+
+DOCKER_EXEC_PROXY_ENV=()
+if [ -n "${HTTP_PROXY_VALUE}" ]; then
+    DOCKER_EXEC_PROXY_ENV+=(-e "HTTP_PROXY=${HTTP_PROXY_VALUE}" -e "http_proxy=${HTTP_PROXY_VALUE}")
+fi
+if [ -n "${HTTPS_PROXY_VALUE}" ]; then
+    DOCKER_EXEC_PROXY_ENV+=(-e "HTTPS_PROXY=${HTTPS_PROXY_VALUE}" -e "https_proxy=${HTTPS_PROXY_VALUE}")
+fi
+if [ -n "${NO_PROXY_VALUE}" ]; then
+    DOCKER_EXEC_PROXY_ENV+=(-e "NO_PROXY=${NO_PROXY_VALUE}" -e "no_proxy=${NO_PROXY_VALUE}")
+fi
+
+if [ ${#DOCKER_EXEC_PROXY_ENV[@]} -gt 0 ]; then
+    info "Proxy environment detected; forwarding proxy vars to Kind node pulls"
+fi
+
 TOTAL=0
 SKIPPED=0
 LOADED=0
 FAILED=0
 
 # Get all Kind node names
-NODES=($(kind get nodes --name "${KIND_CLUSTER_NAME}" 2>/dev/null))
+NODES=()
+while IFS= read -r node; do
+    [ -n "${node}" ] && NODES+=("${node}")
+done < <(kind get nodes --name "${KIND_CLUSTER_NAME}" 2>/dev/null)
 if [ ${#NODES[@]} -eq 0 ]; then
     error "No Kind nodes found for cluster '${KIND_CLUSTER_NAME}'"
     exit 1
 fi
 info "Nodes: ${NODES[*]}"
 echo ""
+
+_docker_exec_node() {
+    local node=$1
+    shift
+    docker exec "${DOCKER_EXEC_PROXY_ENV[@]}" "${node}" "$@"
+}
 
 # Check if image already present on the control-plane node
 _already_in_kind() {
@@ -44,11 +91,17 @@ _already_in_kind() {
 # Pull image into all Kind nodes via ctr
 _ctr_pull() {
     local image=$1
-    local plat_flag=$2   # e.g. "--platform linux/arm64" or ""
+    local platform=$2
     local all_ok=true
+    local pull_args=()
+
+    if [ -n "${platform}" ]; then
+        pull_args+=(--platform "${platform}")
+    fi
+
     for node in "${NODES[@]}"; do
-        if ! docker exec "${node}" ctr --namespace=k8s.io images pull \
-            ${plat_flag} "${image}" 2>&1; then
+        if ! _docker_exec_node "${node}" ctr --namespace=k8s.io images pull \
+            "${pull_args[@]}" "${image}" 2>&1; then
             all_ok=false
         fi
     done
@@ -67,7 +120,7 @@ load_image() {
     fi
 
     echo "  pulling into Kind nodes..."
-    if _ctr_pull "${image}" "--platform ${PLATFORM}"; then
+    if _ctr_pull "${image}" "${PLATFORM}"; then
         info "  ✓ loaded"
         LOADED=$((LOADED + 1))
     else
@@ -95,20 +148,20 @@ load_scarf_image() {
     fi
 
     echo "  pulling into Kind nodes (scarf.sh)..."
-    if _ctr_pull "${scarf_src}" "--platform ${PLATFORM}"; then
+    if _ctr_pull "${scarf_src}" "${PLATFORM}"; then
         # Tag scarf URL → canonical so both refs are available
         for node in "${NODES[@]}"; do
-            docker exec "${node}" ctr --namespace=k8s.io images tag \
+            _docker_exec_node "${node}" ctr --namespace=k8s.io images tag \
                 "${scarf_src}" "${canonical}" 2>/dev/null || true
         done
         info "  ✓ loaded (scarf)"
         LOADED=$((LOADED + 1))
     else
         echo "  → retrying via canonical: ${canonical}"
-        if _ctr_pull "${canonical}" "--platform ${PLATFORM}"; then
+        if _ctr_pull "${canonical}" "${PLATFORM}"; then
             # Tag canonical → scarf URL so pod image refs using the scarf URL also resolve
             for node in "${NODES[@]}"; do
-                docker exec "${node}" ctr --namespace=k8s.io images tag \
+                _docker_exec_node "${node}" ctr --namespace=k8s.io images tag \
                     "${canonical}" "${scarf_src}" 2>/dev/null || true
             done
             info "  ✓ loaded (via canonical)"

--- a/scripts/start-cluster.sh
+++ b/scripts/start-cluster.sh
@@ -6,8 +6,200 @@ source "${SCRIPT_DIR}/common.sh"
 
 require_cmd kind
 require_cmd kubectl
+require_cmd docker
+
+usage() {
+    cat <<'EOF'
+Usage: ./scripts/start-cluster.sh [options]
+
+Options:
+  --http-proxy URL    HTTP proxy URL (overrides env/proxy.conf)
+  --https-proxy URL   HTTPS proxy URL (overrides env/proxy.conf)
+  --no-proxy LIST     NO_PROXY value (overrides env/proxy.conf)
+  --proxy-ca-file P   PEM/CRT file to trust inside Kind nodes for proxy TLS
+  --clear-proxy       Remove managed containerd proxy config from Kind nodes
+  --clear-proxy-ca    Remove managed proxy CA from Kind nodes
+  -h, --help          Show this help
+EOF
+}
+
+HTTP_PROXY_ARG=""
+HTTPS_PROXY_ARG=""
+NO_PROXY_ARG=""
+PROXY_CA_FILE_ARG=""
+CLEAR_PROXY="false"
+CLEAR_PROXY_CA="false"
+HTTP_PROXY_FROM_FLAG="false"
+HTTPS_PROXY_FROM_FLAG="false"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --http-proxy)
+            [ $# -ge 2 ] || { error "Missing value for --http-proxy"; exit 1; }
+            HTTP_PROXY_ARG="$2"
+            HTTP_PROXY_FROM_FLAG="true"
+            shift 2
+            ;;
+        --https-proxy)
+            [ $# -ge 2 ] || { error "Missing value for --https-proxy"; exit 1; }
+            HTTPS_PROXY_ARG="$2"
+            HTTPS_PROXY_FROM_FLAG="true"
+            shift 2
+            ;;
+        --no-proxy)
+            [ $# -ge 2 ] || { error "Missing value for --no-proxy"; exit 1; }
+            NO_PROXY_ARG="$2"
+            shift 2
+            ;;
+        --proxy-ca-file)
+            [ $# -ge 2 ] || { error "Missing value for --proxy-ca-file"; exit 1; }
+            PROXY_CA_FILE_ARG="$2"
+            shift 2
+            ;;
+        --clear-proxy)
+            CLEAR_PROXY="true"
+            shift
+            ;;
+        --clear-proxy-ca)
+            CLEAR_PROXY_CA="true"
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            error "Unknown option: $1"
+            usage
+            exit 1
+            ;;
+    esac
+done
 
 info "Starting Kind Cluster Setup..."
+
+# Prefer uppercase proxy vars; fall back to lowercase if needed.
+first_non_empty() {
+    local first="${1:-}"
+    local second="${2:-}"
+    if [ -n "${first}" ]; then
+        echo "${first}"
+    else
+        echo "${second}"
+    fi
+}
+
+is_loopback_proxy_url() {
+    local proxy_url="${1:-}"
+    case "${proxy_url}" in
+        *"://localhost"*|*"://127.0.0.1"*|*"://[::1]"*|*"@localhost"*|*"@127.0.0.1"*|*"@[::1]"*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+rewrite_loopback_proxy_url_for_kind() {
+    local proxy_url="${1:-}"
+    local rewritten="${proxy_url}"
+    rewritten="${rewritten/:\/\/localhost/://host.docker.internal}"
+    rewritten="${rewritten/:\/\/127.0.0.1/://host.docker.internal}"
+    rewritten="${rewritten/:\/\/[::1]/://host.docker.internal}"
+    rewritten="${rewritten/@localhost/@host.docker.internal}"
+    rewritten="${rewritten/@127.0.0.1/@host.docker.internal}"
+    rewritten="${rewritten/@[::1]/@host.docker.internal}"
+    echo "${rewritten}"
+}
+
+resolve_path() {
+    local input="${1:-}"
+    if [ -z "${input}" ]; then
+        return 0
+    fi
+    if [ "${input#/}" != "${input}" ]; then
+        echo "${input}"
+    else
+        local dir
+        dir="$(cd "$(dirname "${input}")" && pwd)"
+        echo "${dir}/$(basename "${input}")"
+    fi
+}
+
+containerd_proxy_reconcile() {
+    local http_proxy_value="${1:-}"
+    local https_proxy_value="${2:-}"
+    local no_proxy_value="${3:-}"
+    local proxy_ca_file="${4:-}"
+    local clear_proxy_ca="${5:-false}"
+    local nodes=()
+
+    while IFS= read -r node; do
+        [ -n "${node}" ] && nodes+=("${node}")
+    done < <(kind get nodes --name "${KIND_CLUSTER_NAME}" 2>/dev/null)
+    if [ ${#nodes[@]} -eq 0 ]; then
+        warn "No Kind nodes found for proxy reconciliation"
+        return 0
+    fi
+
+    if [ -n "${http_proxy_value}" ] || [ -n "${https_proxy_value}" ]; then
+        info "Proxy detected; configuring containerd proxy on Kind nodes..."
+    else
+        info "No HTTP/HTTPS proxy configured; clearing containerd proxy vars on Kind nodes..."
+    fi
+
+    if [ "${clear_proxy_ca}" = "true" ]; then
+        info "Clearing managed proxy CA from Kind nodes..."
+    elif [ -n "${proxy_ca_file}" ]; then
+        info "Installing proxy CA into Kind nodes from ${proxy_ca_file}..."
+        for node in "${nodes[@]}"; do
+            docker cp "${proxy_ca_file}" "${node}:/root/kates-proxy-ca.crt"
+        done
+    fi
+
+    for node in "${nodes[@]}"; do
+        docker exec \
+            -e HTTP_PROXY="${http_proxy_value}" \
+            -e HTTPS_PROXY="${https_proxy_value}" \
+            -e NO_PROXY="${no_proxy_value}" \
+            -e CLEAR_PROXY_CA="${clear_proxy_ca}" \
+            "${node}" /bin/bash -lc '
+set -e
+dropin_dir="/etc/systemd/system/containerd.service.d"
+dropin_file="${dropin_dir}/10-kates-proxy.conf"
+tmp_file="${dropin_file}.tmp"
+managed_ca="/usr/local/share/ca-certificates/kates-proxy-ca.crt"
+staged_ca="/root/kates-proxy-ca.crt"
+mkdir -p "${dropin_dir}"
+{
+  echo "[Service]"
+  printf "Environment=\"HTTP_PROXY=%s\"\n" "${HTTP_PROXY:-}"
+  printf "Environment=\"http_proxy=%s\"\n" "${HTTP_PROXY:-}"
+  printf "Environment=\"HTTPS_PROXY=%s\"\n" "${HTTPS_PROXY:-}"
+  printf "Environment=\"https_proxy=%s\"\n" "${HTTPS_PROXY:-}"
+  printf "Environment=\"NO_PROXY=%s\"\n" "${NO_PROXY:-}"
+  printf "Environment=\"no_proxy=%s\"\n" "${NO_PROXY:-}"
+} > "${tmp_file}"
+mv "${tmp_file}" "${dropin_file}"
+
+if [ "${CLEAR_PROXY_CA:-false}" = "true" ]; then
+  rm -f "${staged_ca}"
+  if [ -f "${managed_ca}" ]; then
+    rm -f "${managed_ca}"
+    update-ca-certificates
+  fi
+elif [ -f "${staged_ca}" ]; then
+  mv "${staged_ca}" "${managed_ca}"
+  chmod 0644 "${managed_ca}"
+  update-ca-certificates
+fi
+
+systemctl daemon-reload
+systemctl restart containerd
+'
+    done
+}
 
 # Source proxy configuration if it exists
 if [ -f "${SCRIPT_DIR}/../proxy/proxy.conf" ]; then
@@ -15,6 +207,59 @@ if [ -f "${SCRIPT_DIR}/../proxy/proxy.conf" ]; then
     set -a
     source "${SCRIPT_DIR}/../proxy/proxy.conf"
     set +a
+fi
+
+HTTP_PROXY_VALUE="$(first_non_empty "${HTTP_PROXY:-}" "${http_proxy:-}")"
+HTTPS_PROXY_VALUE="$(first_non_empty "${HTTPS_PROXY:-}" "${https_proxy:-}")"
+NO_PROXY_VALUE="$(first_non_empty "${NO_PROXY:-}" "${no_proxy:-}")"
+PROXY_CA_FILE_VALUE="${PROXY_CA_FILE:-}"
+if [ -f "${SCRIPT_DIR}/../proxy/ca.crt" ] && [ -z "${PROXY_CA_FILE_VALUE}" ]; then
+    PROXY_CA_FILE_VALUE="${SCRIPT_DIR}/../proxy/ca.crt"
+fi
+if [ -f "${SCRIPT_DIR}/../proxy/ca.pem" ] && [ -z "${PROXY_CA_FILE_VALUE}" ]; then
+    PROXY_CA_FILE_VALUE="${SCRIPT_DIR}/../proxy/ca.pem"
+fi
+
+# CLI flags override environment/proxy.conf.
+HTTP_PROXY_VALUE="$(first_non_empty "${HTTP_PROXY_ARG}" "${HTTP_PROXY_VALUE}")"
+HTTPS_PROXY_VALUE="$(first_non_empty "${HTTPS_PROXY_ARG}" "${HTTPS_PROXY_VALUE}")"
+NO_PROXY_VALUE="$(first_non_empty "${NO_PROXY_ARG}" "${NO_PROXY_VALUE}")"
+PROXY_CA_FILE_VALUE="$(first_non_empty "${PROXY_CA_FILE_ARG}" "${PROXY_CA_FILE_VALUE}")"
+
+if [ -n "${PROXY_CA_FILE_VALUE}" ]; then
+    PROXY_CA_FILE_VALUE="$(resolve_path "${PROXY_CA_FILE_VALUE}")"
+    if [ ! -f "${PROXY_CA_FILE_VALUE}" ]; then
+        error "Proxy CA file not found: ${PROXY_CA_FILE_VALUE}"
+        exit 1
+    fi
+fi
+
+if [ "${HTTP_PROXY_FROM_FLAG}" != "true" ] && is_loopback_proxy_url "${HTTP_PROXY_VALUE}"; then
+    warn "Ignoring loopback HTTP_PROXY from environment/proxy.conf (${HTTP_PROXY_VALUE})"
+    warn "Pass --http-proxy explicitly if you really want a loopback proxy for Kind nodes"
+    HTTP_PROXY_VALUE=""
+elif [ "${HTTP_PROXY_FROM_FLAG}" = "true" ] && is_loopback_proxy_url "${HTTP_PROXY_VALUE}"; then
+    HTTP_PROXY_VALUE="$(rewrite_loopback_proxy_url_for_kind "${HTTP_PROXY_VALUE}")"
+    warn "Rewriting --http-proxy loopback host to '${HTTP_PROXY_VALUE}' for Kind node reachability"
+fi
+
+if [ "${HTTPS_PROXY_FROM_FLAG}" != "true" ] && is_loopback_proxy_url "${HTTPS_PROXY_VALUE}"; then
+    warn "Ignoring loopback HTTPS_PROXY from environment/proxy.conf (${HTTPS_PROXY_VALUE})"
+    warn "Pass --https-proxy explicitly if you really want a loopback proxy for Kind nodes"
+    HTTPS_PROXY_VALUE=""
+elif [ "${HTTPS_PROXY_FROM_FLAG}" = "true" ] && is_loopback_proxy_url "${HTTPS_PROXY_VALUE}"; then
+    HTTPS_PROXY_VALUE="$(rewrite_loopback_proxy_url_for_kind "${HTTPS_PROXY_VALUE}")"
+    warn "Rewriting --https-proxy loopback host to '${HTTPS_PROXY_VALUE}' for Kind node reachability"
+fi
+
+if [ "${CLEAR_PROXY}" = "true" ]; then
+    HTTP_PROXY_VALUE=""
+    HTTPS_PROXY_VALUE=""
+    NO_PROXY_VALUE=""
+fi
+
+if [ "${CLEAR_PROXY_CA}" = "true" ]; then
+    PROXY_CA_FILE_VALUE=""
 fi
 
 # Create cluster only if it doesn't exist; recover kubeconfig if stale
@@ -27,8 +272,19 @@ if kind get clusters 2>/dev/null | grep -q "^${KIND_CLUSTER_NAME}$"; then
     fi
 else
     info "Creating Kind cluster..."
-    kind create cluster --config "${SCRIPT_DIR}/../config/cluster.yaml" --name "${KIND_CLUSTER_NAME}"
+    if [ -n "${HTTP_PROXY_VALUE}" ] || [ -n "${HTTPS_PROXY_VALUE}" ] || [ -n "${NO_PROXY_VALUE}" ]; then
+        HTTP_PROXY="${HTTP_PROXY_VALUE}" \
+        HTTPS_PROXY="${HTTPS_PROXY_VALUE}" \
+        NO_PROXY="${NO_PROXY_VALUE}" \
+        kind create cluster --config "${SCRIPT_DIR}/../config/cluster.yaml" --name "${KIND_CLUSTER_NAME}"
+    else
+        kind create cluster --config "${SCRIPT_DIR}/../config/cluster.yaml" --name "${KIND_CLUSTER_NAME}"
+    fi
 fi
+
+containerd_proxy_reconcile "${HTTP_PROXY_VALUE}" "${HTTPS_PROXY_VALUE}" "${NO_PROXY_VALUE}" "${PROXY_CA_FILE_VALUE}" "${CLEAR_PROXY_CA}"
+kubectl wait --for=condition=Ready node --all --timeout=180s >/dev/null 2>&1 || \
+    warn "Node readiness check timed out after containerd proxy reconciliation"
 
 # Untaint control-plane node so Kafka pods can schedule on all AZ nodes
 # (Kind uses one of the 3 worker nodes as control-plane)


### PR DESCRIPTION
## Overview
This PR implements multiple critical security and operational enhancements to the Kates deployment and testing lifecycle. It hardens our NetworkPolicy setup, isolates testing components natively into Helm, and fixes CLI alignment issues.

## Detailed Changes

### 🛡️ Network Policy Hardening
- **Strimzi Operator Port Isolation**: NetworkPolicies are now configured to strictly allow only required egress/ingress ports for the Strimzi Operator (e.g., `9443` for admission webhooks, `8443` for metrics, and Kafka component ports), moving away from broader policies.
- **Dynamic Namespace Binding**: Added dynamic templating to support cross-chart namespace injection, ensuring components like Kafka Connect and Strimzi Operator can establish strict connections regardless of the namespaces they are deployed into.

### 🧪 Kafka Connect Test Isolation
- **Helm Test Migration**: The static example manifests inside `config/kafka-connect/` (Debezium Postgres Source, JDBC Sink, CDC Topics) have been safely migrated into `testConnectors: []` and `testTopics: []` in `connect-cluster/values.yaml`.
- **Automatic Cleanup**: A dedicated `helm test` suite for `connect-cluster` was established using `helm.sh/hook: test`. This ensures that example deployments automatically clean themselves up upon successful execution.
- **Tutorial Updates**: Documentation has been updated to use the new native `helm test` invocation instead of manually running `kubectl apply`.

### 🖥️ Kates CLI Improvements
- **Grid Alignment Fix**: Fixed an issue in the `kates deploy status` command where specific single-cell rendered emojis (`☸️`, `🛡️`, `🖥️`) caused grid misalignment on terminal emulators. The Go code now correctly measures visual width dynamically and pads single-cell emojis to two cells.

### ⚙️ Core Enhancements
- Expanded local deployment (`kind`) tooling and proxies for better developer experience with Kafka Connect workflows.
