### PR TITLE
Enhance Kafka Connect image with Debezium 3.6.0 and scripting support

### DIFF
--- a/Dockerfile.connect
+++ b/Dockerfile.connect
@@ -9,8 +9,9 @@ FROM quay.io/strimzi/kafka:1.0.0-kafka-4.2.0 AS base
 #
 FROM eclipse-temurin:21-jre-alpine AS download
 
-ARG DEBEZIUM_VERSION=3.0.2.Final
-ARG APICURIO_VERSION=2.5.11.Final
+ARG DEBEZIUM_VERSION=3.6.0.Final
+ARG APICURIO_VERSION=3.3.0
+ARG GROOVY_VERSION=5.0.7
 
 RUN apk add --no-cache curl tar
 
@@ -40,6 +41,18 @@ RUN mkdir -p debezium-sqlserver && \
     curl -sfL "https://repo1.maven.org/maven2/io/debezium/debezium-connector-sqlserver/${DEBEZIUM_VERSION}/debezium-connector-sqlserver-${DEBEZIUM_VERSION}-plugin.tar.gz" \
     | tar -xz -C debezium-sqlserver --strip-components=1
 
+# Oracle — CDC via Oracle LogMiner or XStream
+# Note: The Oracle JDBC driver (ojdbc11.jar) is not included due to licensing.
+# Users must provide it separately or download it at runtime.
+RUN mkdir -p debezium-oracle && \
+    curl -sfL "https://repo1.maven.org/maven2/io/debezium/debezium-connector-oracle/${DEBEZIUM_VERSION}/debezium-connector-oracle-${DEBEZIUM_VERSION}-plugin.tar.gz" \
+    | tar -xz -C debezium-oracle --strip-components=1
+
+# Db2 — CDC via IBM Db2 ASN capture
+RUN mkdir -p debezium-db2 && \
+    curl -sfL "https://repo1.maven.org/maven2/io/debezium/debezium-connector-db2/${DEBEZIUM_VERSION}/debezium-connector-db2-${DEBEZIUM_VERSION}-plugin.tar.gz" \
+    | tar -xz -C debezium-db2 --strip-components=1
+
 # JDBC Sink Connector — Write events to relational databases
 RUN mkdir -p debezium-jdbc && \
     curl -sfL "https://repo1.maven.org/maven2/io/debezium/debezium-connector-jdbc/${DEBEZIUM_VERSION}/debezium-connector-jdbc-${DEBEZIUM_VERSION}-plugin.tar.gz" \
@@ -51,17 +64,28 @@ RUN mkdir -p debezium-jdbc && \
 RUN mkdir -p apicurio-converter && \
     curl -sfL "https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-utils-converter/${APICURIO_VERSION}/apicurio-registry-utils-converter-${APICURIO_VERSION}.jar" \
     -o apicurio-converter/apicurio-registry-utils-converter.jar && \
