### PR TITLE
feat(book): build, render, and publish pipeline (phase 1)

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,0 +1,72 @@
+name: Book
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/book/**"
+      - ".github/workflows/book.yml"
+  push:
+    branches: [main]
+    paths:
+      - "docs/book/**"
+      - ".github/workflows/book.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: book-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Render Book
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          tinytex: ${{ github.event_name == 'push' }}
+
+      - name: Install Chromium for mermaid PDF rendering
+        if: github.event_name == 'push'
+        run: quarto install chromium --no-prompt
+
+      # Sources are GitHub-flavored .md so chapters render in the repo file
+      # view; Quarto executes mermaid only in .qmd. The script converts
+      # fences, links, filenames, and the chapter list — build-time only,
+      # never committed.
+      - name: Prepare sources for Quarto
+        run: ./scripts/prepare-book-render.sh
+
+      - name: Render (HTML only, PR gate)
+        if: github.event_name == 'pull_request'
+        run: quarto render docs/book --to html
+
+      - name: Render (HTML + PDF)
+        if: github.event_name == 'push'
+        run: quarto render docs/book
+
+      - name: Upload site artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/book/_book
+
+  deploy:
+    name: Publish to GitHub Pages
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,5 +40,5 @@ jobs:
         with:
           # Offline mode validates only local file links (the drift we care
           # about) and never fails on external outages or localhost URLs.
-          args: --offline --no-progress --include-fragments README.md docs/*.md
+          args: --offline --no-progress --include-fragments README.md "docs/**/*.md"
           fail: true

