### PR TITLE
Migrate Kafka UI to Kafbat v1.5.0 with Schema Registry and Connect integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all detect cluster monitoring deploy-all kafka kafka-deploy kafka-upgrade kafka-undeploy kafka-detect kafka-verify-policies kafka-deploy-auto kafka-deploy-generic ui test test-load test-stress test-spike test-endurance test-volume test-capacity destroy clean download-charts litmus litmus-generic litmus-undeploy litmus-test litmus-gameday kates kates-generic kates-prod kates-build kates-native kates-deploy kates-logs kates-undeploy kates-helm kates-helm-deploy kates-helm-upgrade kates-helm-undeploy kates-helm-test kates-secret cli-build cli-install cli-clean logs chaos-ui chaos-status chaos-helm-test chart-lint chart-package chart-push connect-chart-lint connect-chart-template connect-chart-package connect-chart-push connect-chart-test connect-chart-all connect-deploy connect-undeploy kafka-chart-test helm-test-all gameday jaeger kyverno kyverno-undeploy book-html book-pdf book-clean
+.PHONY: all detect cluster monitoring deploy-all kafka kafka-deploy kafka-upgrade kafka-undeploy kafka-detect kafka-verify-policies kafka-deploy-auto kafka-deploy-generic ui ui-deploy ui-upgrade ui-undeploy ui-chart-lint ui-chart-template test test-load test-stress test-spike test-endurance test-volume test-capacity destroy clean download-charts litmus litmus-generic litmus-undeploy litmus-test litmus-gameday kates kates-generic kates-prod kates-build kates-native kates-deploy kates-logs kates-undeploy kates-helm kates-helm-deploy kates-helm-upgrade kates-helm-undeploy kates-helm-test kates-secret cli-build cli-install cli-clean logs chaos-ui chaos-status chaos-helm-test chart-lint chart-package chart-push connect-chart-lint connect-chart-template connect-chart-package connect-chart-push connect-chart-test connect-chart-all connect-deploy connect-undeploy kafka-chart-test helm-test-all gameday jaeger kyverno kyverno-undeploy book-html book-pdf book-clean
 
 .DEFAULT_GOAL := help
 
@@ -144,10 +144,58 @@ ENV ?= kind
 # Deploy Kafka (shorthand for kafka-deploy)
 kafka: kafka-deploy
 
-# Deploy Kafka UI only
+# Deploy Kafka UI only (legacy script — applies raw manifests)
 ui:
-	@echo "🖥️ Deploying Kafka UI..."
+	@echo "🖥️ Deploying Kafka UI (raw manifests)..."
 	./scripts/deploy-kafka-ui.sh
+
+# ── Kafka UI Helm Chart ─────────────────────────────────────────────────────
+UI_CHART_DIR := charts/kafka-ui
+
+ui-chart-lint:
+	@echo "🔍 Linting Kafka UI chart..."
+	helm lint $(UI_CHART_DIR)
+	@echo "✅ Kafka UI chart lint passed"
+
+ui-chart-template:
+	@echo "📄 Rendering Kafka UI templates (ENV=$(ENV))..."
+	@OVERLAY=""; \
+	if [ -f "$(UI_CHART_DIR)/values-$(ENV).yaml" ]; then \
+		OVERLAY="-f $(UI_CHART_DIR)/values-$(ENV).yaml"; \
+	fi; \
+	helm template kafka-ui $(UI_CHART_DIR) \
+		--namespace kafka $$OVERLAY
+
+ui-deploy:
+	@echo "🖥️  Deploying Kafka UI via Helm (ENV=$(ENV))..."
+	@OVERLAY=""; \
+	if [ -f "$(UI_CHART_DIR)/values-$(ENV).yaml" ]; then \
+		OVERLAY="-f $(UI_CHART_DIR)/values-$(ENV).yaml"; \
+		echo "  Using overlay: values-$(ENV).yaml"; \
+	fi; \
+	helm upgrade --install kafka-ui $(UI_CHART_DIR) \
+		--namespace kafka --create-namespace \
+		$$OVERLAY \
+		--timeout 5m --wait
+	@echo "✅ Kafka UI deployed"
+
+ui-upgrade:
+	@echo "🔄 Upgrading Kafka UI (ENV=$(ENV))..."
+	@OVERLAY=""; \
+	if [ -f "$(UI_CHART_DIR)/values-$(ENV).yaml" ]; then \
+		OVERLAY="-f $(UI_CHART_DIR)/values-$(ENV).yaml"; \
+		echo "  Using overlay: values-$(ENV).yaml"; \
+	fi; \
+	helm upgrade kafka-ui $(UI_CHART_DIR) \
+		--namespace kafka --reuse-values \
+		$$OVERLAY \
+		--timeout 5m --wait
+	@echo "✅ Kafka UI upgraded"
+
+ui-undeploy:
+	@echo "🗑️  Removing Kafka UI..."
+	helm uninstall kafka-ui -n kafka 2>/dev/null || true
+	@echo "✅ Kafka UI removed"
 
 # Deploy Apicurio Registry
 apicurio:
@@ -878,7 +926,12 @@ help:
 	@echo "  kafka-deploy-generic-custom        - Generic + extra overlay (VALUES_FILE=...)"
 	@echo "  kafka-upgrade                      - Upgrade existing Kafka release (ENV=...)"
 	@echo "  kafka-undeploy                     - Remove Kafka Helm release + PVCs"
-	@echo "  ui                                 - Deploy Kafka UI"
+	@echo "  ui                                 - Deploy Kafka UI (raw manifests)"
+	@echo "  ui-deploy                          - Deploy Kafka UI via Helm (ENV=kind|dev|staging|prod)"
+	@echo "  ui-upgrade                         - Upgrade Kafka UI Helm release (ENV=...)"
+	@echo "  ui-undeploy                        - Remove Kafka UI Helm release"
+	@echo "  ui-chart-lint                      - Lint the kafka-ui chart"
+	@echo "  ui-chart-template                  - Render kafka-ui templates (ENV=...)"
 	@echo "  apicurio                           - Deploy Apicurio Registry"
 	@echo "  jaeger                             - Deploy Jaeger (distributed tracing)"
 	@echo "  kyverno                            - Deploy Kyverno policy engine"

--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -1,20 +1,21 @@
 apiVersion: v2
 name: kafka-ui
-description: A Helm chart for deploying Kafka UI with Strimzi SCRAM-SHA-512 authentication
+description: A Helm chart for deploying Kafka UI (Kafbat) with Strimzi SCRAM-SHA-512 authentication
 type: application