-    curl -sfL "https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-serdes-avro-serde/${APICURIO_VERSION}/apicurio-registry-serdes-avro-serde-${APICURIO_VERSION}.jar" \
-    -o apicurio-converter/apicurio-registry-serdes-avro-serde.jar && \
-    curl -sfL "https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-serdes-jsonschema-serde/${APICURIO_VERSION}/apicurio-registry-serdes-jsonschema-serde-${APICURIO_VERSION}.jar" \
-    -o apicurio-converter/apicurio-registry-serdes-jsonschema-serde.jar && \
-    curl -sfL "https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-serdes-protobuf-serde/${APICURIO_VERSION}/apicurio-registry-serdes-protobuf-serde-${APICURIO_VERSION}.jar" \
-    -o apicurio-converter/apicurio-registry-serdes-protobuf-serde.jar
+    curl -sfL "https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-avro-serde-kafka/${APICURIO_VERSION}/apicurio-registry-avro-serde-kafka-${APICURIO_VERSION}.jar" \
+    -o apicurio-converter/apicurio-registry-avro-serde-kafka.jar && \
+    curl -sfL "https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-jsonschema-serde-kafka/${APICURIO_VERSION}/apicurio-registry-jsonschema-serde-kafka-${APICURIO_VERSION}.jar" \
+    -o apicurio-converter/apicurio-registry-jsonschema-serde-kafka.jar && \
+    curl -sfL "https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-protobuf-serde-kafka/${APICURIO_VERSION}/apicurio-registry-protobuf-serde-kafka-${APICURIO_VERSION}.jar" \
+    -o apicurio-converter/apicurio-registry-protobuf-serde-kafka.jar
+
+# Debezium Scripting SMT and Groovy JSR-223 Engine
+RUN mkdir -p debezium-scripting && \
+    curl -sfL "https://repo1.maven.org/maven2/io/debezium/debezium-scripting/${DEBEZIUM_VERSION}/debezium-scripting-${DEBEZIUM_VERSION}.tar.gz" \
+    | tar -xz -C debezium-scripting --strip-components=1 && \
+    curl -sfL "https://repo1.maven.org/maven2/org/apache/groovy/groovy/${GROOVY_VERSION}/groovy-${GROOVY_VERSION}.jar" \
+    -o debezium-scripting/groovy-${GROOVY_VERSION}.jar && \
+    curl -sfL "https://repo1.maven.org/maven2/org/apache/groovy/groovy-jsr223/${GROOVY_VERSION}/groovy-jsr223-${GROOVY_VERSION}.jar" \
+    -o debezium-scripting/groovy-jsr223-${GROOVY_VERSION}.jar && \
+    curl -sfL "https://repo1.maven.org/maven2/org/apache/groovy/groovy-json/${GROOVY_VERSION}/groovy-json-${GROOVY_VERSION}.jar" \
+    -o debezium-scripting/groovy-json-${GROOVY_VERSION}.jar
 
 # ─── Stage 2: Final production image ─────────────────────────────────────────
 FROM base
 
-ARG DEBEZIUM_VERSION=3.0.2.Final
+ARG DEBEZIUM_VERSION=3.1.3.Final
 
 USER root:root
 COPY --from=download /plugins/ /opt/kafka/plugins/
@@ -69,7 +93,7 @@ USER 1001
 
 # ─── OCI Image Labels (https://github.com/opencontainers/image-spec) ─────────
 LABEL org.opencontainers.image.title="connect"
-LABEL org.opencontainers.image.description="Enterprise Kafka Connect image with Debezium CDC (PostgreSQL, MySQL, MongoDB, SQL Server), Apicurio Schema Registry (Avro, JSON Schema, Protobuf), and Aiven JDBC connectors. Built on Strimzi Kafka 4.2.0."
+LABEL org.opencontainers.image.description="Enterprise Kafka Connect image with Debezium CDC (PostgreSQL, MySQL, MongoDB, SQL Server, Oracle, Db2), Apicurio Schema Registry (Avro, JSON Schema, Protobuf), and JDBC Sink. Built on Strimzi Kafka 4.2.0."
 LABEL org.opencontainers.image.source="https://github.com/bmscomp/kates"
 LABEL org.opencontainers.image.url="https://github.com/bmscomp/kates/pkgs/container/connect"
 LABEL org.opencontainers.image.documentation="https://github.com/bmscomp/kates/blob/main/docs/kafka-connect.md"

--- a/Makefile
+++ b/Makefile
@@ -264,26 +264,26 @@ tester-build:
 
 connect-build:
 	@echo "🔌 Building Kafka Connect image with enterprise plugins..."
