### PR TITLE
Add ConnectRestException hint to CLI

### DIFF
--- a/cli/cmd/helpers.go
+++ b/cli/cmd/helpers.go
@@ -176,6 +176,7 @@ var hintPatterns = []struct {
 	{"OutOfMemoryError", "JVM ran out of memory — increase -Xmx in deployment config"},
 	{"NetworkException", "Network error communicating with broker — check cluster connectivity"},
 	{"UNKNOWN_TOPIC_OR_PARTITION", "Topic does not exist — create it or check topic name"},
+	{"ConnectRestException", "Invalid connector configuration — check the connector properties for missing or invalid values"},
 }
 
 func matchHints(errMsg string) []string {


### PR DESCRIPTION
This PR adds a hint for `ConnectRestException` in the Kates CLI. When a Kafka Connect configuration is invalid and returns a 400 error, the CLI will now recommend checking the connector properties for missing or invalid values instead of failing silently or without context.