-version: 0.1.0
-appVersion: "v0.7.2"
+version: 0.2.0
+appVersion: "v1.5.0"
 kubeVersion: ">=1.27.0-0"
 home: https://github.com/bmscomp/kates
 sources:
   - https://github.com/bmscomp/kates
-  - https://github.com/provectus/kafka-ui
+  - https://github.com/kafbat/kafka-ui
 maintainers:
   - name: bmscomp
     url: https://github.com/bmscomp
 keywords:
   - kafka
   - kafka-ui
+  - kafbat
   - monitoring
   - strimzi
   - dashboard

--- a/charts/kafka-ui/README.md
+++ b/charts/kafka-ui/README.md
@@ -4,6 +4,95 @@ A Helm chart for deploying [Kafbat Kafka UI](https://github.com/kafbat/kafka-ui)
 
 > **Note** — This chart uses the actively maintained **Kafbat** fork (`ghcr.io/kafbat/kafka-ui`), which is the community continuation of the original Provectus Kafka UI. The old `provectuslabs/kafka-ui` image is deprecated and contains known security vulnerabilities.
 
+## Architecture
+
+The following diagram shows how Kafka UI integrates with the existing Kates platform components. Kafka UI acts as a unified observability layer, connecting to the Kafka brokers for topic and consumer group inspection, to Apicurio Schema Registry for schema visibility, and to Kafka Connect for connector management.
+
+```mermaid
+graph TB
+    subgraph Browser["Browser / Ingress"]
+        USER["👤 User"]
+    end
+
+    subgraph K8S["Kubernetes Cluster — kafka namespace"]
+        subgraph UI["Kafka UI Pod"]
+            KAFKAUI["Kafbat Kafka UI<br/>ghcr.io/kafbat/kafka-ui:v1.5.0"]
+        end
+
+        subgraph Strimzi["Strimzi Operator"]
+            EO["Entity Operator"]
+        end
+
+        subgraph Kafka["Kafka Cluster — krafter"]
+            B1["Broker α<br/>:9092 / :9093"]
+            B2["Broker γ<br/>:9092 / :9093"]
+            B3["Broker σ<br/>:9092 / :9093"]
+        end
+
+        subgraph Registry["Schema Registry"]
+            APICURIO["Apicurio Registry<br/>:8080/apis/ccompat/v7"]
+        end
+
+        subgraph Connect["Kafka Connect"]
+            CW["Connect Workers<br/>REST API :8083"]
+            subgraph Connectors["Connectors"]
+                CDC["Debezium CDC<br/>PostgreSQL · MySQL · MongoDB"]
+                JDBC["JDBC Sink"]
+            end
+        end
+
+        SECRET["Secret: kafka-ui<br/>SCRAM-SHA-512 password"]
+        KAFKAUSER["KafkaUser CR<br/>kafka-ui"]
+    end
+
+    USER -->|"HTTP :8080<br/>NodePort :30081"| KAFKAUI
+
+    KAFKAUI -->|"SASL_PLAINTEXT<br/>SCRAM-SHA-512<br/>:9092"| B1
+    KAFKAUI -->|":9092"| B2
+    KAFKAUI -->|":9092"| B3
+
+    KAFKAUI -->|"HTTP GET<br/>/apis/ccompat/v7"| APICURIO
+    KAFKAUI -->|"HTTP REST<br/>:8083"| CW
+
+    CW --> CDC
+    CW --> JDBC
+    CDC -->|"CDC events"| B1
+    JDBC -->|"Sink reads"| B2
+
+    APICURIO -->|"Schema storage"| B3
+
+    EO -->|"Creates"| SECRET
+    EO -->|"Manages"| KAFKAUSER
+    KAFKAUI -.->|"Mounts password"| SECRET
+
+    classDef kafka fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px
+    classDef ui fill:#e3f2fd,stroke:#1565c0,stroke-width:2px
+    classDef registry fill:#fff3e0,stroke:#e65100,stroke-width:2px
+    classDef connect fill:#fce4ec,stroke:#c62828,stroke-width:2px
+    classDef strimzi fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px
+    classDef user fill:#fffde7,stroke:#f9a825,stroke-width:2px
+    classDef secret fill:#eceff1,stroke:#546e7a,stroke-width:1px,stroke-dasharray: 5 5
+
+    class B1,B2,B3 kafka
+    class KAFKAUI ui
+    class APICURIO registry
+    class CW,CDC,JDBC connect
+    class EO strimzi
+    class USER user
+    class SECRET,KAFKAUSER secret
+```
+
+### Data Flow Summary
+
+| Connection | Protocol | Port | Purpose |
+|------------|----------|------|---------|
+| User → Kafka UI | HTTP | 8080 (NodePort 30081) | Web dashboard access |
+| Kafka UI → Kafka Brokers | SASL_PLAINTEXT / SASL_SSL | 9092 / 9093 | Topic browsing, consumer group monitoring, message inspection |
+| Kafka UI → Apicurio Registry | HTTP | 8080 | Schema listing, compatibility checks, schema content display |
+| Kafka UI → Kafka Connect | HTTP REST | 8083 | Connector CRUD, task status, restart operations |
+| Entity Operator → Secret | Internal | — | Auto-generates SCRAM-SHA-512 credentials from the KafkaUser CR |
+| Kafka UI → Secret | Volume mount | — | Reads the password for broker authentication |
+
 ## Prerequisites
 
 | Component | Required | Version |

--- a/charts/kafka-ui/README.md
+++ b/charts/kafka-ui/README.md
@@ -1,0 +1,262 @@
+# Kafka UI Helm Chart
+
+A Helm chart for deploying [Kafbat Kafka UI](https://github.com/kafbat/kafka-ui) on Kubernetes with first-class support for Strimzi-managed Kafka clusters, Apicurio Schema Registry, and Kafka Connect.
+
+> **Note** — This chart uses the actively maintained **Kafbat** fork (`ghcr.io/kafbat/kafka-ui`), which is the community continuation of the original Provectus Kafka UI. The old `provectuslabs/kafka-ui` image is deprecated and contains known security vulnerabilities.
+
+## Prerequisites
+
+| Component | Required | Version |
+|-----------|----------|---------|
+| Kubernetes | Yes | ≥ 1.27 |
+| Helm | Yes | ≥ 3.x |
+| Strimzi Kafka Operator | Yes | ≥ 0.40 |
+| A running Kafka cluster | Yes | Managed by Strimzi |
+| Apicurio Schema Registry | Optional | ≥ 3.x |
+| Kafka Connect (Strimzi) | Optional | ≥ 4.x |
+
+The chart expects a Strimzi `KafkaUser` with SCRAM-SHA-512 authentication. By default, the chart creates a `KafkaUser` named `kafka-ui` with read-only ACLs. If the `KafkaUser` is managed elsewhere (e.g., by the Kafka cluster chart), set `kafkaUser.enabled: false`.
+
+## Quick Start
+
+```bash
+# Install with default settings (connects to the "krafter" Kafka cluster)
+helm install kafka-ui charts/kafka-ui --namespace kafka
+
+# Install with the Kind (local development) profile
+helm install kafka-ui charts/kafka-ui \
+  -f charts/kafka-ui/values-kind.yaml \
+  --namespace kafka
+
+# Upgrade an existing release
+helm upgrade kafka-ui charts/kafka-ui \
+  -f charts/kafka-ui/values-kind.yaml \
+  --namespace kafka
+```
+
+## Image Configuration
+
+The container image is fully customizable. By default, the chart pulls `ghcr.io/kafbat/kafka-ui` with the tag matching the chart's `appVersion`.
+
+```yaml
+image:
+  repository: ghcr.io/kafbat/kafka-ui
+  tag: ""              # defaults to Chart.appVersion (v1.5.0)
+  pullPolicy: IfNotPresent
+  digest: ""           # set to "sha256:..." for digest-pinned deployments
+
+# For private registries
+imagePullSecrets:
+  - name: my-registry-credentials
+```
+
+When `image.digest` is set, it takes precedence over `image.tag` and the resulting image reference becomes `repository@sha256:...`.
+
+## Connecting to Kafka
+
+The chart auto-computes the Kafka bootstrap servers from the `kafka.clusterName` and the release namespace. You can override this behavior with an explicit bootstrap address.
+
+### Auto-Discovery (Default)
+
+```yaml
+kafka:
+  clusterName: "krafter"          # name of the Strimzi Kafka CR
+  # bootstrapServers is auto-computed as:
+  #   krafter-kafka-bootstrap.<namespace>.svc.cluster.local:9092
+```
+
+The chart selects port `9092` (SASL_PLAINTEXT) by default, or port `9093` (SASL_SSL) when TLS is enabled.
+
+### Explicit Bootstrap
+
+```yaml
+kafka:
+  bootstrapServers: "my-kafka-bootstrap.production.svc:9093"
+  tls:
+    enabled: true
+```
+
+### Authentication
+
+Kafka UI authenticates to the Kafka cluster using SCRAM-SHA-512. The chart creates a Strimzi `KafkaUser` resource, and the Strimzi Entity Operator generates a Kubernetes Secret containing the password. The Deployment mounts this Secret as an environment variable.
+
+```yaml
+kafkaUser:
+  enabled: true          # set to false if managed externally
+  name: "kafka-ui"       # name of the KafkaUser and its Secret
+  quotas:
+    producerByteRate: 1048576
+    consumerByteRate: 52428800
+    requestPercentage: 10
+  acls:                  # read-only by default
+    - resource:
+        type: topic
+        name: "*"
+        patternType: literal
+      operations: ["Describe", "Read"]
+    - resource:
+        type: group
+        name: "*"
+        patternType: literal
+      operations: ["Describe", "Read"]
+    - resource:
+        type: cluster
+      operations: ["Describe"]
+```
+
+## Integrating Apicurio Schema Registry
+
+When enabled, the Kafka UI displays schema information (Avro, JSON Schema, Protobuf) for each topic directly in the browser.
+
+```yaml
+schemaRegistry:
+  enabled: true
+  # Explicit URL to Apicurio's Confluent-compatible API
+  url: "http://apicurio-apicurio-registry.kafka.svc:8080/apis/ccompat/v7"
+```
+
+If `url` is left empty, the chart auto-computes it as `http://apicurio-apicurio-registry.<namespace>.svc.cluster.local:8080/apis/ccompat/v7`.
+
+For registries that require authentication:
+
+```yaml
+schemaRegistry:
+  enabled: true
+  url: "https://registry.example.com/apis/ccompat/v7"
+  auth:
+    enabled: true
+    username: "admin"
+    password: "secret"
+```
+
+## Integrating Kafka Connect
+
+When enabled, the Kafka UI shows the running connectors, their status, tasks, and configuration. You can also create and manage connectors directly from the web interface.
+
+```yaml
+kafkaConnect:
+  enabled: true
+  name: "connect-cluster"     # display name in the UI
+  # Explicit URL to the Kafka Connect REST API
+  url: "http://connect-cluster-connect-api.kafka.svc:8083"
+```
+
+If `url` is left empty, the chart auto-computes it as `http://connect-cluster-connect-api.<namespace>.svc.cluster.local:8083`.
+
+## Environment Profiles
+
+The chart ships with four value overlays for different environments. Use the `-f` flag to apply them on top of the base `values.yaml`.
+
+| Profile | File | Description |
+|---------|------|-------------|
+| **Kind** | `values-kind.yaml` | Local development on Kind clusters. NodePort on 30081, Schema Registry + Connect enabled, lower resources, startup probe. |
+| **Dev** | `values-dev.yaml` | Development/staging clusters. Schema Registry + Connect enabled, startup probe, lower resources. |
+| **Prod** | `values-prod.yaml` | Production. 2 replicas, TLS enabled, Ingress with nginx, LOGIN_FORM auth, Schema Registry + Connect enabled. |
+| **Generic** | `values-generic.yaml` | Minimal — disables NetworkPolicy for clusters without a CNI that supports it. |
+
+### Example: Full Local Stack
+
+```bash
+helm install kafka-ui charts/kafka-ui \
+  -f charts/kafka-ui/values-kind.yaml \
+  --namespace kafka
+```
+
+This deploys Kafka UI with:
+- NodePort on `30081` for browser access
+- Schema Registry pointing to the local Apicurio instance
+- Kafka Connect pointing to the local `connect-cluster`
+- Startup probe for slow-starting Kind environments
+- Reduced resource requests (100m CPU, 256Mi memory)
+
+### Example: Production
+
+```bash
+helm install kafka-ui charts/kafka-ui \
+  -f charts/kafka-ui/values-prod.yaml \
+  --namespace kafka \
+  --set kafka.tls.enabled=true \
+  --set ingress.hosts[0].host=kafka-ui.mycompany.com
+```
+
+## Accessing the UI
+
+The access method depends on the `service.type`:
+
+```bash
+# NodePort (Kind / dev)
+export NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+echo "http://${NODE_IP}:30081"
+
+# ClusterIP (port-forward)
+kubectl port-forward svc/kafka-ui 8080:8080 -n kafka
+echo "http://localhost:8080"
+
+# Ingress (production)
+echo "https://kafka-ui.mycompany.com"
+```
+
+## Parameters Reference
+
+### Image
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `image.repository` | `ghcr.io/kafbat/kafka-ui` | Container image repository |
+| `image.tag` | `""` (Chart.appVersion) | Image tag |
+| `image.pullPolicy` | `IfNotPresent` | Image pull policy |
+| `image.digest` | `""` | Image digest (overrides tag) |
+| `imagePullSecrets` | `[]` | Registry pull secrets |
+
+### Kafka
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `kafka.clusterName` | `krafter` | Strimzi Kafka CR name |
+| `kafka.namespace` | `""` (release namespace) | Kafka cluster namespace |
+| `kafka.bootstrapServers` | `""` (auto-computed) | Bootstrap servers override |
+| `kafka.clusterDomain` | `cluster.local` | Kubernetes cluster domain |
+| `kafka.tls.enabled` | `false` | Enable TLS (port 9093) |
+
+### Schema Registry
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `schemaRegistry.enabled` | `false` | Enable Schema Registry integration |
+| `schemaRegistry.url` | `""` (auto-computed) | Schema Registry URL |
+| `schemaRegistry.auth.enabled` | `false` | Enable authentication |
+| `schemaRegistry.auth.username` | `""` | Auth username |
+| `schemaRegistry.auth.password` | `""` | Auth password |
+
+### Kafka Connect
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `kafkaConnect.enabled` | `false` | Enable Kafka Connect integration |
+| `kafkaConnect.name` | `connect-cluster` | Display name in the UI |
+| `kafkaConnect.url` | `""` (auto-computed) | Connect REST API URL |
+
+### Service
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `service.type` | `ClusterIP` | Service type |
+| `service.port` | `8080` | Service port |
+| `service.nodePort` | `""` | NodePort number (when type is NodePort) |
+
+### Resources
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `resources.requests.cpu` | `250m` | CPU request |
+| `resources.requests.memory` | `512Mi` | Memory request |
+| `resources.limits.cpu` | `1000m` | CPU limit |
+| `resources.limits.memory` | `2Gi` | Memory limit |
+
+## Uninstalling
+
+```bash
+helm uninstall kafka-ui --namespace kafka
+```
+
+The `KafkaUser` resource has a `helm.sh/resource-policy: keep` annotation, so the Strimzi-managed Secret will persist after uninstall to avoid disrupting other consumers.

--- a/charts/kafka-ui/README.md
+++ b/charts/kafka-ui/README.md
@@ -9,77 +9,44 @@ A Helm chart for deploying [Kafbat Kafka UI](https://github.com/kafbat/kafka-ui)
 The following diagram shows how Kafka UI integrates with the existing Kates platform components. Kafka UI acts as a unified observability layer, connecting to the Kafka brokers for topic and consumer group inspection, to Apicurio Schema Registry for schema visibility, and to Kafka Connect for connector management.
 
 ```mermaid
-graph TB
-    subgraph Browser["Browser / Ingress"]
-        USER["👤 User"]
+flowchart LR
+    USER(["👤 User<br/>Browser"])
+
+    USER -- "HTTP :8080 · NodePort :30081" --> KAFKAUI
+
+    subgraph KAFKA_NS["kafka namespace"]
+        direction TB
+
+        KAFKAUI["🖥️ Kafka UI<br/>kafbat/kafka-ui:v1.5.0"]
+
+        KAFKAUI -- "SCRAM-SHA-512<br/>:9092 · :9093" --> BROKERS
+        KAFKAUI -- "HTTP :8080<br/>/apis/ccompat/v7" --> APICURIO
+        KAFKAUI -- "REST :8083" --> CONNECT
+
+        BROKERS["🟢 Kafka Brokers<br/>α · γ · σ<br/>krafter-kafka-bootstrap"]
+
+        APICURIO["🟠 Apicurio Registry<br/>Schema Registry<br/>Avro · JSON Schema · Protobuf"]
+
+        CONNECT["🔴 Kafka Connect<br/>REST API :8083<br/>Debezium CDC · JDBC Sink"]
+
+        CONNECT -- "produce / consume" --> BROKERS
+        APICURIO -- "schema storage" --> BROKERS
+
+        SECRET[/"🔑 Secret: kafka-ui<br/>SCRAM-SHA-512"/]
+        EO["🟣 Entity Operator<br/>Strimzi"]
+
+        EO -. "creates" .-> SECRET
+        SECRET -. "mounts password" .-> KAFKAUI
     end
 
-    subgraph K8S["Kubernetes Cluster — kafka namespace"]
-        subgraph UI["Kafka UI Pod"]
-            KAFKAUI["Kafbat Kafka UI<br/>ghcr.io/kafbat/kafka-ui:v1.5.0"]
-        end
-
-        subgraph Strimzi["Strimzi Operator"]
-            EO["Entity Operator"]
-        end
-
-        subgraph Kafka["Kafka Cluster — krafter"]
-            B1["Broker α<br/>:9092 / :9093"]
-            B2["Broker γ<br/>:9092 / :9093"]
-            B3["Broker σ<br/>:9092 / :9093"]
-        end
-
-        subgraph Registry["Schema Registry"]
-            APICURIO["Apicurio Registry<br/>:8080/apis/ccompat/v7"]
-        end
-
-        subgraph Connect["Kafka Connect"]
-            CW["Connect Workers<br/>REST API :8083"]
-            subgraph Connectors["Connectors"]
-                CDC["Debezium CDC<br/>PostgreSQL · MySQL · MongoDB"]
-                JDBC["JDBC Sink"]
-            end
-        end
-
-        SECRET["Secret: kafka-ui<br/>SCRAM-SHA-512 password"]
-        KAFKAUSER["KafkaUser CR<br/>kafka-ui"]
-    end
-
-    USER -->|"HTTP :8080<br/>NodePort :30081"| KAFKAUI
-
-    KAFKAUI -->|"SASL_PLAINTEXT<br/>SCRAM-SHA-512<br/>:9092"| B1
-    KAFKAUI -->|":9092"| B2
-    KAFKAUI -->|":9092"| B3
-
-    KAFKAUI -->|"HTTP GET<br/>/apis/ccompat/v7"| APICURIO
-    KAFKAUI -->|"HTTP REST<br/>:8083"| CW
-
-    CW --> CDC
-    CW --> JDBC
-    CDC -->|"CDC events"| B1
-    JDBC -->|"Sink reads"| B2
-
-    APICURIO -->|"Schema storage"| B3
-
-    EO -->|"Creates"| SECRET
-    EO -->|"Manages"| KAFKAUSER
-    KAFKAUI -.->|"Mounts password"| SECRET
-
-    classDef kafka fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px
-    classDef ui fill:#e3f2fd,stroke:#1565c0,stroke-width:2px
-    classDef registry fill:#fff3e0,stroke:#e65100,stroke-width:2px
-    classDef connect fill:#fce4ec,stroke:#c62828,stroke-width:2px
-    classDef strimzi fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px
-    classDef user fill:#fffde7,stroke:#f9a825,stroke-width:2px
-    classDef secret fill:#eceff1,stroke:#546e7a,stroke-width:1px,stroke-dasharray: 5 5
-
-    class B1,B2,B3 kafka
-    class KAFKAUI ui
-    class APICURIO registry
-    class CW,CDC,JDBC connect
-    class EO strimzi
-    class USER user
-    class SECRET,KAFKAUSER secret
+    style KAFKAUI fill:#e3f2fd,stroke:#1565c0,stroke-width:2px,color:#0d47a1
+    style BROKERS fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px,color:#1b5e20
+    style APICURIO fill:#fff3e0,stroke:#e65100,stroke-width:2px,color:#bf360c
+    style CONNECT fill:#fce4ec,stroke:#c62828,stroke-width:2px,color:#b71c1c
+    style EO fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px,color:#4a148c
+    style SECRET fill:#eceff1,stroke:#546e7a,stroke-width:1px,stroke-dasharray: 5 5,color:#37474f
+    style USER fill:#fffde7,stroke:#f9a825,stroke-width:2px,color:#f57f17
+    style KAFKA_NS fill:#fafafa,stroke:#bdbdbd,stroke-width:1px
 ```
 
 ### Data Flow Summary
@@ -92,6 +59,7 @@ graph TB
 | Kafka UI → Kafka Connect | HTTP REST | 8083 | Connector CRUD, task status, restart operations |
 | Entity Operator → Secret | Internal | — | Auto-generates SCRAM-SHA-512 credentials from the KafkaUser CR |
 | Kafka UI → Secret | Volume mount | — | Reads the password for broker authentication |
+
 
 ## Prerequisites
 

--- a/charts/kafka-ui/README.md
+++ b/charts/kafka-ui/README.md
@@ -6,37 +6,55 @@ A Helm chart for deploying [Kafbat Kafka UI](https://github.com/kafbat/kafka-ui)
 
 ## Architecture
 
-The following diagram shows how Kafka UI integrates with the existing Kates platform components. Kafka UI acts as a unified observability layer, connecting to the Kafka brokers for topic and consumer group inspection, to Apicurio Schema Registry for schema visibility, and to Kafka Connect for connector management.
+Kafka UI serves as the central observability and management dashboard for the entire Kates streaming platform. Rather than requiring operators to interact with each component individually through CLI tools or raw API calls, Kafka UI provides a single web interface that aggregates information from three core backend services — the Kafka brokers, the Apicurio Schema Registry, and the Kafka Connect cluster — into one unified view.
+
+### How the Components Fit Together
+
+**Kafka Brokers** are the heart of the platform. They store and replicate all event streams across the three-node `krafter` cluster (brokers α, γ, and σ). Kafka UI connects to the brokers using the `krafter-kafka-bootstrap` service, which load-balances across all broker instances. Authentication is handled via SCRAM-SHA-512 — a challenge-response mechanism where the UI presents a username and password without transmitting the password in plain text over the wire. The credentials are managed entirely by the Strimzi Entity Operator, which watches a `KafkaUser` custom resource and automatically generates a Kubernetes Secret containing the SCRAM credentials.
+
+**Apicurio Schema Registry** acts as the schema governance layer. When producers serialize messages using Avro, JSON Schema, or Protobuf, they register schemas with Apicurio. Kafka UI connects to Apicurio through its Confluent-compatible REST API (`/apis/ccompat/v7`), which allows the UI to display registered schemas, their versions, compatibility rules, and the decoded structure of messages directly alongside the topic data. Apicurio itself stores its schema data in internal Kafka topics on the same broker cluster.
+
+**Kafka Connect** provides the data integration layer. The Connect workers run Debezium CDC connectors (PostgreSQL, MySQL, MongoDB, SQL Server, Oracle, Db2) and sink connectors (JDBC Sink) that move data between external databases and Kafka topics. Kafka UI communicates with Connect through its REST API on port 8083, allowing operators to create, configure, pause, resume, and restart connectors and their individual tasks directly from the browser without needing `curl` commands.
+
+**Strimzi Entity Operator** is the automated credential manager. When the Helm chart creates a `KafkaUser` custom resource with `authentication.type: scram-sha-512`, the Entity Operator detects this resource, registers the user in the Kafka cluster's credential store, and creates a Kubernetes Secret containing the generated password. The Kafka UI Deployment mounts this Secret as an environment variable, completing the authentication chain without any manual password management.
+
+**NetworkPolicy** controls all traffic flowing in and out of the Kafka UI pod. It enforces a zero-trust model where only explicitly allowed connections succeed — browser traffic from the ingress controller, SASL connections to the brokers, HTTP calls to Apicurio and Connect, DNS resolution, and Kubernetes API access for Secret reads. All other traffic is denied by default.
 
 ```mermaid
 flowchart LR
     USER(["👤 User<br/>Browser"])
 
-    USER -- "HTTP :8080 · NodePort :30081" --> KAFKAUI
+    USER -- "HTTP :8080<br/>NodePort :30081<br/>or Ingress" --> KAFKAUI
 
-    subgraph KAFKA_NS["kafka namespace"]
+    subgraph KAFKA_NS["Kubernetes · kafka namespace"]
         direction TB
 
-        KAFKAUI["🖥️ Kafka UI<br/>kafbat/kafka-ui:v1.5.0"]
+        KAFKAUI["🖥️ Kafka UI<br/>kafbat/kafka-ui:v1.5.0<br/>Web Dashboard"]
 
-        KAFKAUI -- "SCRAM-SHA-512<br/>:9092 · :9093" --> BROKERS
-        KAFKAUI -- "HTTP :8080<br/>/apis/ccompat/v7" --> APICURIO
-        KAFKAUI -- "REST :8083" --> CONNECT
+        KAFKAUI -- "SCRAM-SHA-512<br/>SASL_PLAINTEXT :9092<br/>SASL_SSL :9093" --> BROKERS
+        KAFKAUI -- "HTTP :8080<br/>/apis/ccompat/v7<br/>Schema listing" --> APICURIO
+        KAFKAUI -- "HTTP REST :8083<br/>Connector CRUD<br/>Task management" --> CONNECT
 
-        BROKERS["🟢 Kafka Brokers<br/>α · γ · σ<br/>krafter-kafka-bootstrap"]
+        BROKERS["🟢 Kafka Brokers<br/>α · γ · σ<br/>krafter-kafka-bootstrap<br/>Topics · Partitions · Consumer Groups"]
 
-        APICURIO["🟠 Apicurio Registry<br/>Schema Registry<br/>Avro · JSON Schema · Protobuf"]
+        APICURIO["🟠 Apicurio Registry<br/>Schema Registry<br/>Avro · JSON Schema · Protobuf<br/>Confluent-compatible API v7"]
 
-        CONNECT["🔴 Kafka Connect<br/>REST API :8083<br/>Debezium CDC · JDBC Sink"]
+        CONNECT["🔴 Kafka Connect<br/>REST API :8083<br/>Debezium 3.6.0 CDC<br/>PostgreSQL · MySQL · MongoDB<br/>Oracle · SQL Server · Db2<br/>JDBC Sink · Scripting SMT"]
 
-        CONNECT -- "produce / consume" --> BROKERS
-        APICURIO -- "schema storage" --> BROKERS
+        CONNECT -- "CDC events /<br/>Sink reads" --> BROKERS
+        APICURIO -- "Schema storage<br/>in Kafka topics" --> BROKERS
 
-        SECRET[/"🔑 Secret: kafka-ui<br/>SCRAM-SHA-512"/]
-        EO["🟣 Entity Operator<br/>Strimzi"]
+        CONNECT --- DB[("🗄️ Databases<br/>PostgreSQL · MySQL<br/>Oracle · MongoDB")]
 
-        EO -. "creates" .-> SECRET
-        SECRET -. "mounts password" .-> KAFKAUI
+        SECRET[/"🔑 Secret: kafka-ui<br/>SCRAM-SHA-512 password<br/>Auto-generated by Strimzi"/]
+        KAFKAUSER[/"📋 KafkaUser CR<br/>kafka-ui<br/>Read-only ACLs"/]
+        EO["🟣 Entity Operator<br/>Strimzi<br/>Credential lifecycle"]
+        NETPOL{{"🛡️ NetworkPolicy<br/>Ingress + Egress rules<br/>Zero-trust enforcement"}}
+
+        EO -. "watches CR &<br/>creates Secret" .-> SECRET
+        EO -. "manages" .-> KAFKAUSER
+        SECRET -. "env mount<br/>KAFKA_UI_PASSWORD" .-> KAFKAUI
+        NETPOL -. "enforces traffic<br/>policies on" .-> KAFKAUI
     end
 
     style KAFKAUI fill:#e3f2fd,stroke:#1565c0,stroke-width:2px,color:#0d47a1
@@ -45,20 +63,27 @@ flowchart LR
     style CONNECT fill:#fce4ec,stroke:#c62828,stroke-width:2px,color:#b71c1c
     style EO fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px,color:#4a148c
     style SECRET fill:#eceff1,stroke:#546e7a,stroke-width:1px,stroke-dasharray: 5 5,color:#37474f
+    style KAFKAUSER fill:#eceff1,stroke:#546e7a,stroke-width:1px,stroke-dasharray: 5 5,color:#37474f
     style USER fill:#fffde7,stroke:#f9a825,stroke-width:2px,color:#f57f17
+    style DB fill:#efebe9,stroke:#4e342e,stroke-width:2px,color:#3e2723
+    style NETPOL fill:#e8eaf6,stroke:#283593,stroke-width:1px,stroke-dasharray: 3 3,color:#1a237e
     style KAFKA_NS fill:#fafafa,stroke:#bdbdbd,stroke-width:1px
 ```
 
 ### Data Flow Summary
 
-| Connection | Protocol | Port | Purpose |
-|------------|----------|------|---------|
-| User → Kafka UI | HTTP | 8080 (NodePort 30081) | Web dashboard access |
-| Kafka UI → Kafka Brokers | SASL_PLAINTEXT / SASL_SSL | 9092 / 9093 | Topic browsing, consumer group monitoring, message inspection |
-| Kafka UI → Apicurio Registry | HTTP | 8080 | Schema listing, compatibility checks, schema content display |
-| Kafka UI → Kafka Connect | HTTP REST | 8083 | Connector CRUD, task status, restart operations |
-| Entity Operator → Secret | Internal | — | Auto-generates SCRAM-SHA-512 credentials from the KafkaUser CR |
-| Kafka UI → Secret | Volume mount | — | Reads the password for broker authentication |
+| # | Connection | Protocol | Port | Direction | Purpose |
+|---|------------|----------|------|-----------|---------|
+| 1 | User → Kafka UI | HTTP | 8080 / NodePort 30081 | Inbound | Web dashboard access from browser or Ingress controller |
+| 2 | Kafka UI → Kafka Brokers | SASL_PLAINTEXT or SASL_SSL | 9092 / 9093 | Outbound | Topic browsing, partition inspection, consumer group monitoring, message sampling |
+| 3 | Kafka UI → Apicurio Registry | HTTP GET | 8080 | Outbound | Schema listing, version history, compatibility checks, decoded message structure |
+| 4 | Kafka UI → Kafka Connect | HTTP REST | 8083 | Outbound | Connector creation, configuration, status monitoring, task restart, pause/resume |
+| 5 | Kafka Connect → Brokers | Kafka protocol | 9092 / 9093 | Internal | CDC event production and sink consumption |
+| 6 | Kafka Connect → Databases | JDBC / CDC protocol | Various | Outbound | Source CDC capture and sink writes to external databases |
+| 7 | Apicurio → Brokers | Kafka protocol | 9092 | Internal | Schema metadata stored in internal Kafka topics |
+| 8 | Entity Operator → Secret | Kubernetes API | 443 | Internal | Auto-generates SCRAM-SHA-512 credentials from the KafkaUser CR |
+| 9 | Secret → Kafka UI | Volume mount | — | Internal | Injects the broker password as the `KAFKA_UI_PASSWORD` environment variable |
+| 10 | NetworkPolicy → Kafka UI | — | — | Enforcement | Restricts ingress to port 8080 and egress to brokers, registry, connect, DNS, and K8s API |
 
 
 ## Prerequisites
@@ -90,6 +115,64 @@ helm upgrade kafka-ui charts/kafka-ui \
   -f charts/kafka-ui/values-kind.yaml \
   --namespace kafka
 ```
+
+## Makefile Commands
+
+The project root `Makefile` provides shorthand targets for managing the Kafka UI chart without having to remember the full `helm` commands. These targets automatically detect and apply the correct environment overlay based on the `ENV` variable.
+
+### Available Targets
+
+| Command | Description |
+|---------|-------------|
+| `make ui-deploy` | Install or upgrade Kafka UI using the Helm chart. Automatically selects the `values-<ENV>.yaml` overlay when it exists. |
+| `make ui-upgrade` | Upgrade an existing Kafka UI release while preserving user-supplied values (`--reuse-values`). Useful for rolling out configuration changes without respecifying all overrides. |
+| `make ui-undeploy` | Remove the Kafka UI Helm release from the cluster. The `KafkaUser` Secret is preserved thanks to the `helm.sh/resource-policy: keep` annotation. |
+| `make ui-chart-lint` | Run `helm lint` against the chart to catch template errors, missing values, and YAML formatting issues before deploying. |
+| `make ui-chart-template` | Render the chart templates locally without deploying. Outputs the full Kubernetes manifests to stdout so you can review exactly what will be applied. Respects the `ENV` overlay. |
+| `make ui` | Legacy target — applies the raw `config/kafka-ui/kafka-ui.yaml` manifests via `kubectl apply`. Provided for backward compatibility; prefer `make ui-deploy` for new deployments. |
+
+### Environment Selection
+
+All Helm-based targets respect the `ENV` variable (defaults to `kind`). The Makefile looks for a matching `values-<ENV>.yaml` file in the chart directory and applies it as an overlay on top of the base `values.yaml`:
+
+```bash
+# Deploy using the Kind profile (default)
+make ui-deploy
+
+# Deploy using the dev profile
+make ui-deploy ENV=dev
+
+# Deploy using the production profile
+make ui-deploy ENV=prod
+```
+
+### How It Works
+
+Each target follows the same pattern:
+
+1. **Overlay detection** — The Makefile checks whether `charts/kafka-ui/values-<ENV>.yaml` exists. If it does, it is passed as `-f` to Helm. If not, only the base `values.yaml` is used.
+2. **Helm execution** — The target runs `helm upgrade --install` (for `ui-deploy`) or `helm upgrade --reuse-values` (for `ui-upgrade`), targeting the `kafka` namespace with a 5-minute timeout and `--wait` to block until all pods are ready.
+3. **Idempotent operation** — `helm upgrade --install` is safe to run repeatedly. If the release does not exist, Helm creates it. If it already exists, Helm upgrades it in place.
+
+### Usage Examples
+
+```bash
+# Full lifecycle on a Kind cluster
+make ui-deploy                   # Install with values-kind.yaml
+make ui-upgrade                  # Roll out a config change
+make ui-undeploy                 # Tear down
+
+# Preview what would be deployed to production
+make ui-chart-template ENV=prod
+
+# Lint before pushing to CI
+make ui-chart-lint
+
+# Override the image tag at deploy time
+make ui-deploy ENV=kind HELM_ARGS="--set image.tag=v1.4.2"
+```
+
+> **Note** — These Makefile targets are convenience wrappers. You can always use the raw `helm` commands directly if you need finer control (e.g., `--dry-run`, `--debug`, or `--set` overrides beyond what the targets expose).
 
 ## Image Configuration
 

--- a/charts/kafka-ui/templates/_helpers.tpl
+++ b/charts/kafka-ui/templates/_helpers.tpl
@@ -92,6 +92,42 @@ Kafka bootstrap servers FQDN.
 {{- end -}}
 
 {{/*
+Container image reference.
+Returns repository@digest when digest is set, repository:tag otherwise.
+*/}}
+{{- define "kafka-ui.image" -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Schema Registry URL — auto-computed from namespace if not explicitly set.
+*/}}
+{{- define "kafka-ui.schemaRegistryUrl" -}}
+{{- if .Values.schemaRegistry.url -}}
+{{- .Values.schemaRegistry.url -}}
+{{- else -}}
+{{- $clusterDomain := .Values.kafka.clusterDomain | default "cluster.local" -}}
+{{- printf "http://apicurio-apicurio-registry.%s.svc.%s:8080/apis/ccompat/v7" (include "kafka-ui.kafkaNamespace" .) $clusterDomain -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Kafka Connect URL — auto-computed from namespace if not explicitly set.
+*/}}
+{{- define "kafka-ui.kafkaConnectUrl" -}}
+{{- if .Values.kafkaConnect.url -}}
+{{- .Values.kafkaConnect.url -}}
+{{- else -}}
+{{- $clusterDomain := .Values.kafka.clusterDomain | default "cluster.local" -}}
+{{- printf "http://connect-cluster-connect-api.%s.svc.%s:8083" (include "kafka-ui.kafkaNamespace" .) $clusterDomain -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 KafkaUser secret name — the Strimzi-generated SCRAM credential.
 */}}
 {{- define "kafka-ui.secretName" -}}

--- a/charts/kafka-ui/templates/configmap.yaml
+++ b/charts/kafka-ui/templates/configmap.yaml
@@ -25,6 +25,19 @@ data:
             {{- if .Values.kafka.tls.enabled }}
             ssl.truststore.type: PEM
             {{- end }}
+          {{- if .Values.schemaRegistry.enabled }}
+          schemaRegistry: {{ include "kafka-ui.schemaRegistryUrl" . }}
+          {{- if .Values.schemaRegistry.auth.enabled }}
+          schemaRegistryAuth:
+            username: {{ .Values.schemaRegistry.auth.username }}
+            password: {{ .Values.schemaRegistry.auth.password }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.kafkaConnect.enabled }}
+          kafkaConnect:
+            - name: {{ .Values.kafkaConnect.name | default "connect-cluster" }}
+              address: {{ include "kafka-ui.kafkaConnectUrl" . }}
+          {{- end }}
 
     auth:
       type: {{ .Values.auth.type | default "DISABLED" }}
@@ -32,3 +45,6 @@ data:
       health:
         ldap:
           enabled: false
+    {{- with .Values.extraConfig }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}

--- a/charts/kafka-ui/templates/deployment.yaml
+++ b/charts/kafka-ui/templates/deployment.yaml
@@ -16,14 +16,21 @@ spec:
         {{- include "kafka-ui.selectorLabels" . | nindent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: kafka-ui
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "kafka-ui.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
@@ -71,6 +78,16 @@ spec:
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          {{- end }}
       volumes:
         - name: config
           configMap:

--- a/charts/kafka-ui/templates/networkpolicy.yaml
+++ b/charts/kafka-ui/templates/networkpolicy.yaml
@@ -58,6 +58,26 @@ spec:
           protocol: TCP
         - port: 9093
           protocol: TCP
+    {{- if .Values.schemaRegistry.enabled }}
+    # To Schema Registry (Apicurio)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ include "kafka-ui.kafkaNamespace" . }}
+      ports:
+        - port: 8080
+          protocol: TCP
+    {{- end }}
+    {{- if .Values.kafkaConnect.enabled }}
+    # To Kafka Connect REST API
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ include "kafka-ui.kafkaNamespace" . }}
+      ports:
+        - port: 8083
+          protocol: TCP
+    {{- end }}
     # Kubernetes API server (for Secret reads and health checks)
     - to: []
       ports:

--- a/charts/kafka-ui/values-dev.yaml
+++ b/charts/kafka-ui/values-dev.yaml
@@ -1,4 +1,19 @@
 # Development overlay for kafka-ui
+# Enables Schema Registry and Kafka Connect integration for full visibility.
+
+schemaRegistry:
+  enabled: true
+
+kafkaConnect:
+  enabled: true
+
+startupProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 30
+
 resources:
   requests:
     cpu: 100m

--- a/charts/kafka-ui/values-kind.yaml
+++ b/charts/kafka-ui/values-kind.yaml
@@ -1,4 +1,6 @@
 # Kind (local development) overlay for kafka-ui
+# Integrates with the local Apicurio Schema Registry and Kafka Connect cluster.
+
 service:
   type: NodePort
   nodePort: 30081
@@ -6,6 +8,22 @@ service:
 kafkaUser:
   # Managed by the krafter chart in this stack; avoid Helm ownership conflicts.
   enabled: false
+
+schemaRegistry:
+  enabled: true
+  url: "http://apicurio-apicurio-registry.kafka.svc:8080/apis/ccompat/v7"
+
+kafkaConnect:
+  enabled: true
+  name: "connect-cluster"
+  url: "http://connect-cluster-connect-api.kafka.svc:8083"
+
+startupProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 30
 
 resources:
   requests:

--- a/charts/kafka-ui/values-prod.yaml
+++ b/charts/kafka-ui/values-prod.yaml
@@ -24,5 +24,14 @@ kafka:
   tls:
     enabled: true
 
+schemaRegistry:
+  enabled: true
+  # url: "http://apicurio-registry.kafka.svc:8080/apis/ccompat/v7"
+
+kafkaConnect:
+  enabled: true
+  name: "connect-cluster"
+  # url: "http://connect-cluster-connect-api.kafka.svc:8083"
+
 networkPolicy:
   enabled: true

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -1,8 +1,18 @@
 # -- Image configuration
 image:
-  repository: provectuslabs/kafka-ui
-  tag: ""  # defaults to Chart.appVersion
+  # -- Container image repository (migrated from deprecated provectuslabs/kafka-ui)
+  repository: ghcr.io/kafbat/kafka-ui
+  # -- Image tag — defaults to Chart.appVersion when empty
+  tag: ""
+  # -- Image pull policy
   pullPolicy: IfNotPresent
+  # -- Optional image digest for pinned deployments (overrides tag when set)
+  # digest: "sha256:abc123..."
+  digest: ""
+
+# -- Image pull secrets for private registries
+imagePullSecrets: []
+#  - name: ghcr-credentials
 
 # -- Number of replicas
 replicas: 1
@@ -44,6 +54,25 @@ kafka:
     enabled: false
     trustedCertificateSecret: ""
     certificateKey: "ca.crt"
+
+# -- Schema Registry integration (shows schemas in Kafka UI)
+schemaRegistry:
+  enabled: false
+  # -- Schema Registry URL (e.g., Apicurio Registry)
+  url: ""
+  # -- Authentication for Schema Registry
+  auth:
+    enabled: false
+    username: ""
+    password: ""
+
+# -- Kafka Connect integration (shows connectors in Kafka UI)
+kafkaConnect:
+  enabled: false
+  # -- Display name for the Connect cluster in the UI
+  name: "connect-cluster"
+  # -- Kafka Connect REST API URL
+  url: ""
 
 # -- Kafka UI application authentication (login to the web UI itself)
 auth:
@@ -87,6 +116,11 @@ networkPolicy:
   # -- Namespace of the ingress controller (for browser access restriction)
   ingressNamespace: "ingress-nginx"
 
+# -- Pod annotations (e.g., Prometheus scraping)
+podAnnotations: {}
+#  prometheus.io/scrape: "true"
+#  prometheus.io/port: "8080"
+
 # -- Pod resource requests and limits
 resources:
   requests:
@@ -109,6 +143,14 @@ readinessProbe:
   periodSeconds: 10
   timeoutSeconds: 10
   failureThreshold: 10
+
+# -- Startup probe configuration (useful for slow-starting environments)
+startupProbe:
+  enabled: false
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 30
 
 # -- Pod-level security context
 podSecurityContext:
@@ -138,6 +180,9 @@ extraEnv: []
 
 # -- Extra labels to add to all resources
 extraLabels: {}
+
+# -- Extra Kafka UI YAML config merged into config.yml
+extraConfig: {}
 
 # -- Logging
 logging:

--- a/config/kafka-ui/kafka-ui.yaml
+++ b/config/kafka-ui/kafka-ui.yaml
@@ -16,6 +16,10 @@ data:
               org.apache.kafka.common.security.scram.ScramLoginModule required
               username="kafka-ui"
               password="${KAFKA_UI_PASSWORD}";
+          schemaRegistry: http://apicurio-apicurio-registry.kafka.svc:8080/apis/ccompat/v7
+          kafkaConnect:
+            - name: connect-cluster
+              address: http://connect-cluster-connect-api.kafka.svc:8083
 
     auth:
       type: DISABLED
@@ -43,7 +47,7 @@ spec:
     spec:
       containers:
       - name: kafka-ui
-        image: provectuslabs/kafka-ui:v0.7.2
+        image: ghcr.io/kafbat/kafka-ui:v1.5.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -66,8 +70,8 @@ spec:
           mountPath: /etc/kafkaui
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "500m"
+            memory: "512Mi"
+            cpu: "250m"
           limits:
             memory: "2Gi"
             cpu: "1000m"
@@ -82,8 +86,8 @@ spec:
           httpGet:
             path: /actuator/health
             port: 8080
-          initialDelaySeconds: 60
-          periodSeconds: 30
+          initialDelaySeconds: 30
+          periodSeconds: 10
           timeoutSeconds: 10
       volumes:
       - name: config


### PR DESCRIPTION
This pull request migrates the Kafka UI chart from the deprecated `provectuslabs/kafka-ui` (v0.7.2) to the actively maintained community fork `kafbat/kafka-ui` (v1.5.0). The old Provectus image is no longer maintained and contains known security vulnerabilities. The Kafbat fork is backward compatible and serves as the official continuation of the project.

The image is now fully customizable in values.yaml, supporting repository, tag, digest-pinned deployments, and private registry pull secrets. Schema Registry (Apicurio) and Kafka Connect cluster integrations have been wired into the configmap so the UI shows schemas and connectors out of the box. All environment profiles (dev, kind, prod, generic) have been preserved and enhanced with sensible defaults for each target. A startup probe has been added for slow-starting environments, and the NetworkPolicy now includes conditional egress rules for Schema Registry and Kafka Connect traffic.