-	@DBZ_VERSION=$$(grep '^ARG DEBEZIUM_VERSION=' Dockerfile.connect | cut -d= -f2); \
+	@DBZ_VERSION=$$(grep '^ARG DEBEZIUM_VERSION=' Dockerfile.connect | head -n1 | cut -d= -f2); \
 	TAG=$${DBZ_VERSION%.Final}; \
 	echo "  Debezium: $${DBZ_VERSION}  →  connect:$${TAG}"; \
 	docker build -t connect:$${TAG} -t connect:latest \
 		-t ghcr.io/bmscomp/connect:$${TAG} \
 		-t ghcr.io/bmscomp/connect:latest \
-		-f Dockerfile.connect .; \
+		-f Dockerfile.connect . && \
 	if kind get clusters 2>/dev/null | grep -q "$(CLUSTER_NAME)"; then \
 		echo "Loading into Kind cluster ($(CLUSTER_NAME))..."; \
 		kind load docker-image connect:$${TAG} --name $(CLUSTER_NAME); \
-	fi; \
-	echo "✅ connect:$${TAG} built successfully"; \
-	echo "   Plugins: debezium-postgres, debezium-mysql, debezium-mongodb, debezium-sqlserver, apicurio-converter, aiven-jdbc"
+	fi && \
+	echo "✅ connect:$${TAG} built successfully" && \
+	echo "   Plugins: debezium-postgres, debezium-mysql, debezium-mongodb, debezium-sqlserver, debezium-oracle, debezium-db2, apicurio-converter, debezium-jdbc, debezium-scripting"
 
 connect-push:
 	@echo "🚀 Pushing Kafka Connect image to $(REGISTRY)..."
-	@DBZ_VERSION=$$(grep '^ARG DEBEZIUM_VERSION=' Dockerfile.connect | cut -d= -f2); \
+	@DBZ_VERSION=$$(grep '^ARG DEBEZIUM_VERSION=' Dockerfile.connect | head -n1 | cut -d= -f2); \
 	TAG=$${DBZ_VERSION%.Final}; \
-	docker push $(REGISTRY)/connect:$${TAG}; \
-	docker push $(REGISTRY)/connect:latest; \
+	docker push $(REGISTRY)/connect:$${TAG} && \
+	docker push $(REGISTRY)/connect:latest && \
 	echo "✅ Pushed: $(REGISTRY)/connect:$${TAG}"
 
 REGISTRY ?= ghcr.io/bmscomp

--- a/charts/connect-cluster/Chart.yaml
+++ b/charts/connect-cluster/Chart.yaml
@@ -3,7 +3,7 @@ name: connect-cluster
 description: A Helm chart for deploying Strimzi Kafka Connect clusters
 type: application
 version: 1.0.1
-appVersion: "3.0.2"
+appVersion: "3.6.0"
 kubeVersion: ">=1.27.0-0"
 home: https://github.com/bmscomp/kates
 sources:

--- a/charts/connect-cluster/values.yaml
+++ b/charts/connect-cluster/values.yaml
@@ -20,7 +20,7 @@ testImages:
 # -- Number of Kafka Connect worker replicas
 replicas: 3
 # -- Kafka Connect image (leave empty to use Strimzi default)
-image: "ghcr.io/bmscomp/connect:3.0.2"
+image: "ghcr.io/bmscomp/connect:3.6.0"
 # -- Kafka version
 version: "4.2.0"
 # -- Group ID for the Connect cluster
@@ -196,21 +196,56 @@ livenessProbe:
 build: {}
   # output:
   #   type: docker
-  #   image: "ghcr.io/bmscomp/connect:"
+  #   image: "ghcr.io/bmscomp/connect:custom"
   #   pushSecret: my-registry-credentials
   # plugins:
-  #   - name: debezium-postgres
+  #   # --- Cloud Storage ---
+  #   - name: camel-s3-sink
+  #     artifacts:
+  #       - type: maven
+  #         group: org.apache.camel.kafkaconnector
+  #         artifact: camel-aws-s3-sink-kafka-connector
+  #         version: "4.8.3"
+  #
+  #   # --- Search / Analytics ---
+  #   - name: elasticsearch-sink
+  #     artifacts:
+  #       - type: maven
+  #         group: io.confluent
+  #         artifact: kafka-connect-elasticsearch
+  #         version: "14.1.0"
+  #
+  #   # --- Data Warehouse ---
+  #   - name: bigquery-sink
+  #     artifacts:
+  #       - type: maven
+  #         group: com.wepay.kcbq
+  #         artifact: kcbq-connector
+  #         version: "2.5.0"
+  #
+  #   # --- HTTP / Webhooks ---
+  #   - name: http-sink
+  #     artifacts:
+  #       - type: maven
+  #         group: io.aiven
+  #         artifact: aiven-kafka-connect-http
+  #         version: "0.6.0"
+  #
+  #   # --- JDBC (Aiven alternative) ---
+  #   - name: aiven-jdbc
+  #     artifacts:
+  #       - type: maven
+  #         group: io.aiven
+  #         artifact: jdbc-connector-for-apache-kafka
+  #         version: "6.11.1"
+  #
+  #   # --- Incubating Debezium ---
+  #   - name: debezium-vitess
   #     artifacts:
   #       - type: maven
   #         group: io.debezium
-  #         artifact: debezium-connector-postgres
-  #         version: 2.5.0.Final
-  #   - name: apicurio-converter
-  #     artifacts:
-  #       - type: maven
-  #         group: io.apicurio
-  #         artifact: apicurio-registry-distro-connect-converter
-  #         version: 2.6.5.Final
+  #         artifact: debezium-connector-vitess
+  #         version: "3.6.0.Final"
 
 # ── Metrics ─────────────────────────────────────────────────────────────────
 metricsConfig:

--- a/config/kafka-connect/kafka-connect.yaml
+++ b/config/kafka-connect/kafka-connect.yaml
@@ -23,14 +23,14 @@ spec:
   build:
     output:
       type: docker
-      image: ghcr.io/bmscomp/connect:3.0.2
+      image: ghcr.io/bmscomp/connect:3.6.0
     plugins:
       - name: debezium-postgres
         artifacts:
           - type: maven
             group: io.debezium
             artifact: debezium-connector-postgres
-            version: 3.1.1.Final
+            version: 3.6.0.Final
       - name: camel-s3-sink
         artifacts:
           - type: maven

--- a/docs/book/21-kafka-connect.md
+++ b/docs/book/21-kafka-connect.md
@@ -141,7 +141,7 @@ sequenceDiagram
 |---------|---------|---------|
 | `groupId` | `kates-connect-cluster` | All workers sharing this ID form a single cluster |
 | `replicas` | 3 (prod) / 1 (kind) | Number of worker pods |
-| `image` | `ghcr.io/bmscomp/connect:3.0.2` | Pre-built image with Debezium + Apicurio plugins |
+| `image` | `ghcr.io/bmscomp/connect:3.6.0` | Pre-built image with Debezium + Apicurio plugins |
 | `bootstrapServers` | `krafter-kafka-bootstrap:9093` | TLS-encrypted connection to Kafka |
 | `version` | 4.2.0 | Kafka protocol version |
 
@@ -241,16 +241,62 @@ When a connector fails, Strimzi will restart it up to `maxRestarts` times with e
 
 ### The Connect Image
 
-The pre-built Connect image (`ghcr.io/bmscomp/connect:3.0.2`) bundles the following plugins:
+The pre-built Connect image (`ghcr.io/bmscomp/connect:3.6.0`) bundles the following plugins:
 
 | Plugin | Version | Use Case |
 |--------|---------|----------|
