### PR TITLE
feat(connect-cluster): production hardening — observability fixes, managed KafkaUser, default-deny NetworkPolicies (v1.2.0)

### DIFF
--- a/charts/connect-cluster/Chart.yaml
+++ b/charts/connect-cluster/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: connect-cluster
 description: A Helm chart for deploying Strimzi Kafka Connect clusters
 type: application
-version: 1.0.1
-appVersion: "3.6.0"
+version: 1.2.0
+appVersion: "4.2.0"
 kubeVersion: ">=1.27.0-0"
 home: https://github.com/bmscomp/kates
 sources:

--- a/charts/connect-cluster/README.md
+++ b/charts/connect-cluster/README.md
@@ -78,6 +78,26 @@ helm install backend-connect charts/connect-cluster \
 | `kafka.authentication.username` | SCRAM username | `kates-connect` |
 | `kafka.authentication.secretName` | Secret containing the password | `kates-connect` |
 
+### Managed KafkaUser
+
+Set `kafkaUser.create=true` and the chart provisions everything the Connect cluster needs to authenticate — the Strimzi `KafkaUser` (in the Kafka namespace), least-privilege ACLs derived from chart values, and the credentials Secret in the Connect namespace:
+
+```yaml
+kafkaUser:
+  create: true
+  authorization:
+    mode: auto          # ACLs from groupId, internal topics, exactly-once, topicGrants
+  topicGrants:          # connector data topics
+    - name: cdc
+      patternType: prefix
+  secretSync:
+    method: job         # or "reflector" if kubernetes-reflector is installed
+```
+
+Auto mode grants: internal topics (`<groupId>-offsets/configs/status`), worker group `<groupId>` + `connect-*` sink groups, declared `topicGrants`, `transactionalId <groupId>*` when `exactly.once.source.support` is enabled, and cluster `Describe`. Use `mode: custom` + `acls:` for verbatim ACLs. Requires the Strimzi User Operator; supported auth types: `scram-sha-512`, `scram-sha-256`, `tls`.
+
+When Kafka and Connect are in different namespaces, a post-install/upgrade hook Job copies the generated Secret into the Connect namespace (re-runs on upgrades to pick up rotation). With `method: reflector` the Secret is annotated for [kubernetes-reflector](https://github.com/emberstack/kubernetes-reflector) instead.
+
 ### Converters & Worker Config
 
 ```yaml
@@ -101,9 +121,11 @@ extraConfig:
 | `schemaRegistry.serviceName` | Registry service name | `apicurio-apicurio-registry` |
 | `schemaRegistry.port` | Registry port | `80` |
 | `schemaRegistry.path` | Compatibility API path | `/apis/ccompat/v7` |
+| `schemaRegistry.namespace` | Registry namespace | Kafka namespace |
+| `schemaRegistry.podSelector` | Pod labels for NetworkPolicy egress | `{app.kubernetes.io/name: apicurio-registry}` |
 
 The `schema.registry.url` is automatically computed as:
-`http://<serviceName>.<namespace>.svc.<clusterDomain>:<port><path>`
+`http://<serviceName>.<registryNamespace>.svc.<clusterDomain>:<port><path>`
 
 ### JVM & Resources
 
@@ -135,7 +157,14 @@ database.password: "${secrets:<namespace>/<secret-name>:<key>}"
 ```
 
 The Connect ServiceAccount is automatically granted RBAC permissions to read secrets
-in its namespace.
+in its namespace. To restrict access to specific secrets (recommended for production):
+
+```yaml
+rbac:
+  secretNames:
+    - kates-connect
+    - connect-pg-credentials
+```
 
 ### Connectors
 
@@ -204,6 +233,18 @@ build:
 | `rack.enabled` | Rack awareness | `true` |
 | `tolerations` | Pod tolerations | `[]` |
 
+### Autoscaling (HPA)
+
+`KafkaConnect` exposes the scale subresource, so a standard `autoscaling/v2` HPA can drive worker count. When enabled, the chart stops rendering `spec.replicas` so upgrades don't fight the autoscaler.
+
+```yaml
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+```
+
 ### RBAC & ServiceAccount
 
 | Parameter | Description | Default |
@@ -253,7 +294,7 @@ Included alerts:
 - **KafkaConnectTaskCountMismatch** (critical) — Expected vs running task mismatch
 - **KafkaConnectRebalanceStorm** (warning) — Excessive rebalance rate
 - **KafkaConnectHighErrorRate** (warning) — Task error rate above 1/s
-- **KafkaConnectRebalanceTooLong** (warning) — Rebalance exceeding 2 minutes
+- **KafkaConnectRebalanceTooLong** (warning) — Worker stuck rebalancing for 5+ minutes
 - **KafkaConnectWorkerHeapHigh** (warning) — JVM heap above 85%
 - **KafkaConnectSourceLag** (warning) — Source connector polling 0 records for 15+ min
 
@@ -263,6 +304,16 @@ Included alerts:
 |-----------|-------------|---------|
 | `podMonitors.enabled` | Create PodMonitor | `true` |
 | `podMonitors.labels` | Labels for discovery | `{release: kafka}` |
+
+#### Metrics ConfigMap
+
+The chart ships its own JMX Prometheus Exporter rules (Connect worker, rebalance, connector, and task metrics), so it works standalone in any namespace:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `metricsConfig.create` | Create the metrics ConfigMap in-chart | `true` |
+| `metricsConfig.configMapName` | Name (or existing ConfigMap when `create: false`) | `<fullname>-metrics` |
+| `metricsConfig.configMapKey` | Key within the ConfigMap | `kafka-metrics-config.yml` |
 
 #### Grafana Dashboards
 
@@ -275,9 +326,25 @@ Included alerts:
 
 ### Network Policies
 
+**Default-deny by default.** The chart ships a deny-all Ingress+Egress policy for the Connect pods; every allowed flow is an explicit, individually configurable rule. Anything not listed is blocked — declare connector endpoints via `databaseEgress` or `networkPolicy.extraEgress`.
+
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `databaseEgress` | Cross-namespace egress rules for databases | `[]` |
+| `networkPolicy.enabled` | Create NetworkPolicies | `true` |
+| `networkPolicy.defaultDeny.enabled` | Deny-all policy for Connect pods | `true` |
+| `networkPolicy.dns.*` | DNS egress; pin `namespaceSelector`/`podSelector` to kube-dns on strict clusters | any dest, port 53 |
+| `networkPolicy.apiServer.*` | API server egress; pin `ipBlock` to the control-plane CIDR | any dest, 443/6443 |
+| `networkPolicy.workerToWorker.enabled` | 8083 leader forwarding | `true` |
+| `networkPolicy.kafka.ports` | Broker egress ports | `[9092, 9093]` |
+| `networkPolicy.monitoring.*` | Metrics scrape ingress | `monitoring` ns, 9404 |
+| `networkPolicy.restApi.clients` | Clients allowed on 8083 (no catch-all; `allowAll: true` restores open behavior) | kates UI |
+| `networkPolicy.tracing.*` | OTLP egress (port parsed from `tracing.endpoint`) | auto |
+| `networkPolicy.extraIngress` / `extraEgress` | Raw rule fragments, appended verbatim | `[]` |
+| `databaseEgress` | Cross-namespace egress rules for databases (`createIngressPolicy: false` skips the reciprocal policy in the DB namespace) | `[]` |
+
+Deprecated (still honored, win when set): `kafkaPorts` → `kafka.ports`, `monitoringNamespace` → `monitoring.namespace`, `restApiClients` → `restApi.clients`.
+
+> **Upgrade note (1.2.0):** default-deny ships enabled and the former `namespaceSelector: {}` catch-all on 8083 was removed (kubelet probes bypass NetworkPolicy — it only opened the REST API cluster-wide). In-cluster REST clients must be listed in `networkPolicy.restApi.clients`; undeclared connector egress will be blocked.
 
 ```yaml
 databaseEgress:
@@ -294,6 +361,14 @@ databaseEgress:
 | `logging.type` | `external` or `inline` | `external` |
 | `tracing.enabled` | Enable distributed tracing | `true` |
 | `tracing.type` | Tracing type | `opentelemetry` |
+| `tracing.endpoint` | OTLP collector endpoint (required for traces to be exported) | `""` |
+| `tracing.serviceName` | `OTEL_SERVICE_NAME` | release fullname |
+
+```yaml
+tracing:
+  enabled: true
+  endpoint: http://otel-collector.observability.svc:4317
+```
 
 ### Probes
 

--- a/charts/connect-cluster/templates/NOTES.txt
+++ b/charts/connect-cluster/templates/NOTES.txt
@@ -17,6 +17,28 @@ Components:
   REST API Service:   {{ if .Values.restApi.service.enabled }}enabled (port {{ .Values.restApi.service.port | default 8083 }}){{ else }}disabled{{ end }}
   Alerts:             {{ if .Values.alerts.enabled }}enabled{{ else }}disabled{{ end }}
   Dashboards:         {{ if .Values.dashboards.enabled }}enabled{{ else }}disabled{{ end }}
+  Managed KafkaUser:  {{ if (.Values.kafkaUser).create }}enabled ({{ .Values.kafkaUser.name | default .Values.kafka.authentication.username }}, secretSync: {{ ((.Values.kafkaUser).secretSync).method | default "job" }}){{ else }}disabled — secret "{{ .Values.kafka.authentication.secretName | default .Values.kafka.authentication.username }}" must exist{{ end }}
+  NetworkPolicy:      {{ if .Values.networkPolicy.enabled }}{{ if ((.Values.networkPolicy.defaultDeny).enabled | default true) }}default-deny + explicit allows{{ else }}allow rules only (no default-deny){{ end }}{{ else }}disabled{{ end }}
+{{- if or .Values.networkPolicy.kafkaPorts .Values.networkPolicy.monitoringNamespace .Values.networkPolicy.restApiClients }}
+
+  ⚠ DEPRECATED networkPolicy keys in use — migrate:
+{{- if .Values.networkPolicy.kafkaPorts }}
+    kafkaPorts          → networkPolicy.kafka.ports
+{{- end }}
+{{- if .Values.networkPolicy.monitoringNamespace }}
+    monitoringNamespace → networkPolicy.monitoring.namespace
+{{- end }}
+{{- if .Values.networkPolicy.restApiClients }}
+    restApiClients      → networkPolicy.restApi.clients
+{{- end }}
+{{- end }}
+{{- if and .Values.networkPolicy.enabled ((.Values.networkPolicy.defaultDeny).enabled | default true) }}
+
+  ⚠ Default-deny is ACTIVE: traffic not covered by the configured allow rules
+    (DNS, API server, Kafka, workers, monitoring, REST clients, registry,
+    tracing, databaseEgress, extra*) is blocked. Declare connector endpoints
+    via databaseEgress or networkPolicy.extraEgress.
+{{- end }}
 
 ────────────────────────────────────────────
   Getting Started
@@ -30,7 +52,7 @@ Components:
 2. Check worker pods:
 
   kubectl get pods -n {{ include "connect-cluster.namespace" . }} \
-    -l strimzi.io/name={{ include "connect-cluster.fullname" . }} \
+    -l strimzi.io/name={{ include "connect-cluster.fullname" . }}-connect \
     -o custom-columns=NAME:.metadata.name,READY:.status.containerStatuses[0].ready,NODE:.spec.nodeName
 
 3. Run Helm tests:
@@ -57,4 +79,4 @@ Components:
 
   kubectl get kafkaconnect,kafkaconnector -n {{ include "connect-cluster.namespace" . }}
   kubectl logs -n {{ include "connect-cluster.namespace" . }} \
-    -l strimzi.io/name={{ include "connect-cluster.fullname" . }} --tail=50
+    -l strimzi.io/name={{ include "connect-cluster.fullname" . }}-connect --tail=50

--- a/charts/connect-cluster/templates/_helpers.tpl
+++ b/charts/connect-cluster/templates/_helpers.tpl
@@ -113,6 +113,39 @@ Defaults to the Connect cluster namespace if not set.
 {{- end -}}
 
 {{/*
+Schema Registry namespace — defaults to the Kafka namespace (consistent
+with the NetworkPolicy egress rule).
+*/}}
+{{- define "connect-cluster.schemaRegistryNamespace" -}}
+{{- .Values.schemaRegistry.namespace | default (include "connect-cluster.kafkaNamespace" .) -}}
+{{- end -}}
+
+{{/*
+Metrics ConfigMap name. When the chart creates the ConfigMap
+(metricsConfig.create=true) it defaults to <fullname>-metrics; otherwise
+an existing ConfigMap name must be provided via metricsConfig.configMapName.
+*/}}
+{{- define "connect-cluster.metricsConfigMapName" -}}
+{{- if .Values.metricsConfig.configMapName -}}
+{{- .Values.metricsConfig.configMapName -}}
+{{- else if .Values.metricsConfig.create -}}
+{{- printf "%s-metrics" (include "connect-cluster.fullname" .) -}}
+{{- else -}}
+kafka-metrics
+{{- end -}}
+{{- end -}}
+
+{{/*
+Tracing OTLP egress port, parsed from tracing.endpoint (default 4317).
+*/}}
+{{- define "connect-cluster.tracingEgressPort" -}}
+{{- $hostport := .Values.tracing.endpoint | default "" | replace "https://" "" | replace "http://" "" | replace "grpc://" "" -}}
+{{- $hostport = splitList "/" $hostport | first -}}
+{{- $parts := splitList ":" $hostport -}}
+{{- if gt (len $parts) 1 -}}{{ last $parts }}{{- else -}}4317{{- end -}}
+{{- end -}}
+
+{{/*
 Kafka bootstrap servers FQDN (SASL_PLAINTEXT port 9092).
 Usage: {{ include "connect-cluster.bootstrapServers" . }}
 */}}

--- a/charts/connect-cluster/templates/alerts-connect.yaml
+++ b/charts/connect-cluster/templates/alerts-connect.yaml
@@ -49,7 +49,7 @@ spec:
 
         # ── Warning ──────────────────────────────────────────────────────
         - alert: KafkaConnectRebalanceStorm
-          expr: rate(kafka_connect_worker_rebalance_metrics_rebalance_total[5m]) > {{ .Values.alerts.thresholds.rebalanceRatePerSecond }}
+          expr: rate(kafka_connect_worker_rebalance_metrics_completed_rebalances_total[5m]) > {{ .Values.alerts.thresholds.rebalanceRatePerSecond }}
           for: 5m
           labels:
             severity: warning
@@ -59,7 +59,7 @@ spec:
             description: "Connect workers are rebalancing at {{ "{{" }} $value {{ "}}" }}/s which may indicate instability."
 
         - alert: KafkaConnectHighErrorRate
-          expr: rate(kafka_connect_task_metrics_total_errors_logged_total[5m]) > {{ .Values.alerts.thresholds.errorRatePerSecond }}
+          expr: rate(kafka_connect_task_error_metrics_total_errors_logged[5m]) > {{ .Values.alerts.thresholds.errorRatePerSecond }}
           for: 5m
           labels:
             severity: warning
@@ -69,8 +69,8 @@ spec:
             description: "Connect tasks are logging errors at {{ "{{" }} $value {{ "}}" }}/s."
 
         - alert: KafkaConnectRebalanceTooLong
-          expr: kafka_connect_worker_rebalance_metrics_rebalance_time_ms_total > 120000
-          for: 2m
+          expr: kafka_connect_worker_rebalance_metrics_rebalancing == 1
+          for: 5m
           labels:
             severity: warning
             cluster: {{ $clusterName }}
@@ -80,8 +80,8 @@ spec:
 
         - alert: KafkaConnectWorkerHeapHigh
           expr: |
-            jvm_memory_bytes_used{area="heap", kubernetes_name="{{ include "connect-cluster.fullname" . }}-connect"}
-            / jvm_memory_bytes_max{area="heap", kubernetes_name="{{ include "connect-cluster.fullname" . }}-connect"}
+            sum by (pod) (jvm_memory_bytes_used{area="heap", namespace="{{ include "connect-cluster.namespace" . }}", pod=~"{{ include "connect-cluster.fullname" . }}-connect-.*"})
+            / sum by (pod) (jvm_memory_bytes_max{area="heap", namespace="{{ include "connect-cluster.namespace" . }}", pod=~"{{ include "connect-cluster.fullname" . }}-connect-.*"})
             > {{ divf .Values.alerts.thresholds.heapUsagePercent 100.0 }}
           for: 5m
           labels:

--- a/charts/connect-cluster/templates/connectors.yaml
+++ b/charts/connect-cluster/templates/connectors.yaml
@@ -8,27 +8,21 @@ metadata:
   name: {{ .name }}
   namespace: {{ include "connect-cluster.namespace" $ }}
   labels:
-    {{- include "connect-cluster.labels" $ | nindent 4 }}
-    app.kubernetes.io/component: connector
-    kates.io/connector-name: {{ .name }}
-    strimzi.io/cluster: {{ include "connect-cluster.fullname" $ }}
-    {{- with .labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-  {{- if .annotations }}
+    {{- /* merge to avoid duplicate app.kubernetes.io/component key; per-connector labels win */}}
+    {{- $labels := mergeOverwrite
+          (include "connect-cluster.labels" $ | fromYaml)
+          (dict "app.kubernetes.io/component" "connector"
+                "kates.io/connector-name" .name
+                "strimzi.io/cluster" (include "connect-cluster.fullname" $))
+          (default (dict) .labels) }}
+    {{- toYaml $labels | nindent 4 }}
   annotations:
     {{- if not (eq (toString $.Values.keepOnDelete) "false") }}
     helm.sh/resource-policy: keep
     {{- end }}
-    {{- range $k, $v := .annotations }}
+    {{- range $k, $v := (default (dict) .annotations) }}
     {{ $k }}: {{ $v | quote }}
     {{- end }}
-  {{- else }}
-  annotations:
-    {{- if not (eq (toString $.Values.keepOnDelete) "false") }}
-    helm.sh/resource-policy: keep
-    {{- end }}
-  {{- end }}
 spec:
   class: {{ .class }}
   tasksMax: {{ .tasksMax | default 1 }}

--- a/charts/connect-cluster/templates/dashboard-connect.yaml
+++ b/charts/connect-cluster/templates/dashboard-connect.yaml
@@ -43,14 +43,14 @@ data:
           "title": "Rebalance Rate",
           "type": "stat",
           "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
-          "targets": [{ "expr": "rate(kafka_connect_worker_rebalance_metrics_rebalance_total[5m])", "legendFormat": "{{ "{{" }}pod{{ "}}" }}" }],
+          "targets": [{ "expr": "rate(kafka_connect_worker_rebalance_metrics_completed_rebalances_total[5m])", "legendFormat": "{{ "{{" }}pod{{ "}}" }}" }],
           "fieldConfig": { "defaults": { "unit": "ops", "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 0.05 }, { "color": "red", "value": 0.1 }] } } }
         },
         {
           "title": "Task Error Rate",
           "type": "timeseries",
           "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
-          "targets": [{ "expr": "rate(kafka_connect_task_metrics_total_errors_logged_total[5m])", "legendFormat": "{{ "{{" }}connector{{ "}}" }}/{{ "{{" }}task{{ "}}" }}" }],
+          "targets": [{ "expr": "rate(kafka_connect_task_error_metrics_total_errors_logged[5m])", "legendFormat": "{{ "{{" }}connector{{ "}}" }}/{{ "{{" }}task{{ "}}" }}" }],
           "fieldConfig": { "defaults": { "unit": "errors/s" } }
         },
         {
@@ -72,8 +72,8 @@ data:
           "type": "timeseries",
           "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
           "targets": [
-            { "expr": "jvm_memory_bytes_used{area=\"heap\", kubernetes_name=~\".*connect.*\"}", "legendFormat": "{{ "{{" }}pod{{ "}}" }} used" },
-            { "expr": "jvm_memory_bytes_max{area=\"heap\", kubernetes_name=~\".*connect.*\"}", "legendFormat": "{{ "{{" }}pod{{ "}}" }} max" }
+            { "expr": "jvm_memory_bytes_used{area=\"heap\", pod=~\"{{ include "connect-cluster.fullname" . }}-connect-.*\"}", "legendFormat": "{{ "{{" }}pod{{ "}}" }} used" },
+            { "expr": "jvm_memory_bytes_max{area=\"heap\", pod=~\"{{ include "connect-cluster.fullname" . }}-connect-.*\"}", "legendFormat": "{{ "{{" }}pod{{ "}}" }} max" }
           ],
           "fieldConfig": { "defaults": { "unit": "bytes" } }
         }

--- a/charts/connect-cluster/templates/hpa.yaml
+++ b/charts/connect-cluster/templates/hpa.yaml
@@ -1,0 +1,45 @@
+{{- /*
+  Optional HPA. KafkaConnect exposes the scale subresource, so the HPA can
+  target it directly. When enabled, spec.replicas is omitted from the
+  KafkaConnect resource so Helm upgrades don't fight the autoscaler.
+*/ -}}
+{{- if (.Values.autoscaling).enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "connect-cluster.fullname" . }}
+  namespace: {{ include "connect-cluster.namespace" . }}
+  labels:
+    {{- include "connect-cluster.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: kafka.strimzi.io/v1
+    kind: KafkaConnect
+    name: {{ include "connect-cluster.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas | default 3 }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas | default 10 }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- with .Values.autoscaling.extraMetrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/connect-cluster/templates/kafka-connect.yaml
+++ b/charts/connect-cluster/templates/kafka-connect.yaml
@@ -15,7 +15,10 @@ spec:
   image: "{{ .Values.image }}"
   {{- end }}
   version: {{ .Values.version }}
+  {{- /* When HPA is enabled it owns the replica count via the scale subresource */}}
+  {{- if not (.Values.autoscaling).enabled }}
   replicas: {{ .Values.replicas }}
+  {{- end }}
   bootstrapServers: {{ include "connect-cluster.bootstrapServers" . }}
   authentication:
     type: {{ .Values.kafka.authentication.type | default "scram-sha-512" }}
@@ -53,7 +56,7 @@ spec:
     key.converter.schemas.enable: {{ .Values.config.keyConverterSchemasEnable | default true }}
     value.converter.schemas.enable: {{ .Values.config.valueConverterSchemasEnable | default true }}
     {{- if .Values.schemaRegistry.enabled }}
-    schema.registry.url: {{ printf "http://%s.%s.svc.%s:%d%s" .Values.schemaRegistry.serviceName (include "connect-cluster.namespace" .) (include "connect-cluster.clusterDomain" .) (.Values.schemaRegistry.port | int) .Values.schemaRegistry.path }}
+    schema.registry.url: {{ printf "http://%s.%s.svc.%s:%d%s" .Values.schemaRegistry.serviceName (include "connect-cluster.schemaRegistryNamespace" .) (include "connect-cluster.clusterDomain" .) (.Values.schemaRegistry.port | int) .Values.schemaRegistry.path }}
     {{- end }}
     config.providers: file,dir,secrets
     config.providers.file.class: org.apache.kafka.common.config.provider.FileConfigProvider
@@ -88,7 +91,7 @@ spec:
     type: jmxPrometheusExporter
     valueFrom:
       configMapKeyRef:
-        name: {{ .Values.metricsConfig.configMapName | default "kafka-metrics" }}
+        name: {{ include "connect-cluster.metricsConfigMapName" . }}
         key: {{ .Values.metricsConfig.configMapKey | default "kafka-metrics-config.yml" }}
   {{- if .Values.tracing.enabled }}
   tracing:
@@ -115,6 +118,9 @@ spec:
           {{- toYaml . | nindent 10 }}
           {{- end }}
           checksum/logging: {{ include (print $.Template.BasePath "/kafka-connect-logging.yaml") . | sha256sum }}
+          {{- if .Values.metricsConfig.create }}
+          checksum/metrics: {{ include (print $.Template.BasePath "/metrics-configmap-connect.yaml") . | sha256sum }}
+          {{- end }}
       securityContext:
         fsGroup: {{ .Values.podSecurityContext.fsGroup | default 1001 }}
         {{- if .Values.podSecurityContext.runAsNonRoot }}
@@ -181,9 +187,20 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     connectContainer:
-      {{- with .Values.env }}
+      {{- $tracingEnv := and .Values.tracing.enabled .Values.tracing.endpoint }}
+      {{- if or .Values.env $tracingEnv }}
       env:
+        {{- if $tracingEnv }}
+        - name: OTEL_SERVICE_NAME
+          value: {{ .Values.tracing.serviceName | default (include "connect-cluster.fullname" .) | quote }}
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: {{ .Values.tracing.endpoint | quote }}
+        - name: OTEL_TRACES_EXPORTER
+          value: "otlp"
+        {{- end }}
+        {{- with .Values.env }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       securityContext:
         {{- include "connect-cluster.containerSecurityContext" . | nindent 8 }}

--- a/charts/connect-cluster/templates/kafka-user-secret-sync.yaml
+++ b/charts/connect-cluster/templates/kafka-user-secret-sync.yaml
@@ -1,0 +1,168 @@
+{{- /*
+  Seamless credentials availability across namespaces.
+  The User Operator writes the KafkaUser Secret in the Kafka namespace, but
+  KafkaConnect reads passwordSecret from its own namespace. When they differ,
+  this hook Job waits for the Secret and copies it over (method: job), or the
+  KafkaUser is annotated for kubernetes-reflector (method: reflector, handled
+  in kafka-user.yaml values passthrough via kafkaUser.template).
+  No-op when Kafka and Connect share a namespace.
+*/ -}}
+{{- $sync := ((.Values.kafkaUser).secretSync) | default dict }}
+{{- $kafkaNs := include "connect-cluster.kafkaNamespace" . }}
+{{- $connectNs := include "connect-cluster.namespace" . }}
+{{- if and (.Values.kafkaUser).create ($sync.enabled | default true) (ne $kafkaNs $connectNs) (eq ($sync.method | default "job") "job") }}
+{{- $username := .Values.kafkaUser.name | default .Values.kafka.authentication.username | default "kates-connect" }}
+{{- $fullname := include "connect-cluster.fullname" . }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $fullname }}-secret-sync
+  namespace: {{ $connectNs }}
+  labels:
+    {{- include "connect-cluster.labels" . | nindent 4 }}
+---
+# Read the generated credentials Secret in the Kafka namespace (scoped by name)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $fullname }}-secret-sync-read
+  namespace: {{ $kafkaNs }}
+  labels:
+    {{- include "connect-cluster.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: [{{ $username | quote }}]
+    verbs: ["get", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $fullname }}-secret-sync-read
+  namespace: {{ $kafkaNs }}
+  labels:
+    {{- include "connect-cluster.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $fullname }}-secret-sync-read
+subjects:
+  - kind: ServiceAccount
+    name: {{ $fullname }}-secret-sync
+    namespace: {{ $connectNs }}
+---
+# Write the copy in the Connect namespace (scoped by name; create needs no resourceNames)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $fullname }}-secret-sync-write
+  namespace: {{ $connectNs }}
+  labels:
+    {{- include "connect-cluster.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: [{{ $username | quote }}]
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $fullname }}-secret-sync-write
+  namespace: {{ $connectNs }}
+  labels:
+    {{- include "connect-cluster.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $fullname }}-secret-sync-write
+subjects:
+  - kind: ServiceAccount
+    name: {{ $fullname }}-secret-sync
+    namespace: {{ $connectNs }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $fullname }}-secret-sync
+  namespace: {{ $connectNs }}
+  labels:
+    {{- include "connect-cluster.labels" . | nindent 4 }}
+  annotations:
+    # Runs on every install/upgrade to pick up password rotation.
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 2
+  activeDeadlineSeconds: {{ $sync.timeoutSeconds | default 300 }}
+  template:
+    metadata:
+      labels:
+        {{- include "connect-cluster.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ $fullname }}-secret-sync
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: sync
+          image: {{ .Values.testImages.kubectl }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          env:
+            - name: SECRET_NAME
+              value: {{ $username | quote }}
+            - name: SRC_NS
+              value: {{ $kafkaNs | quote }}
+            - name: DST_NS
+              value: {{ $connectNs | quote }}
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              echo "Waiting for User Operator to create ${SRC_NS}/${SECRET_NAME}..."
+              i=0
+              until kubectl -n "${SRC_NS}" get secret "${SECRET_NAME}" >/dev/null 2>&1; do
+                i=$((i+1))
+                if [ "$i" -ge 60 ]; then
+                  echo "Timed out waiting for secret ${SRC_NS}/${SECRET_NAME}" >&2
+                  exit 1
+                fi
+                sleep 5
+              done
+              echo "Copying to ${DST_NS}/${SECRET_NAME}..."
+              kubectl -n "${SRC_NS}" get secret "${SECRET_NAME}" -o json \
+                | jq --arg ns "${DST_NS}" --arg src "${SRC_NS}/${SECRET_NAME}" '
+                    {
+                      apiVersion: "v1",
+                      kind: "Secret",
+                      type: .type,
+                      data: .data,
+                      metadata: {
+                        name: .metadata.name,
+                        namespace: $ns,
+                        labels: (.metadata.labels // {}),
+                        annotations: {"kates.io/synced-from": $src}
+                      }
+                    }' \
+                | kubectl apply -f -
+              echo "Done."
+{{- end }}

--- a/charts/connect-cluster/templates/kafka-user.yaml
+++ b/charts/connect-cluster/templates/kafka-user.yaml
@@ -1,0 +1,119 @@
+{{- /*
+  Managed KafkaUser for this Connect cluster (kafkaUser.create=true).
+  Created in the Kafka namespace, where the Strimzi User Operator watches and
+  writes the credentials Secret. ACLs are derived from chart values (mode: auto)
+  so group/topic names never drift, or taken verbatim (mode: custom).
+*/ -}}
+{{- if (.Values.kafkaUser).create }}
+{{- $auth := .Values.kafka.authentication }}
+{{- $authType := $auth.type | default "scram-sha-512" }}
+{{- if not (has $authType (list "scram-sha-512" "scram-sha-256" "tls")) }}
+{{- fail (printf "kafkaUser.create=true supports authentication types scram-sha-512, scram-sha-256, tls — got %q. Provision OAuth identities externally." $authType) }}
+{{- end }}
+{{- $username := .Values.kafkaUser.name | default $auth.username | default "kates-connect" }}
+{{- $groupId := .Values.groupId | default "kates-connect-cluster" }}
+{{- $authz := .Values.kafkaUser.authorization | default dict }}
+{{- $sync := (.Values.kafkaUser.secretSync) | default dict }}
+{{- $connectNs := include "connect-cluster.namespace" . }}
+{{- $tpl := deepCopy (.Values.kafkaUser.template | default dict) }}
+{{- /* method: reflector — annotate the generated Secret for kubernetes-reflector */}}
+{{- if and ($sync.enabled | default true) (eq ($sync.method | default "job") "reflector") (ne (include "connect-cluster.kafkaNamespace" .) $connectNs) }}
+{{- $ann := dict
+      "reflector.v1.k8s.emberstack.com/reflection-allowed" "true"
+      "reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces" $connectNs
+      "reflector.v1.k8s.emberstack.com/reflection-auto-enabled" "true"
+      "reflector.v1.k8s.emberstack.com/reflection-auto-namespaces" $connectNs }}
+{{- $tpl = merge $tpl (dict "secret" (dict "metadata" (dict "annotations" $ann))) }}
+{{- end }}
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaUser
+metadata:
+  name: {{ $username }}
+  namespace: {{ include "connect-cluster.kafkaNamespace" . }}
+  labels:
+    {{- include "connect-cluster.labels" . | nindent 4 }}
+    strimzi.io/cluster: {{ .Values.kafka.clusterName | default "krafter" }}
+  annotations:
+    {{- if not (eq (toString .Values.keepOnDelete) "false") }}
+    helm.sh/resource-policy: keep
+    {{- end }}
+spec:
+  authentication:
+    type: {{ $authType }}
+  {{- with .Values.kafkaUser.quotas }}
+  quotas:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $tpl }}
+  template:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if $authz.enabled | default true }}
+  authorization:
+    type: {{ $authz.type | default "simple" }}
+    acls:
+      {{- if eq ($authz.mode | default "auto") "custom" }}
+      {{- if not .Values.kafkaUser.acls }}
+      {{- fail "kafkaUser.authorization.mode=custom requires kafkaUser.acls" }}
+      {{- end }}
+      {{- toYaml .Values.kafkaUser.acls | nindent 6 }}
+      {{- else }}
+      # ── Connect internal topics ────────────────────────────────────────
+      {{- range $topic := list
+            ((.Values.internalTopics).offsetsName | default (printf "%s-offsets" $groupId))
+            ((.Values.internalTopics).configsName | default (printf "%s-configs" $groupId))
+            ((.Values.internalTopics).statusName  | default (printf "%s-status"  $groupId)) }}
+      - resource:
+          type: topic
+          name: {{ $topic | quote }}
+          patternType: literal
+        operations: ["Read", "Write", "Create", "Describe", "DescribeConfigs"]
+        host: "*"
+      {{- end }}
+      # ── Worker group + per-connector sink groups ───────────────────────
+      - resource:
+          type: group
+          name: {{ $groupId | quote }}
+          patternType: literal
+        operations: ["Read", "Describe"]
+        host: "*"
+      - resource:
+          type: group
+          name: "connect-"
+          patternType: prefix
+        operations: ["Read", "Describe"]
+        host: "*"
+      {{- range .Values.kafkaUser.groupGrants }}
+      - resource:
+          type: group
+          name: {{ .name | quote }}
+          patternType: {{ .patternType | default "prefix" }}
+        operations: ["Read", "Describe"]
+        host: "*"
+      {{- end }}
+      # ── Connector data topics ──────────────────────────────────────────
+      {{- range .Values.kafkaUser.topicGrants }}
+      - resource:
+          type: topic
+          name: {{ .name | quote }}
+          patternType: {{ .patternType | default "prefix" }}
+        operations: {{ .operations | default (list "Read" "Write" "Create" "Describe") | toJson }}
+        host: "*"
+      {{- end }}
+      {{- if eq (get (.Values.extraConfig | default dict) "exactly.once.source.support" | toString) "enabled" }}
+      # ── Exactly-once source support ────────────────────────────────────
+      - resource:
+          type: transactionalId
+          name: {{ $groupId | quote }}
+          patternType: prefix
+        operations: ["Write", "Describe"]
+        host: "*"
+      {{- end }}
+      # ── Cluster metadata (admin client) ────────────────────────────────
+      - resource:
+          type: cluster
+        operations: ["Describe", "DescribeConfigs"]
+        host: "*"
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/connect-cluster/templates/metrics-configmap-connect.yaml
+++ b/charts/connect-cluster/templates/metrics-configmap-connect.yaml
@@ -1,0 +1,82 @@
+{{- /*
+  JMX Prometheus Exporter rules for Kafka Connect.
+  Created in-chart so Connect works in its own namespace without depending
+  on the kafka-cluster chart's ConfigMap. Set metricsConfig.create=false to
+  use an existing ConfigMap instead (metricsConfig.configMapName).
+*/ -}}
+{{- if .Values.metricsConfig.create }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "connect-cluster.metricsConfigMapName" . }}
+  namespace: {{ include "connect-cluster.namespace" . }}
+  labels:
+    {{- include "connect-cluster.labels" . | nindent 4 }}
+data:
+  {{ .Values.metricsConfig.configMapKey | default "kafka-metrics-config.yml" }}: |
+    lowercaseOutputName: true
+    lowercaseOutputLabelNames: true
+    rules:
+    # Client app-info (producer/consumer/connect clients embedded in workers)
+    - pattern: "kafka.(.+)<type=app-info, client-id=(.+)><>start-time-ms"
+      name: kafka_$1_start_time_seconds
+      type: GAUGE
+      valueFactor: 0.001
+      labels:
+        clientId: "$2"
+    - pattern: "kafka.(.+)<type=app-info, client-id=(.+)><>(commit-id|version): (.+)"
+      name: kafka_$1_$3_info
+      value: 1
+      type: UNTYPED
+      labels:
+        clientId: "$2"
+        $3: "$4"
+
+    # Connect worker metrics (per connector)
+    - pattern: "kafka.connect<type=connect-worker-metrics, connector=(.+)>([^:]+):"
+      name: kafka_connect_worker_metrics_$2
+      type: GAUGE
+      labels:
+        connector: "$1"
+
+    # Connect worker metrics (global)
+    - pattern: "kafka.connect<type=connect-worker-metrics>([^:]+):"
+      name: kafka_connect_worker_metrics_$1
+      type: GAUGE
+
+    # Connect worker rebalance metrics
+    - pattern: "kafka.connect<type=connect-worker-rebalance-metrics>([^:]+):"
+      name: kafka_connect_worker_rebalance_metrics_$1
+      type: GAUGE
+
+    # Connector status / metadata
+    - pattern: "kafka.connect<type=connector-metrics, connector=(.+)><>(connector-class|connector-type|connector-version|status): (.+)"
+      name: kafka_connect_connector_metrics
+      value: 1
+      type: UNTYPED
+      labels:
+        connector: "$1"
+        $2: "$3"
+
+    # Task-level metrics: task-metrics, source-task-metrics, sink-task-metrics, task-error-metrics
+    - pattern: "kafka.connect<type=(.+)-metrics, connector=(.+), task=(.+)><>(.+-total|.+-count|.+-ms|.+-ratio|.+-seq-no|.+-rate|.+-max|.+-avg|.+-failures|.+-requests|.+-timestamp|.+-logged|.+-errors|.+-retries|.+-skipped)"
+      name: kafka_connect_$1_metrics_$4
+      type: GAUGE
+      labels:
+        connector: "$2"
+        task: "$3"
+
+    # Connect coordinator / client metrics
+    - pattern: "kafka.connect<type=connect-metrics, client-id=(.+)><>(.+-total|.+-rate|.+-avg|.+-max|.+-count|.+-ms|.+-age|.+-ratio)"
+      name: kafka_connect_connect_metrics_$2
+      type: GAUGE
+      labels:
+        clientId: "$1"
+
+    # Embedded producer/consumer/admin client metrics
+    - pattern: "kafka.(producer|consumer|admin.client)<type=(.+)-metrics, client-id=(.+)><>(.+-total|.+-rate|.+-avg|.+-max)"
+      name: kafka_$1_$2_$4
+      type: GAUGE
+      labels:
+        clientId: "$3"
+{{- end }}

--- a/charts/connect-cluster/templates/networkpolicies.yaml
+++ b/charts/connect-cluster/templates/networkpolicies.yaml
@@ -1,7 +1,24 @@
+{{- /*
+  Explicit allow rules for the Connect pods. Together with the default-deny
+  policy (networkpolicy-default-deny.yaml) this is the complete traffic
+  contract: every flow is individually configurable, anything not listed is
+  blocked. Deprecated flat keys (kafkaPorts, monitoringNamespace,
+  restApiClients) still win over the structured ones when set.
+*/ -}}
 {{- if .Values.networkPolicy.enabled }}
+{{- $np := .Values.networkPolicy }}
 {{- $clusterName := include "connect-cluster.fullname" . -}}
 {{- $namespace := include "connect-cluster.namespace" . -}}
 {{- $connectPodName := printf "%s-connect" $clusterName -}}
+{{- $dns := $np.dns | default dict }}
+{{- $api := $np.apiServer | default dict }}
+{{- $kafkaCfg := $np.kafka | default dict }}
+{{- $mon := $np.monitoring | default dict }}
+{{- $rest := $np.restApi | default dict }}
+{{- /* deprecated aliases take precedence when explicitly set */}}
+{{- $kafkaPorts := $np.kafkaPorts | default ($kafkaCfg.ports | default (list 9092 9093)) }}
+{{- $monNs := $np.monitoringNamespace | default ($mon.namespace | default "monitoring") }}
+{{- $clients := $np.restApiClients | default ($rest.clients | default (list)) }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -17,40 +34,77 @@ spec:
     - Ingress
     - Egress
   ingress:
+    {{- if $mon.enabled | default true }}
+    # Metrics scraping (JMX exporter)
     - from:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: monitoring
+              kubernetes.io/metadata.name: {{ $monNs }}
       ports:
-        - port: 9404
+        - port: {{ $mon.port | default 9404 }}
           protocol: TCP
+    {{- end }}
+    {{- if $rest.allowAll }}
+    # REST API open to all sources (explicit opt-in)
+    - ports:
+        - port: 8083
+          protocol: TCP
+    {{- else if or $clients ($rest.operator | default true) }}
+    # REST API: declared clients + Strimzi operator only.
+    # NOTE: no catch-all — kubelet probes bypass NetworkPolicy anyway.
     - from:
+        {{- range $clients }}
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: kates
+              kubernetes.io/metadata.name: {{ .namespace }}
+          {{- with .podSelector }}
           podSelector:
             matchLabels:
-              app.kubernetes.io/name: kates
+              {{- toYaml . | nindent 14 }}
+          {{- end }}
+        {{- end }}
+        {{- if $rest.operator | default true }}
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: {{ .Values.networkPolicy.strimziOperatorNamespace | default (include "connect-cluster.kafkaNamespace" .) }}
+              kubernetes.io/metadata.name: {{ $np.strimziOperatorNamespace | default (include "connect-cluster.kafkaNamespace" .) }}
           podSelector:
             matchLabels:
               strimzi.io/kind: cluster-operator
-        # Allow ingress from all sources for health probes (kubelet)
-        - namespaceSelector: {}
+        {{- end }}
       ports:
         - port: 8083
           protocol: TCP
+    {{- end }}
+    {{- with $np.extraIngress }}
+    # Extra ingress rules (verbatim)
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   egress:
-    # Allow DNS resolution
-    - to: []
+    {{- if $dns.enabled | default true }}
+    # DNS resolution
+    - to:
+        {{- if or $dns.namespaceSelector $dns.podSelector }}
+        - {{- with $dns.namespaceSelector }}
+          namespaceSelector:
+            matchLabels:
+              {{- toYaml . | nindent 14 }}
+          {{- end }}
+          {{- with $dns.podSelector }}
+          podSelector:
+            matchLabels:
+              {{- toYaml . | nindent 14 }}
+          {{- end }}
+        {{- end }}
       ports:
-        - port: 53
+        {{- range $dns.ports | default (list 53) }}
+        - port: {{ . }}
           protocol: UDP
-        - port: 53
+        - port: {{ . }}
           protocol: TCP
-    # Allow worker-to-worker REST traffic (leader forwarding and task assignment)
+        {{- end }}
+    {{- end }}
+    {{- if ($np.workerToWorker).enabled | default true }}
+    # Worker-to-worker REST traffic (leader forwarding and task assignment)
     - to:
         - podSelector:
             matchLabels:
@@ -60,6 +114,9 @@ spec:
       ports:
         - port: 8083
           protocol: TCP
+    {{- end }}
+    {{- if $kafkaCfg.enabled | default true }}
+    # Kafka brokers
     - to:
         - namespaceSelector:
             matchLabels:
@@ -68,23 +125,45 @@ spec:
             matchLabels:
               strimzi.io/cluster: {{ .Values.kafka.clusterName }}
       ports:
-        {{- range .Values.networkPolicy.kafkaPorts | default (list 9092 9093) }}
+        {{- range $kafkaPorts }}
         - protocol: TCP
           port: {{ . }}
         {{- end }}
-    {{- if .Values.schemaRegistry.enabled }}
+    {{- end }}
+    {{- if and .Values.schemaRegistry.enabled (($np.schemaRegistry).enabled | default true) }}
+    # Schema Registry
     - to:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: {{ .Values.schemaRegistry.namespace | default (include "connect-cluster.kafkaNamespace" .) }}
+              kubernetes.io/metadata.name: {{ include "connect-cluster.schemaRegistryNamespace" . }}
           podSelector:
             matchLabels:
-              app.kubernetes.io/name: apicurio-registry
+              {{- .Values.schemaRegistry.podSelector | default (dict "app.kubernetes.io/name" "apicurio-registry") | toYaml | nindent 14 }}
       ports:
         - port: {{ .Values.schemaRegistry.port | default 80 }}
           protocol: TCP
     {{- end }}
+    {{- if and .Values.tracing.enabled .Values.tracing.endpoint (($np.tracing).enabled | default true) }}
+    # OTLP tracing collector
+    - to:
+        {{- if or (($np.tracing).namespaceSelector) (($np.tracing).podSelector) }}
+        - {{- with ($np.tracing).namespaceSelector }}
+          namespaceSelector:
+            matchLabels:
+              {{- toYaml . | nindent 14 }}
+          {{- end }}
+          {{- with ($np.tracing).podSelector }}
+          podSelector:
+            matchLabels:
+              {{- toYaml . | nindent 14 }}
+          {{- end }}
+        {{- end }}
+      ports:
+        - port: {{ ($np.tracing).port | default (include "connect-cluster.tracingEgressPort" . | int) }}
+          protocol: TCP
+    {{- end }}
     {{- range (default (list) .Values.databaseEgress) }}
+    # Database egress ({{ .namespace }}:{{ .port | default 5432 }})
     - to:
         - namespaceSelector:
             matchLabels:
@@ -98,16 +177,28 @@ spec:
         - port: {{ .port | default 5432 }}
           protocol: TCP
     {{- end }}
-    # Allow API Server egress
-    - to: []
+    {{- if $api.enabled | default true }}
+    # Kubernetes API server (KubernetesSecretConfigProvider)
+    - to:
+        {{- with $api.ipBlock }}
+        - ipBlock:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
       ports:
-        - port: 443
+        {{- range $api.ports | default (list 443 6443) }}
+        - port: {{ . }}
           protocol: TCP
-        - port: 6443
-          protocol: TCP
-{{- if .Values.databaseEgress }}
-{{- range .Values.databaseEgress }}
+        {{- end }}
+    {{- end }}
+    {{- with $np.extraEgress }}
+    # Extra egress rules (verbatim)
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- range (default (list) .Values.databaseEgress) }}
+{{- if ne (toString (.createIngressPolicy | default true)) "false" }}
 ---
+# Reciprocal ingress in the database namespace (disable with createIngressPolicy: false
+# when the platform team manages policies in that namespace)
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -129,7 +220,7 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: {{ include "connect-cluster.namespace" $ }}
+              kubernetes.io/metadata.name: {{ $namespace }}
           podSelector:
             matchLabels:
               strimzi.io/name: {{ $connectPodName }}

--- a/charts/connect-cluster/templates/networkpolicy-default-deny.yaml
+++ b/charts/connect-cluster/templates/networkpolicy-default-deny.yaml
@@ -1,0 +1,26 @@
+{{- /*
+  Default-deny for the Connect pods — ON by default. The allow rules in
+  networkpolicies.yaml define the complete traffic contract; anything not
+  listed there is blocked. Disable only when a platform-level default-deny
+  already exists and policy engines forbid duplicates.
+*/ -}}
+{{- if and .Values.networkPolicy.enabled ((.Values.networkPolicy.defaultDeny).enabled | default true) }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "connect-cluster.fullname" . }}-connect-default-deny
+  namespace: {{ include "connect-cluster.namespace" . }}
+  labels:
+    {{- include "connect-cluster.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- if (.Values.networkPolicy.defaultDeny).selector }}
+      {{- toYaml .Values.networkPolicy.defaultDeny.selector | nindent 6 }}
+      {{- else }}
+      strimzi.io/name: {{ include "connect-cluster.fullname" . }}-connect
+      {{- end }}
+  policyTypes:
+    - Ingress
+    - Egress
+{{- end }}

--- a/charts/connect-cluster/templates/podmonitor-connect.yaml
+++ b/charts/connect-cluster/templates/podmonitor-connect.yaml
@@ -13,7 +13,9 @@ metadata:
 spec:
   selector:
     matchLabels:
-      strimzi.io/name: {{ $clusterName }}
+      # Strimzi labels Connect pods <cluster>-connect
+      strimzi.io/name: {{ $clusterName }}-connect
+      strimzi.io/kind: KafkaConnect
   podMetricsEndpoints:
     - port: tcp-prometheus
       path: /metrics

--- a/charts/connect-cluster/templates/secret-reader-rbac.yaml
+++ b/charts/connect-cluster/templates/secret-reader-rbac.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.serviceAccount.create }}
+{{- $secretNames := (.Values.rbac).secretNames | default (list) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -9,7 +10,14 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
+    {{- if $secretNames }}
+    # Scoped: only the secrets referenced by connector configs
+    resourceNames:
+      {{- toYaml $secretNames | nindent 6 }}
+    verbs: ["get", "watch"]
+    {{- else }}
     verbs: ["get", "list", "watch"]
+    {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -40,7 +48,13 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
+    {{- if $secretNames }}
+    resourceNames:
+      {{- toYaml $secretNames | nindent 6 }}
+    verbs: ["get", "watch"]
+    {{- else }}
     verbs: ["get", "list", "watch"]
+    {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -80,6 +94,11 @@ rules:
   - apiGroups: ["kafka.strimzi.io"]
     resources: ["kafkaconnectors"]
     verbs: ["get", "list", "create", "delete"]
+  # Tier 0 test: verify the Kafka auth secret exists (scoped to that secret)
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: [{{ .Values.kafka.authentication.secretName | default .Values.kafka.authentication.username | default "kates-connect" | quote }}]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/connect-cluster/templates/tests/test-connect.yaml
+++ b/charts/connect-cluster/templates/tests/test-connect.yaml
@@ -74,6 +74,16 @@ spec:
           CONNECT="{{ include "connect-cluster.fullname" . }}"
           NAMESPACE="{{ include "connect-cluster.namespace" . }}"
 
+          # ─── Tier 0: Auth Secret Availability ──────────────────────────────
+          echo ""
+          echo "=== Tier 0: Auth Secret Availability ==="
+          AUTH_SECRET="{{ .Values.kafka.authentication.secretName | default .Values.kafka.authentication.username | default "kates-connect" }}"
+          if kubectl get secret "$AUTH_SECRET" -n $NAMESPACE >/dev/null 2>&1; then
+            ok "Auth secret $AUTH_SECRET present in $NAMESPACE"
+          else
+            fail "Auth secret $AUTH_SECRET missing in $NAMESPACE{{ if (.Values.kafkaUser).create }} (kafkaUser.create=true — check the secret-sync Job / User Operator){{ else }} (create it or set kafkaUser.create=true){{ end }}"
+          fi
+
           # ─── Tier 1: KafkaConnect CR Readiness ─────────────────────────────
           echo ""
           echo "=== Tier 1: KafkaConnect CR Readiness ==="

--- a/charts/connect-cluster/values-prod.yaml
+++ b/charts/connect-cluster/values-prod.yaml
@@ -54,9 +54,19 @@ autoRestart:
 
 networkPolicy:
   enabled: true
-  kafkaPorts:
-    - 9093
-  monitoringNamespace: monitoring
+  defaultDeny:
+    enabled: true
+  # Pin DNS egress to kube-dns (strict zero-trust)
+  dns:
+    namespaceSelector:
+      kubernetes.io/metadata.name: kube-system
+    podSelector:
+      k8s-app: kube-dns
+  kafka:
+    ports:
+      - 9093
+  monitoring:
+    namespace: monitoring
 
 databaseEgress:
   - namespace: database

--- a/charts/connect-cluster/values.schema.json
+++ b/charts/connect-cluster/values.schema.json
@@ -142,8 +142,172 @@
       "properties": {
         "enabled": { "type": "boolean" },
         "serviceName": { "type": "string" },
+        "namespace": { "type": "string" },
         "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
-        "path": { "type": "string" }
+        "path": { "type": "string" },
+        "podSelector": { "type": "object" }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "defaultDeny": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "selector": { "type": "object" }
+          }
+        },
+        "dns": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "namespaceSelector": { "type": "object" },
+            "podSelector": { "type": "object" },
+            "ports": {
+              "type": "array",
+              "items": { "type": "integer", "minimum": 1, "maximum": 65535 }
+            }
+          }
+        },
+        "apiServer": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "ports": {
+              "type": "array",
+              "items": { "type": "integer", "minimum": 1, "maximum": 65535 }
+            },
+            "ipBlock": { "type": "object" }
+          }
+        },
+        "workerToWorker": {
+          "type": "object",
+          "properties": { "enabled": { "type": "boolean" } }
+        },
+        "kafka": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "ports": {
+              "type": "array",
+              "items": { "type": "integer", "minimum": 1, "maximum": 65535 }
+            }
+          }
+        },
+        "monitoring": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "namespace": { "type": "string" },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+          }
+        },
+        "restApi": {
+          "type": "object",
+          "properties": {
+            "allowAll": { "type": "boolean" },
+            "operator": { "type": "boolean" },
+            "clients": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["namespace"],
+                "properties": {
+                  "namespace": { "type": "string" },
+                  "podSelector": { "type": "object" }
+                }
+              }
+            }
+          }
+        },
+        "schemaRegistry": {
+          "type": "object",
+          "properties": { "enabled": { "type": "boolean" } }
+        },
+        "tracing": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "namespaceSelector": { "type": "object" },
+            "podSelector": { "type": "object" },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+          }
+        },
+        "strimziOperatorNamespace": { "type": "string" },
+        "extraIngress": { "type": "array", "items": { "type": "object" } },
+        "extraEgress": { "type": "array", "items": { "type": "object" } },
+        "kafkaPorts": {
+          "type": "array",
+          "description": "DEPRECATED — use networkPolicy.kafka.ports",
+          "items": { "type": "integer", "minimum": 1, "maximum": 65535 }
+        },
+        "monitoringNamespace": {
+          "type": "string",
+          "description": "DEPRECATED — use networkPolicy.monitoring.namespace"
+        },
+        "restApiClients": {
+          "type": "array",
+          "description": "DEPRECATED — use networkPolicy.restApi.clients",
+          "items": {
+            "type": "object",
+            "required": ["namespace"],
+            "properties": {
+              "namespace": { "type": "string" },
+              "podSelector": { "type": "object" }
+            }
+          }
+        }
+      }
+    },
+    "kafkaUser": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean" },
+        "name": { "type": "string" },
+        "authorization": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "type": { "type": "string", "enum": ["simple"] },
+            "mode": { "type": "string", "enum": ["auto", "custom"] }
+          }
+        },
+        "topicGrants": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "patternType": { "type": "string", "enum": ["literal", "prefix"] },
+              "operations": { "type": "array", "items": { "type": "string" } }
+            }
+          }
+        },
+        "groupGrants": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "patternType": { "type": "string", "enum": ["literal", "prefix"] }
+            }
+          }
+        },
+        "acls": { "type": "array", "items": { "type": "object" } },
+        "quotas": { "type": "object" },
+        "template": { "type": "object" },
+        "secretSync": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "method": { "type": "string", "enum": ["job", "reflector"] },
+            "timeoutSeconds": { "type": "integer", "minimum": 30 }
+          }
+        }
       }
     },
 
