### PR TITLE
docs(readme): replace logo image with a text wordmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <div align="center">
-  <img src="docs/assets/kates-wordmark.svg" width="500" alt="Kates — Kafka advanced testing and engineering suite" />
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/kates-wordmark-dark.svg" />
+    <img src="docs/assets/kates-wordmark.svg" width="500" alt="Kates — Kafka advanced testing and engineering suite" />
+  </picture>
 
   <p>
     A Kubernetes-native platform for performance testing, chaos engineering,<br/>

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 <div align="center">
-  <img src="docs/assets/kates-logo.png" width="140" alt="Kates Logo" />
-
-  <h1>Kates</h1>
-
-  <p><strong>Kafka Advanced Testing & Engineering Suite</strong></p>
+  <img src="docs/assets/kates-wordmark.svg" width="500" alt="Kates — Kafka advanced testing and engineering suite" />
 
   <p>
     A Kubernetes-native platform for performance testing, chaos engineering,<br/>

--- a/docs/assets/kates-wordmark-dark.svg
+++ b/docs/assets/kates-wordmark-dark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 44" width="500" height="44" role="img" aria-label="Kates — Kafka advanced testing and engineering suite">
+  <text x="8" y="31" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif"><tspan font-size="30" font-weight="800" fill="#4FA3F0" textLength="22">K</tspan><tspan font-size="30" font-weight="500" fill="#E6EAF2" textLength="56">ates</tspan><tspan font-size="17" fill="#8B94A6" dx="14" textLength="386" lengthAdjust="spacingAndGlyphs">— Kafka advanced testing and engineering suite</tspan></text>
+</svg>

--- a/docs/assets/kates-wordmark.svg
+++ b/docs/assets/kates-wordmark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 44" width="500" height="44" role="img" aria-label="Kates — Kafka advanced testing and engineering suite">
+  <text x="8" y="31" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif"><tspan font-size="30" font-weight="800" fill="#2E8BE6" textLength="22">K</tspan><tspan font-size="30" font-weight="500" fill="#1D2B62" textLength="56">ates</tspan><tspan font-size="17" fill="#5F6B85" dx="14" textLength="386" lengthAdjust="spacingAndGlyphs">— Kafka advanced testing and engineering suite</tspan></text>
+</svg>


### PR DESCRIPTION
## Summary

Replaces the README's raster logo with a text wordmark: **K**ates in an extra-bold blue K, the rest in navy, and the tagline on the same line.

## What changed

- New `docs/assets/kates-wordmark.svg` (light) wired into the README hero — it replaces the old logo image, the `<h1>`, and the bold tagline line in one element. Description paragraph and badges unchanged.
- New `docs/assets/kates-wordmark-dark.svg` shipped alongside for dark surfaces (not yet referenced).
- Both SVGs are ~500 bytes with pinned `textLength` so glyph metrics render consistently across platforms.

## Notes

- `kates-logo.png` stays in the repo — `docs/book/_quarto.yml` uses it as the book cover — but the README no longer references it. This also retires the README's 324 KB JPEG-mislabeled-as-PNG with its baked-in white background.
- This re-lands `630d22e`, which briefly landed on `main` directly and was reverted in `54f8aea` so it could go through review here.
- Possible follow-up: a `<picture>` block serving the dark variant on GitHub's dark theme.