-| Debezium PostgreSQL | 3.0.2.Final | WAL-based CDC from PostgreSQL |
-| Debezium MySQL | 3.0.2.Final | Binlog-based CDC from MySQL |
-| Debezium MongoDB | 3.0.2.Final | Change stream CDC from MongoDB |
-| Debezium SQL Server | 3.0.2.Final | Change Tracking CDC from SQL Server |
-| Apicurio Registry Converter | 2.5.11.Final | Schema Registry integration (Avro, JSON Schema, Protobuf) |
-| Aiven JDBC Connector | 6.12.0 | Poll-based source/sink for SQL databases |
+| Debezium PostgreSQL | 3.6.0.Final | WAL-based CDC from PostgreSQL |
+| Debezium MySQL | 3.6.0.Final | Binlog-based CDC from MySQL |
+| Debezium MongoDB | 3.6.0.Final | Change stream CDC from MongoDB |
+| Debezium SQL Server | 3.6.0.Final | Change Tracking CDC from SQL Server |
+| Debezium Oracle | 3.6.0.Final | CDC from Oracle LogMiner/XStream |
+| Debezium Db2 | 3.6.0.Final | CDC from IBM Db2 ASN capture |
+| Debezium Scripting | 3.6.0.Final | SMT for filtering and routing with Groovy 5 JSR-223 |
+| Apicurio Registry Converter | 3.3.0 | Schema Registry integration (Avro, JSON Schema, Protobuf) |
+| Debezium JDBC Sink | 3.6.0.Final | Upsert sink for SQL databases |
+
+### Extending the Image with Additional Plugins
+
+While the pre-built image contains the most common CDC connectors, you may need additional plugins (e.g., S3 Sink, Elasticsearch Sink). There are two ways to add plugins at runtime without rebuilding the Docker image:
+
+#### 1. Using Strimzi `spec.build` (Recommended)
+
+Strimzi can download plugins from Maven Central and build a new image automatically during operator reconciliation. Enable this in `values.yaml`:
+
+```yaml
+build:
+  output:
+    type: docker
+    image: "ghcr.io/bmscomp/connect:custom"
+    pushSecret: my-registry-credentials
+  plugins:
+    - name: camel-s3-sink
+      artifacts:
+        - type: maven
+          group: org.apache.camel.kafkaconnector
+          artifact: camel-aws-s3-sink-kafka-connector
+          version: "4.8.3"
+```
+
+#### 2. Using the Init Container Script
+
+For environments where Strimzi image builds aren't possible, use the provided plugin loader script as an init container to download JARs at pod startup:
+
+```yaml
+template:
+  pod:
+    metadata: {}
+    initContainers:
+      - name: plugin-loader
+        image: ghcr.io/bmscomp/connect:3.6.0
+        command: ["/bin/bash", "-c", "curl -sfL https://raw.githubusercontent.com/bmscomp/kates/main/scripts/connect-plugin-loader.sh | bash"]
+        env:
+          - name: EXTRA_PLUGINS
+            value: "org.apache.camel.kafkaconnector:camel-aws-s3-sink-kafka-connector:4.8.3"
+        volumeMounts:
+          - name: extra-plugins
+            mountPath: /plugins
+```
 
 ### PostgreSQL CDC Pipeline
 
@@ -1167,7 +1213,7 @@ helm rollback connect-cluster -n kafka
 # Or pin to previous image
 helm upgrade connect-cluster charts/connect-cluster \
   --namespace kafka --reuse-values \