@@ -181,7 +345,9 @@
         "type": {
           "type": "string",
           "enum": ["opentelemetry", "jaeger"]
-        }
+        },
+        "endpoint": { "type": "string" },
+        "serviceName": { "type": "string" }
       }
     },
     "env": { "type": "array" },
@@ -207,8 +373,40 @@
     "metricsConfig": {
       "type": "object",
       "properties": {
+        "create": { "type": "boolean" },
         "configMapName": { "type": "string" },
         "configMapKey": { "type": "string" }
+      }
+    },
+    "autoscaling": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minReplicas": { "type": "integer", "minimum": 1 },
+        "maxReplicas": { "type": "integer", "minimum": 1 },
+        "targetCPUUtilizationPercentage": {
+          "anyOf": [
+            { "type": "integer", "minimum": 1, "maximum": 100 },
+            { "type": "string", "maxLength": 0 }
+          ]
+        },
+        "targetMemoryUtilizationPercentage": {
+          "anyOf": [
+            { "type": "integer", "minimum": 1, "maximum": 100 },
+            { "type": "string", "maxLength": 0 }
+          ]
+        },
+        "extraMetrics": { "type": "array" },
+        "behavior": { "type": "object" }
+      }
+    },
+    "rbac": {
+      "type": "object",
+      "properties": {
+        "secretNames": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
       }
     },
     "template": { "type": "object" },