--- a/docs/book/01-introduction.md
+++ b/docs/book/01-introduction.md
@@ -121,7 +121,7 @@ kates test list
 kates report show <id>
 ```
 
-For a complete setup guide, see [Chapter 12: Deployment Guide](12-deployment.md). For hands-on tutorials, see the [Tutorials](../tutorials/) directory.
+For a complete setup guide, see [Chapter 12: Deployment Guide](12-deployment.md). For hands-on tutorials, see the [Tutorials](https://github.com/bmscomp/kates/tree/main/docs/tutorials) directory.
 
 ## What Kates Is Not
 

--- a/docs/book/09-observability.md
+++ b/docs/book/09-observability.md
@@ -85,7 +85,7 @@ Get in the habit of following this sequence — cluster health → performance �
 
 ## Kafka Grafana Dashboards
 
-Kates deploys six Kafka-focused Grafana dashboards, each targeting a specific monitoring dimension. For the full dashboard and metrics reference, see [docs/monitoring.md](../monitoring.md).
+Kates deploys six Kafka-focused Grafana dashboards, each targeting a specific monitoring dimension. For the full dashboard and metrics reference, see [docs/monitoring.md](https://github.com/bmscomp/kates/blob/main/docs/monitoring.md).
 
 ### Kafka Cluster Health
 

--- a/docs/book/16-grpc-api.md
+++ b/docs/book/16-grpc-api.md
@@ -66,7 +66,7 @@ grpcurl -plaintext localhost:9000 list
 
 ## Service Definitions
 
-The protobuf contract is defined in [`kates.proto`](../../kates/src/main/proto/kates.proto).
+The protobuf contract is defined in [`kates.proto`](https://github.com/bmscomp/kates/blob/main/kates/src/main/proto/kates.proto).
 
 ### TestService
 

--- a/docs/book/17-security.md
+++ b/docs/book/17-security.md
@@ -614,7 +614,7 @@ kates kyverno audit kates-pod-security-standards
 
 ::: {.callout-tip}
 **Cross-references:**
-- For Kyverno installation instructions, see [Chapter 20: Installation Guide](20-installation-guide.md#kyverno-optional).
+- For Kyverno installation instructions, see [Chapter 20: Installation Guide](20-installation-guide.md#15-kyverno-optional).
 - For Kyverno upgrade procedures, see [Chapter 18: Upgrade Playbook](18-upgrade-playbook.md).
 - For a full index of Kyverno-related troubleshooting, see [Appendix B: Troubleshooting](appendix-b-troubleshooting.md#deployment-issues).
 :::

--- a/docs/book/_quarto.yml
+++ b/docs/book/_quarto.yml
@@ -11,7 +11,14 @@ book:
   author: "The Kates Team"
   date: today
   date-format: "MMMM YYYY"
-  cover-image: ../assets/kates-logo.png
+  cover-image: assets/cover.svg
+  repo-url: https://github.com/bmscomp/kates
+  repo-subdir: docs/book
+  repo-actions: [edit, issue]
+  search: true
+  sidebar:
+    logo: assets/kates-wordmark.svg
+  downloads: [pdf]
 
   chapters:
     - index.qmd
@@ -56,7 +63,18 @@ book:
         - appendix-c-cicd.md
 
 format:
+  html:
+    theme:
+      - cosmo
+      - custom.scss
+    toc: true
+    toc-depth: 3
+    code-copy: true
+    code-overflow: wrap
+    mermaid:
+      theme: neutral
   pdf:
+    output-file: kates-definitive-guide
     documentclass: scrbook
     papersize: a4
     fontsize: 11pt

--- a/docs/book/appendix-b-troubleshooting.md
+++ b/docs/book/appendix-b-troubleshooting.md
@@ -42,7 +42,7 @@ A consolidated index of troubleshooting procedures from across the book. Jump to
 | Kafka pods stuck in `Pending` | StorageClass not created or no available nodes in the zone | [Ch 12](12-deployment.md#kafka-pods-not-starting) |
 | PDB blocks rolling restart | Only 1 pod can be unavailable — intentional safety behavior | [Ch 18](18-upgrade-playbook.md#common-upgrade-issues) |
 | Entity Operator never starts | Kafka CR hasn't reached `Ready` — check operator logs for `UnforceableProblem` | [Ch 15](15-kafka-deployment.md#strimzi-operator-cannot-determine-active-controller) |
-| PostgreSQL pod `CrashLoopBackOff` with `could not create lock file` | `readOnlyRootFilesystem: true` mutated by Kyverno — mount `emptyDir` at `/var/run/postgresql` and `/tmp` | [Ch 12](12-deployment.md#postgresql-read-only-filesystem-compliance) |
+| PostgreSQL pod `CrashLoopBackOff` with `could not create lock file` | `readOnlyRootFilesystem: true` mutated by Kyverno — mount `emptyDir` at `/var/run/postgresql` and `/tmp` | [Ch 12](12-deployment.md#read-only-filesystem-compliance) |
 | Pod admission rejected with Kyverno policy violation | Pod doesn't meet PSS standards — run `kates kyverno violations` to identify failing rules, then fix the manifest or add a `PolicyException` | [Ch 17](17-security.md#kyverno-policy-integration--admission-control) |
 
 ## CLI Issues

--- a/docs/book/assets/cover.svg
+++ b/docs/book/assets/cover.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 840" width="600" height="840" role="img" aria-label="Kates — The Definitive Guide">
+  <defs>
+    <marker id="ah" viewBox="0 0 8 8" refX="5" refY="4" markerWidth="3.4" markerHeight="3.4" orient="auto">
+      <path d="M0 0 L8 4 L0 8 Z" fill="#5FA9EE"/>
+    </marker>
+  </defs>
+  <rect width="600" height="840" fill="#1D2B62"/>
+  <g transform="translate(300 250)" fill="none" stroke-linecap="round">
+    <circle r="80" stroke="#2E4080" stroke-width="10"/>
+    <circle cx="0" cy="-80" r="14" fill="#2E4080"/>
+    <circle cx="69.3" cy="40" r="14" fill="#2E4080"/>
+    <circle cx="-69.3" cy="40" r="14" fill="#2E4080"/>
+    <g transform="rotate(-28)">
+      <circle cx="-124.4" cy="29.5" r="11" fill="#5FA9EE"/>
+      <path d="M -124.4 29.5 A 132 86 0 0 1 124.4 -29.5" stroke="#5FA9EE" stroke-width="9" marker-end="url(#ah)"/>
+    </g>
+  </g>
+  <text x="300" y="520" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif"><tspan font-size="88" font-weight="800" fill="#5FA9EE">K</tspan><tspan font-size="88" font-weight="500" fill="#E8EDF5">ates</tspan></text>
+  <rect x="240" y="560" width="120" height="3" fill="#5FA9EE"/>
+  <text x="300" y="620" text-anchor="middle" font-family="Charter, 'Bitstream Charter', Cambria, Georgia, serif" font-size="30" fill="#E8EDF5">The Definitive Guide</text>
+  <text x="300" y="662" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="16" fill="#93A0B4">Performance testing, chaos engineering, and resilience for Apache Kafka</text>
+</svg>

--- a/docs/book/assets/kates-wordmark.svg
+++ b/docs/book/assets/kates-wordmark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 44" width="500" height="44" role="img" aria-label="Kates — Kafka advanced testing and engineering suite">
+  <text x="8" y="31" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif"><tspan font-size="30" font-weight="800" fill="#2E8BE6" textLength="22">K</tspan><tspan font-size="30" font-weight="500" fill="#1D2B62" textLength="56">ates</tspan><tspan font-size="17" fill="#5F6B85" dx="14" textLength="386" lengthAdjust="spacingAndGlyphs">— Kafka advanced testing and engineering suite</tspan></text>
+</svg>

--- a/scripts/prepare-book-render.sh
+++ b/scripts/prepare-book-render.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Build-time conversion of the book sources for Quarto rendering.
+#
+# The committed sources are GitHub-flavored markdown (.md with ```mermaid
+# fences) so chapters render in the GitHub file view. Quarto can only execute
+# mermaid diagrams inside .qmd files with ```{mermaid} cells, so CI runs this
+# script on its checkout right before `quarto render` — the conversion is
+# never committed. It:
+#   1. converts ```mermaid fences to ```{mermaid} executable cells
+#   2. rewrites relative intra-book links from .md to .qmd (URLs untouched)
+#   3. renames chapter .md files to .qmd (README.md stays — not a chapter)
+#   4. updates the chapter list in _quarto.yml accordingly
+set -euo pipefail
+
+cd "$(dirname "$0")/../docs/book"
+
+python3 - <<'PY'
+import glob, os, re
+
+def convert_body(text):
+    text = re.sub(r'^```mermaid[ \t]*$', '```{mermaid}', text, flags=re.M)
+    text = re.sub(r'\]\((?!https?://)([^)#\s]+)\.md(#[^)]*)?\)', r'](\1.qmd\2)', text)
+    return text
+
+for f in sorted(glob.glob('*.md')):
+    if f == 'README.md':
+        continue
+    with open(f, encoding='utf-8') as fh:
+        body = fh.read()
+    with open(f[:-3] + '.qmd', 'w', encoding='utf-8') as fh:
+        fh.write(convert_body(body))
+    os.remove(f)
+
+with open('index.qmd', encoding='utf-8') as fh:
+    idx = fh.read()
+with open('index.qmd', 'w', encoding='utf-8') as fh:
+    fh.write(convert_body(idx))
+
+with open('_quarto.yml', encoding='utf-8') as fh:
+    qy = fh.read()
+qy = re.sub(r'^(\s*- )([\w][\w\-]*)\.md(\s*)$', r'\1\2.qmd\3', qy, flags=re.M)
+with open('_quarto.yml', 'w', encoding='utf-8') as fh:
+    fh.write(qy)
+
+print(f"prepared {len(glob.glob('*.qmd')) - 1} chapters for Quarto render")
+PY