-  --set image=ghcr.io/bmscomp/connect:3.0.2
+  --set image=ghcr.io/bmscomp/connect:3.6.0
 ```
 
 ::: {.callout-warning}
@@ -1325,8 +1371,8 @@ Fix the connector configs in `values.yaml` and re-run `helm upgrade`.
 |-----------|---------|-------|
 | Kafka Connect | 4.2.0 | Matches broker version |
 | Strimzi Operator | 1.0.0 | Manages KafkaConnect CR |
-| Debezium | 3.0.2.Final | CDC connectors for PostgreSQL, MySQL, MongoDB, SQL Server |
-| Apicurio Converter | 2.5.11.Final | Schema Registry integration |
-| Aiven JDBC | 6.12.0 | Apache 2.0 licensed JDBC connector |
-| Connect Image | `ghcr.io/bmscomp/connect:3.0.2` | Pre-built with all plugins |
+| Debezium | 3.6.0.Final | CDC connectors for PostgreSQL, MySQL, MongoDB, SQL Server, Oracle, Db2 |
+| Apicurio Converter | 3.3.0 | Schema Registry integration |
+| Debezium JDBC | 3.6.0.Final | Apache 2.0 licensed JDBC sink connector |
+| Connect Image | `ghcr.io/bmscomp/connect:3.6.0` | Pre-built with all plugins |
 | Helm Chart | 1.0.0 | `charts/connect-cluster` |

--- a/docs/kafka-connect.md
+++ b/docs/kafka-connect.md
@@ -8,7 +8,7 @@ Production-ready Kafka Connect image with pre-installed CDC, Schema Registry, an
 
 ```bash
 # Pull from GHCR
-docker pull ghcr.io/bmscomp/connect:3.0.2
+docker pull ghcr.io/bmscomp/connect:3.6.0
 
 # Or build locally
 make connect-build
@@ -35,12 +35,15 @@ make connect-build
 
 | Plugin | Version | Purpose |
 |--------|---------|---------|
-| **Debezium PostgreSQL** | 3.1.1.Final | CDC from PostgreSQL (logical replication) |
-| **Debezium MySQL** | 3.1.1.Final | CDC from MySQL/MariaDB (binlog) |
-| **Debezium MongoDB** | 3.1.1.Final | CDC from MongoDB (change streams) |
-| **Debezium SQL Server** | 3.1.1.Final | CDC from SQL Server (CT tables) |
-| **Apicurio Registry Converter** | 3.0.6 | Schema Registry integration (Avro, JSON Schema, Protobuf) |
-| **Confluent JDBC Connector** | 10.8.0 | Source/Sink for any JDBC-compatible database |
+| **Debezium PostgreSQL** | 3.6.0.Final | CDC from PostgreSQL (logical replication) |
+| **Debezium MySQL** | 3.6.0.Final | CDC from MySQL/MariaDB (binlog) |
+| **Debezium MongoDB** | 3.6.0.Final | CDC from MongoDB (change streams) |
+| **Debezium SQL Server** | 3.6.0.Final | CDC from SQL Server (CT tables) |
+| **Debezium Oracle** | 3.6.0.Final | CDC from Oracle (LogMiner/XStream) |
+| **Debezium Db2** | 3.6.0.Final | CDC from IBM Db2 (ASN capture) |
+| **Debezium Scripting** | 3.6.0.Final | SMT for filtering and routing with Groovy 5 JSR-223 |
+| **Apicurio Registry Converter** | 3.3.0 | Schema Registry integration (Avro, JSON Schema, Protobuf) |
+| **Debezium JDBC Sink** | 3.6.0.Final | Upsert sink for SQL databases |
 
 ## Building the Image
 