--- a/charts/connect-cluster/values.yaml
+++ b/charts/connect-cluster/values.yaml
@@ -53,6 +53,39 @@ kafka:
     # -- Key in the Secret containing the authentication password
     secretKey: "password"
 
+# ── Managed KafkaUser ───────────────────────────────────────────────────────
+# One flag provisions everything: KafkaUser (in the Kafka namespace), ACLs,
+# and the credentials Secret in the Connect namespace. Requires the Strimzi
+# User Operator; ACLs apply when the Kafka cluster has authorization enabled.
+kafkaUser:
+  create: false
+  # -- User name (defaults to kafka.authentication.username)
+  name: ""
+  authorization:
+    enabled: true
+    type: simple
+    # -- auto: derive least-privilege ACLs from chart values (groupId,
+    # internal topics, exactly-once, topicGrants). custom: use acls verbatim.
+    mode: auto
+  # -- Data topics connectors read/write (auto mode). Prefix patterns recommended.
+  topicGrants:
+    - name: cdc
+      patternType: prefix
+  # -- Extra consumer groups beyond <groupId> and connect-*
+  groupGrants: []
+  # -- Used only when authorization.mode=custom
+  acls: []
+  quotas: {}
+  # -- KafkaUser template passthrough (labels/annotations on the generated Secret)
+  template: {}
+  # -- Make the credentials Secret available in the Connect namespace when
+  # Kafka lives elsewhere. job: hook Job copies it (re-runs on upgrade for
+  # rotation). reflector: annotate for kubernetes-reflector instead.
+  secretSync:
+    enabled: true
+    method: job
+    timeoutSeconds: 300
+
 # ── Scheduling ──────────────────────────────────────────────────────────────
 topologySpreadConstraints:
   enabled: true