### PR DESCRIPTION
## Summary

Phase 1 of the book enhancement plan: make the Definitive Guide build, render, and publish. Before this PR the book built to PDF only, nothing published it, and all 102 mermaid diagrams shipped as raw source text in that PDF.

## What changed

- **HTML site as the primary format** — `_quarto.yml` now wires the previously orphaned `custom.scss` theme, adds search, per-page edit/issue links, the wordmark as sidebar logo, and a PDF download; the PDF gets a clean `output-file` name (was `Kates-—-The-Definitive-Guide.pdf`, hostile to URLs).
- **New portrait cover** (`docs/book/assets/cover.svg`) — orbit mark + wordmark on brand navy, replacing the retired white-box logo that was referenced from outside the project directory.
- **`scripts/prepare-book-render.sh`** — build-time conversion of the GitHub-flavored `.md` sources into Quarto-executable `.qmd` (mermaid cells, intra-book links, filenames, chapter list). Sources stay GitHub-renderable; the conversion is never committed. Local verification proved the audit's simpler sed-only proposal insufficient: Quarto rejects executable cells in `.md` files.
- **`book.yml` workflow** — `quarto render` as a fast HTML-only gate on PRs touching `docs/book/**`; on main, full HTML+PDF render published to GitHub Pages (`upload-pages-artifact` → `deploy-pages`, no gh-pages branch).
- **Link hygiene** — lychee now checks all of `docs/**/*.md` (book chapters were never link-checked); the two broken anchors this surfaced are fixed, and the three relative links escaping the project directory are now absolute GitHub URLs so they work on GitHub, the site, and in the PDF.

## Verification

- Full local render of all 26 files to HTML succeeds with zero warnings; mermaid diagrams render as diagrams (verified in a served preview: sidebar logo, part navigation, search, repo actions all working).
- Local link/anchor validation over all 44 `docs/**` markdown files passes.

## Action needed after merge

**Enable GitHub Pages** in repo settings (Settings → Pages → Source: **GitHub Actions**) — I left repo settings untouched. Until then the `deploy` job will fail while the render gate still protects PRs.

## Known non-issue

The rendered site shows double numbering ("2  Chapter 2: Architecture & Design") — hardcoded chapter prefixes fighting Quarto's auto-numbering. That is the plan's Phase 3 fix (strip prefixes, let Quarto number) and is intentionally out of scope here.