--- a/scripts/connect-plugin-loader.sh
+++ b/scripts/connect-plugin-loader.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# connect-plugin-loader.sh — Download additional Kafka Connect plugins at runtime.
+#
+# This script is designed to run as an init container in environments where
+# Strimzi's `spec.build` is not available. It downloads plugins from Maven Central
+# and extracts them to a shared volume mounted at /plugins.
+#
+# Usage:
+#   Set the EXTRA_PLUGINS environment variable to a comma-separated list of
+#   maven artifacts in the format: group:artifact:version
+#
+# Example:
+#   EXTRA_PLUGINS="org.apache.camel.kafkaconnector:camel-aws-s3-sink-kafka-connector:4.8.3,io.aiven:jdbc-connector-for-apache-kafka:6.11.1" ./scripts/connect-plugin-loader.sh
+
+set -euo pipefail
+
+PLUGIN_DIR="/plugins"
+MAVEN_REPO="https://repo1.maven.org/maven2"
+
+echo "=========================================================="
+echo " Starting Kafka Connect Runtime Plugin Loader"
+echo "=========================================================="
+
+if [[ -z "${EXTRA_PLUGINS:-}" ]]; then
+  echo "INFO: No EXTRA_PLUGINS environment variable set. Exiting."
+  exit 0
+fi
+
+# Ensure plugin directory exists
+mkdir -p "$PLUGIN_DIR"
+
+# Parse comma-separated list
+IFS=',' read -ra PLUGIN_LIST <<< "$EXTRA_PLUGINS"
+
+for plugin_def in "${PLUGIN_LIST[@]}"; do
+  # Parse group:artifact:version
+  IFS=':' read -r group artifact version <<< "$plugin_def"
+
+  if [[ -z "$group" || -z "$artifact" || -z "$version" ]]; then
+    echo "ERROR: Invalid plugin definition: '$plugin_def'. Must be group:artifact:version"
+    exit 1
+  fi
+
+  echo "----------------------------------------------------------"
+  echo "Processing plugin: $artifact ($version)"
+
+  # Convert group (e.g. io.debezium) to path (io/debezium)
+  group_path="${group//.//}"
+  
+  # Determine plugin format. Most Kafka Connect plugins use tar.gz or zip.
+  # We will check common formats.
+  base_url="${MAVEN_REPO}/${group_path}/${artifact}/${version}"
+  tar_url="${base_url}/${artifact}-${version}-plugin.tar.gz"
+  zip_url="${base_url}/${artifact}-${version}.zip"
+  jar_url="${base_url}/${artifact}-${version}.jar"
+
+  plugin_dest="${PLUGIN_DIR}/${artifact}"
+  mkdir -p "$plugin_dest"
+
+  # 1. Try plugin.tar.gz (Debezium standard)
+  if curl --output /dev/null --silent --head --fail "$tar_url"; then
+    echo "  Downloading: $tar_url"
+    curl -sfL "$tar_url" | tar -xz -C "$plugin_dest" --strip-components=1
+    echo "  Successfully installed to $plugin_dest"
+    continue
+  fi
+
+  # 2. Try .zip (Confluent standard)
+  if curl --output /dev/null --silent --head --fail "$zip_url"; then
+    echo "  Downloading: $zip_url"
+    tmp_zip="/tmp/${artifact}.zip"
+    curl -sfL -o "$tmp_zip" "$zip_url"
+    unzip -q -d "$plugin_dest" "$tmp_zip"
+    rm "$tmp_zip"
+    echo "  Successfully installed to $plugin_dest"
+    continue
+  fi
+
+  # 3. Try raw .jar (Simple plugins/converters)
+  if curl --output /dev/null --silent --head --fail "$jar_url"; then
+    echo "  Downloading: $jar_url"
+    curl -sfL -o "${plugin_dest}/${artifact}-${version}.jar" "$jar_url"
+    echo "  Successfully installed to $plugin_dest"
+    continue
+  fi
+
+  echo "ERROR: Could not find a valid tar.gz, zip, or jar for $plugin_def at $base_url"
+  exit 1
+done
+
+echo "=========================================================="
+echo " Plugin loading complete."
+echo " Contents of $PLUGIN_DIR:"
+ls -la "$PLUGIN_DIR"
+echo "=========================================================="


### PR DESCRIPTION
This pull request significantly enhances the Kafka Connect image by upgrading the Debezium core to the latest stable 3.6.0.Final version and Apicurio to 3.3.0. It integrates the officially supported Debezium JDBC sink, as well as the Oracle and Db2 CDC connectors. Furthermore, the Debezium Scripting module powered by Groovy 5 has been added to enable dynamic routing and message filtering on the fly via Single Message Transformations (SMTs). Finally, for deployments lacking native build capabilities, a runtime fallback plugin loader script has been introduced and documented, ensuring maximum compatibility across various Kubernetes clusters.