@@ -120,10 +153,13 @@ resources:
 schemaRegistry:
   enabled: false
   serviceName: apicurio-apicurio-registry
-  # -- Namespace where the Schema Registry is deployed (leave empty if same as Kafka)
+  # -- Namespace where the Schema Registry is deployed (defaults to the Kafka namespace)
   namespace: ""
   port: 80
   path: /apis/ccompat/v7
+  # -- Pod labels used by the NetworkPolicy egress rule
+  podSelector:
+    app.kubernetes.io/name: apicurio-registry
 
 # ── Secret Access (Strimzi 1.0.0+) ──────────────────────────────────────────
 # The KubernetesSecretConfigProvider is always enabled. Use the syntax
@@ -134,14 +170,84 @@ schemaRegistry:
 
 
 # ── Network Policy ──────────────────────────────────────────────────────────
+# Default-deny posture: the chart ships a deny-all policy for the Connect pods
+# and every allowed flow below is an explicit, individually configurable rule.
+# Anything not listed is blocked.
+# Deprecated flat keys (kafkaPorts, monitoringNamespace, restApiClients) are
+# still honored and win over the structured equivalents when set.
 networkPolicy:
   enabled: true
+
+  # -- Deny-all Ingress+Egress for the Connect pods. Disable only when a
+  # platform-level default-deny already exists and duplicates are forbidden.
+  defaultDeny:
+    enabled: true
+    # -- Pod selector for the deny policy (empty = Connect pods only)
+    selector: {}
+
+  # -- DNS egress. Empty selectors = any destination; on locked-down clusters
+  # pin to kube-dns, e.g.:
+  #   namespaceSelector: {kubernetes.io/metadata.name: kube-system}
+  #   podSelector: {k8s-app: kube-dns}
+  dns:
+    enabled: true
+    namespaceSelector: {}
+    podSelector: {}
+    ports: [53]
+
+  # -- Kubernetes API server egress (needed by KubernetesSecretConfigProvider).
+  # Empty ipBlock = any destination; pin the control-plane CIDR on strict
+  # clusters, e.g. ipBlock: {cidr: 10.0.0.1/32}
+  apiServer:
+    enabled: true
+    ports: [443, 6443]
+    ipBlock: {}
+
+  # -- Worker-to-worker REST traffic on 8083 (leader forwarding)
+  workerToWorker:
+    enabled: true
+
+  # -- Kafka broker egress
+  kafka:
+    enabled: true
+    ports: [9092, 9093]
+
+  # -- Metrics scrape ingress (JMX exporter, port 9404)
+  monitoring:
+    enabled: true
+    namespace: monitoring
+    port: 9404
+
+  # -- Connect REST API (8083) ingress. No catch-all: kubelet probes bypass
+  # NetworkPolicy, so only the clients listed here (plus the Strimzi operator)
+  # get access. allowAll: true restores the old open behavior.
+  restApi:
+    allowAll: false
+    operator: true
+    clients:
+      - namespace: kates
+        podSelector:
+          app.kubernetes.io/name: kates
+
+  # -- Schema Registry egress (rendered only when schemaRegistry.enabled)
+  schemaRegistry:
+    enabled: true
+
+  # -- OTLP tracing egress (rendered only when tracing.endpoint is set).
+  # Port is parsed from tracing.endpoint; pin selectors to the collector
+  # namespace/pods if desired.
+  tracing:
+    enabled: true
+    namespaceSelector: {}
+    podSelector: {}
+    # port: 4317
+
   # -- Namespace where the Strimzi Operator is deployed (leave empty if same as Kafka)
   strimziOperatorNamespace: ""
-  kafkaPorts:
-    - 9092
-    - 9093
-  monitoringNamespace: monitoring
+
+  # -- Extra raw NetworkPolicy rule fragments, appended verbatim
+  extraIngress: []
+  extraEgress: []
 
 # ── Database Egress (NetworkPolicy) ─────────────────────────────────────────
 databaseEgress: []
@@ -174,6 +280,11 @@ logging:
 tracing:
   enabled: true
   type: opentelemetry
+  # -- OTLP collector endpoint, e.g. http://otel-collector.observability.svc:4317
+  # Tracing is inert until this is set (injects OTEL_* env vars into workers).
+  endpoint: ""
+  # -- Service name reported in traces (defaults to the release fullname)
+  serviceName: ""
 
 # ── Environment Variables ───────────────────────────────────────────────────
 env: []
@@ -249,7 +360,11 @@ build: {}
 
 # ── Metrics ─────────────────────────────────────────────────────────────────
 metricsConfig:
-  configMapName: kafka-metrics
+  # -- Create the JMX exporter ConfigMap in-chart (recommended; makes the chart
+  # self-contained). Set false to reference an existing ConfigMap.
+  create: true
+  # -- ConfigMap name (empty = <fullname>-metrics when create=true)
+  configMapName: ""
   configMapKey: kafka-metrics-config.yml
 
 # ── Pod Template Overrides ──────────────────────────────────────────────────
@@ -342,7 +457,30 @@ testTopics:
     replicas: 3
     config:
       min.insync.replicas: "2"
+# ── Autoscaling (HPA) ───────────────────────────────────────────────────────
+# KafkaConnect exposes the scale subresource, so a standard HPA works.
+# When enabled, the chart stops managing spec.replicas.
+autoscaling:
+  enabled: false
+  minReplicas: 3
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+  # -- Set to enable memory-based scaling (e.g. 80)
+  targetMemoryUtilizationPercentage: ""
+  # -- Additional autoscaling/v2 metrics entries
+  extraMetrics: []
+  # -- HPA scaling behavior (autoscaling/v2 behavior block)
+  behavior: {}
+
 # ── RBAC ────────────────────────────────────────────────────────────────────
+# -- Restrict the secret-reader Role to specific secrets. Empty = all secrets
+# in the namespace (get/list/watch). When set, verbs narrow to get/watch and
+# access is limited to the named secrets.
+rbac:
+  secretNames: []
+  # - kates-connect
+  # - connect-pg-credentials
+
 serviceAccount:
   # -- Create a dedicated ServiceAccount for Connect pods
   create: true

--- a/docs/internal/connect-user-netpol-plan.md
+++ b/docs/internal/connect-user-netpol-plan.md
@@ -1,0 +1,188 @@
+# Plan: connect-cluster — managed KafkaUser & default-deny-ready NetworkPolicies
+
+Status: implemented in v1.2.0 · Chart: `charts/connect-cluster`
+
+## 1. Problem
+
+**User creation.** The chart authenticates as `kates-connect` but never creates that identity. The `KafkaUser` (and its ACLs) lives in `charts/kafka-cluster` values (`users.items`), so:
+
+- Installing connect-cluster against any Kafka not deployed by kafka-cluster fails until someone hand-creates a user + secret.
+- ACLs are maintained far from the thing that needs them; group/topic names (`groupId`, `<groupId>-offsets/configs/status`, connector topics) are duplicated by hand and drift.
+- Multi-tenancy ("one Connect cluster per team") requires editing kafka-cluster values per tenant — the opposite of the chart's independent-lifecycle goal.
+
+**NetworkPolicy.** The current `-connect-extra` policy assumes the namespace is otherwise open. On a cluster where a platform team enforces default-deny (or where we want the chart to bring its own default-deny, as kafka-cluster does):
+
+- There is no default-deny policy in the connect chart itself (kafka-cluster has `networkPolicies.defaultDeny`; connect has nothing).
+- Several flows are hardcoded and can't be adapted: DNS egress is `to: []` port 53 (blocked if the platform requires kube-dns pod selectors — some CNIs also need port 5353/9153), API-server egress is `to: []` 443/6443 (some clusters need the kubernetes endpoint CIDR instead), no egress for OTLP tracing endpoint, no egress for Strimzi build (registry push), no generic escape hatch (`extraEgress`/`extraIngress`).
+- Ingress 8083 has a `namespaceSelector: {}` catch-all "for kubelet probes" — kubelet traffic is not subject to NetworkPolicy; this rule actually opens the REST API to the whole cluster and defeats default-deny.
+
+## 2. Design
+
+### 2.1 Managed KafkaUser (`kafkaUser.*`)
+
+New template `templates/kafka-user.yaml`, created in the **Kafka namespace** (`connect-cluster.kafkaNamespace`), since the User Operator watches there and Strimzi writes the password Secret next to the Kafka cluster.
+
+```yaml
+kafkaUser:
+  # Create a KafkaUser for this Connect cluster (requires Strimzi User Operator
+  # and authorization enabled on the Kafka cluster for ACLs to apply).
+  create: false                 # off by default: backward compatible
+  # Name defaults to kafka.authentication.username
+  name: ""
+  # ACL mode:
+  #   auto     — derive least-privilege ACLs from chart values (below)
+  #   custom   — use kafkaUser.acls verbatim
+  authorization:
+    type: simple
+    mode: auto
+  # Topics connectors read/write, granted Read/Write/Create/Describe.
+  # Prefix patterns recommended.
+  topicGrants:
+    - name: cdc
+      patternType: prefix
+  # Extra consumer groups beyond connect-<groupId> / <groupId>
+  groupGrants: []
+  # Used only when mode: custom
+  acls: []
+  quotas: {}
+  # Secret template passthrough (labels/annotations on the generated secret)
+  template: {}
+  # Make the generated credentials Secret available in the Connect namespace
+  # when Kafka lives elsewhere (see "Seamless secret availability" below).
+  secretSync:
+    enabled: true             # no-op when Kafka and Connect share a namespace
+    method: job               # job | reflector
+```
+
+**Seamless secret availability.** Goal: `kafkaUser.create=true` is the *only* flag needed — user, ACLs, and password Secret all materialize without manual steps. Strimzi's User Operator writes the credentials Secret in the **Kafka namespace**, but `KafkaConnect.spec.authentication.passwordSecret` must live in the **Connect namespace**. When the two differ:
+
+- `method: job` (default, no extra dependencies): a post-install/post-upgrade hook Job waits for the User Operator to create the Secret (`kubectl wait --for=jsonpath=...`, bounded retries), then copies it into the Connect namespace with chart labels. The existing cross-namespace secret-reader Role already grants read in the Kafka namespace; the hook additionally needs `create/update` on the named Secret in the Connect namespace (tightly scoped via `resourceNames`). Re-runs on every upgrade to pick up password rotation; a `kates.io/synced-from` annotation marks provenance.
+- `method: reflector`: if the cluster runs [kubernetes-reflector](https://github.com/emberstack/kubernetes-reflector), the chart only annotates the KafkaUser `template.secret` for auto-reflection — zero hook Jobs, live rotation propagation.
+- Same-namespace installs skip all of this: the User Operator's Secret is already where Connect expects it (name defaults line up: user name = secret name = `kafka.authentication.secretName`).
+
+`mode: auto` renders, from existing values (single source of truth):
+
+| Resource | Names | Ops | Why |
+|---|---|---|---|
+| topic | `<groupId>-offsets`, `-configs`, `-status` (or `internalTopics.*` overrides), literal | Read, Write, Create, Describe, DescribeConfigs | Connect internal topics |
+| group | `<groupId>` literal + `connect-` prefix | Read, Describe | worker group + per-connector sink groups |
+| topic | each `kafkaUser.topicGrants[]` | Read, Write, Create, Describe | connector data topics |
+| transactionalId | `<groupId>` prefix | Write, Describe | `exactly.once.source.support: enabled` (rendered only when that extraConfig is set) |
+| cluster | — | Describe, DescribeConfigs | admin client metadata |
+
+Wiring changes in existing templates:
+
+- `kafka-connect.yaml`: no change needed — `kafka.authentication.secretName` already defaults to the username, which is exactly the Secret name Strimzi's User Operator generates. Add a NOTES.txt line and a `fail` guard: `kafkaUser.create=true` with `authentication.type=oauth` is rejected (`tls`/`scram-*` supported).
+- `authentication.type: tls`: template sets `spec.authentication.type: tls` on the KafkaUser and the existing `certificateSecret` default (`<username>` secret with `user.crt`/`user.key`) lines up with what Strimzi generates — document this.
+- Validation hook (`validate-connectors.yaml`): warn when `kafkaUser.create=false` and `kafka.authentication.secretName` doesn't exist is not checkable at template time — instead, extend the Helm **test** (`test-connect.yaml`) to assert the auth secret exists before curling.
+- values.schema.json: full schema for `kafkaUser` incl. enum on `mode`, required `name+patternType` on grants.
+
+Cross-namespace note: KafkaUser goes to the Kafka namespace, but the chart may not own that namespace. Guard with `kafkaUser.create` and document that the release must have RBAC there (same caveat as the existing cross-namespace secret-reader Role).
+
+### 2.2 Default-deny-ready NetworkPolicies (`networkPolicy.*`)
+
+Restructure `templates/networkpolicies.yaml` values — **default-deny by default**: the chart ships its own deny-all policy for the Connect pods and every allowed flow is an explicit, individually configurable rule. Zero-trust out of the box, matching kafka-cluster's `defaultDeny: true` posture; anything not listed below is blocked.
+
+```yaml
+networkPolicy:
+  enabled: true
+
+  # Deny-all Ingress+Egress for the Connect pods (mirrors kafka-cluster).
+  # ON by default — the allow rules below define the complete traffic contract.
+  # Set false only if a platform-level default-deny already exists and Kyverno/
+  # OPA forbids duplicate deny policies.
+  defaultDeny:
+    enabled: true
+    # selector defaults to the Connect pods only (strimzi.io/name: <fullname>-connect)
+    selector: {}
+
+  dns:
+    enabled: true
+    # Empty = any destination (current behavior). On locked-down clusters set:
+    # namespaceSelector: {kubernetes.io/metadata.name: kube-system}
+    # podSelector: {k8s-app: kube-dns}
+    namespaceSelector: {}
+    podSelector: {}
+    ports: [53]               # add 5353/9153 if the CNI needs them
+
+  apiServer:
+    enabled: true
+    ports: [443, 6443]
+    # Empty = any destination. For strict clusters, pin the control-plane CIDR:
+    # ipBlock: {cidr: 10.0.0.1/32}
+    ipBlock: {}
+
+  workerToWorker:
+    enabled: true             # 8083 leader forwarding (unchanged)
+
+  kafka:
+    enabled: true
+    ports: [9092, 9093]       # replaces top-level kafkaPorts (kept as deprecated alias)
+
+  monitoring:
+    enabled: true
+    namespace: monitoring     # replaces monitoringNamespace (deprecated alias)
+    port: 9404
+
+  restApi:
+    # Replaces restApiClients + the namespaceSelector:{} catch-all.
+    # The catch-all is REMOVED (it defeats default-deny; kubelet probes
+    # bypass NetworkPolicy). allowAll restores old behavior if needed.
+    allowAll: false
+    clients:
+      - namespace: kates
+        podSelector: {app.kubernetes.io/name: kates}
+    operator: true            # Strimzi operator ingress on 8083 (unchanged)
+
+  schemaRegistry:
+    enabled: true             # rendered only if schemaRegistry.enabled anyway
+
+  tracing:
+    enabled: true             # egress to tracing.endpoint host port (4317/4318), rendered only when endpoint set
+
+  # Escape hatches — raw NetworkPolicy rule fragments appended verbatim
+  extraEgress: []
+  extraIngress: []
+```
+
+Also:
+
+- Split the monolithic policy into `default-deny` (optional) + the existing `-connect-extra` allow policy, matching the kafka-cluster chart layout.
+- `databaseEgress` unchanged (already configurable), but its reciprocal ingress policy in the DB namespace gets a toggle (`databaseEgress[].createIngressPolicy`, default true) — platform teams often forbid charts writing policies into other namespaces.
+- Deprecation shims in `_helpers.tpl`: `networkPolicy.kafkaPorts` → `networkPolicy.kafka.ports`, `monitoringNamespace` → `monitoring.namespace`, `restApiClients` → `restApi.clients` (old keys win if set, warn in NOTES).
+
+### 2.3 Behavior changes called out explicitly
+
+Two deliberate breaking changes, both security fixes:
+
+1. **Default-deny ships enabled.** Traffic not covered by the allow rules (DNS, API server, Kafka, worker-to-worker, monitoring, REST clients, registry, tracing, `databaseEgress`, `extraEgress`/`extraIngress`) is blocked. Connectors reaching endpoints nobody declared will break on upgrade — that's the point; declare them via `databaseEgress` or `extraEgress`. Escape hatch: `networkPolicy.defaultDeny.enabled=false`.
+2. **The `namespaceSelector: {}` catch-all on 8083 is removed** — kubelet probes bypass NetworkPolicy, so it only opened the REST API cluster-wide. In-cluster clients must be listed in `restApi.clients` (or set `restApi.allowAll: true`).
+
+Both get release notes in README/Chart.yaml `artifacthub.io/changes` and an upgrade checklist in NOTES.txt.
+
+## 3. Files touched
+
+| File | Change |
+|---|---|
+| `templates/kafka-user.yaml` | new — KafkaUser with auto/custom ACLs |
+| `templates/kafka-user-secret-sync.yaml` | new — hook Job (or reflector annotations) copying the credentials Secret into the Connect namespace |
+| `templates/networkpolicies.yaml` | restructure per §2.2 |
+| `templates/networkpolicy-default-deny.yaml` | new — optional default-deny |
+| `templates/_helpers.tpl` | ACL builders, deprecation shims, tracing endpoint host/port parser |
+| `templates/kafka-connect.yaml` | oauth+kafkaUser guard (`fail`) |
+| `templates/tests/test-connect.yaml` | assert auth secret exists |
+| `values.yaml`, `values.schema.json` | new keys, deprecated aliases |
+| `values-prod.yaml` | pinned DNS/API-server selectors on top of the default deny-all |
+| `README.md`, `NOTES.txt` | docs, deprecation warnings |
+| `Chart.yaml` | 1.2.0 |
+
+## 4. Test plan
+
+1. `helm template` matrix: defaults (v1.1.0 output + the new default-deny policy, everything else byte-identical apart from deprecation comments), `kafkaUser.create=true` × {scram-512, scram-256, tls}, `mode=custom`, cross-namespace Kafka with `secretSync` (job and reflector variants), pinned DNS/API selectors, `defaultDeny.enabled=false` opt-out, `restApi.allowAll=true`, deprecated aliases still honored.
+2. `ct lint` (repo has `ct.yaml`).
+3. kind e2e (`values-kind.yaml`): default-deny on, verify workers join group, connector runs, PodMonitor scrapes, `helm test` passes — proves the allow rules are complete.
+4. Negative test: unlisted client namespace cannot reach 8083.
+
+## 5. Out of scope
+
+OAuth KafkaUser provisioning, Cilium/other CNI-specific policies, mTLS between workers (Strimzi doesn't support it on the REST API), automatic ACL inference from connector `config` (topic lists are free-form strings; `topicGrants` keeps it explicit).


### PR DESCRIPTION
## Summary

Production hardening of the `connect-cluster` chart (1.0.1 → 1.2.0, appVersion → Kafka 4.2.0). Three themes: **observability that actually works**, a **managed KafkaUser** so the chart provisions its own Kafka credentials, and **default-deny NetworkPolicies** around the Connect pods.

## Observability & correctness

The monitoring stack in this chart was quietly inert. Fixed:

- **PodMonitor never matched anything.** Strimzi labels Connect pods `strimzi.io/name: <cluster>-connect`, but the selector used `<cluster>`. No metrics were scraped, so no alert could ever fire.
- **Alert and dashboard queries referenced metric names the JMX exporter doesn't emit** (`..._rebalance_total`, `kafka_connect_task_metrics_total_errors_logged_total`, `kubernetes_name` label). Corrected to the real series, and heap queries are now scoped by namespace + pod regex instead of a `.*connect.*` match.
- **Self-contained metrics config.** `metricsConfig.create` ships a JMX exporter ConfigMap in-chart, so Connect no longer depends on `kafka-cluster` having created a `kafka-metrics` ConfigMap in the same namespace. Pod template carries a `checksum/metrics` annotation so rule changes roll the workers.
- **Tracing was enabled but did nothing.** `tracing.endpoint` / `tracing.serviceName` now wire `OTEL_*` env vars into the Connect container.
- Honor `schemaRegistry.namespace` and the monitoring namespace instead of assuming the release namespace; drop a duplicate `app.kubernetes.io/component` label on `KafkaConnector`.
- Optional **HPA** through the `KafkaConnect` scale subresource (`autoscaling.*`); when enabled, `replicas` is omitted so the HPA owns the count.

## Managed KafkaUser

`kafkaUser.create=true` is the single flag that provisions everything Connect needs to authenticate:

- A `KafkaUser` in the Kafka namespace with **least-privilege ACLs derived from chart values** — internal config/offset/status topics, worker and sink consumer groups, `topicGrants`, the exactly-once `transactionalId`, and cluster `Describe`. `mode=custom` passes ACLs through verbatim for anything the generator doesn't cover.
- **Cross-namespace secret sync**, since the User Operator writes the Secret next to the Kafka cluster, not next to Connect. `secretSync.method` picks between a Helm-hook `Job` that copies (and re-copies on upgrade, so rotation works) or `kubernetes-reflector` annotations.
- Scoped RBAC for the sync Job, optional `rbac.secretNames` scoping for the secret-reader Role, and a helm test asserting the auth Secret exists before the release is called good.

## NetworkPolicies

- **New default-deny policy** for Connect pods. Every flow is now an explicit, individually toggleable allow rule: `dns`, `apiServer`, `workerToWorker`, `kafka`, `monitoring`, `restApi`, `schemaRegistry`, `tracing`, `databaseEgress`, plus `extraIngress` / `extraEgress` escape hatches. DNS and API-server destinations are pinnable for zero-trust clusters.
- **Removed the `namespaceSelector: {}` catch-all on 8083**, which opened the Connect REST API to every namespace in the cluster. It was there for probes, but kubelet probes bypass NetworkPolicy entirely, so it bought nothing. `restApi.allowAll` restores the old behavior for anyone who needs it.
- `databaseEgress[].createIngressPolicy` emits the reciprocal ingress policy on the database side.
- Deprecated flat keys (`kafkaPorts`, `monitoringNamespace`, `restApiClients`) still work; NOTES.txt warns when they're used.

## ⚠️ Breaking change

**Default-deny ships enabled.** Any traffic to or from the Connect pods that isn't declared through the allow rules above will be blocked after upgrade. Custom connector egress (databases, REST sinks, object stores) must be declared via `databaseEgress` or `extraEgress`. See the upgrade note in the chart README.

To keep the previous permissive behavior, set `networkPolicy.defaultDeny.enabled=false`.

## Test plan

- [ ] `helm lint charts/connect-cluster` and `helm template` against default, `values-prod.yaml`, and `kafkaUser.create=true`
- [ ] Values validate against the extended `values.schema.json`
- [ ] Deploy to a cluster: confirm PodMonitor targets are `UP`, dashboard panels populate, and alert rules evaluate
- [ ] Confirm the synced auth Secret lands in the Connect namespace and workers connect with the generated ACLs
- [ ] Confirm Connect ↔ Kafka, worker ↔ worker, and scrape traffic survive default-deny; confirm undeclared egress is blocked

Design notes: [`docs/internal/connect-user-netpol-plan.md`](docs/internal/connect-user-netpol-plan.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
