### PR TITLE
docs(book): the truth pass — remove fabricated features, fix drifted claims (phase 2)

### DIFF
--- a/docs/book/01-introduction.md
+++ b/docs/book/01-introduction.md
@@ -64,13 +64,13 @@ Disruption tests include safety guardrails: maximum affected broker limits, auto
 
 | Category | Features |
 |----------|----------|
-| **Performance Testing** | 8 test types: Load, Stress, Spike, Endurance, Volume, Capacity, Round-Trip, Integrity |
-| **Chaos Engineering** | 10 disruption types, 6 built-in playbooks, safety guardrails, automatic rollback |
+| **Performance Testing** | Load, Stress, Spike, Endurance, Volume, Capacity, Round-Trip, and Integrity test types |
+| **Chaos Engineering** | Kubernetes-native disruption types, 6 built-in playbooks, safety guardrails, automatic rollback |
 | **Data Integrity** | Sequence tracking, idempotency validation, exactly-once verification, gap detection |
 | **Observability** | Latency heatmaps, broker metrics correlation, historical trends, sparkline charts |
 | **Export Formats** | JSON, CSV, JUnit XML, Grafana-compatible heatmap JSON |
 | **SLA Enforcement** | Per-test thresholds for throughput, latency, error rate with pass/fail verdicts |
-| **CLI** | 30+ commands covering test management, reports, cluster inspection, and disruption control |
+| **CLI** | Commands covering test management, reports, cluster inspection, and disruption control |
 | **Scheduling** | Cron-based recurring tests for regression detection |
 | **Resilience Testing** | Combined performance + chaos tests with before/after impact analysis |
 
@@ -129,6 +129,6 @@ To set expectations clearly:
 
 - **Not a Confluent Platform replacement** — Kates is a testing and validation tool, not a managed Kafka distribution. It works alongside Confluent, Strimzi, or any Kafka deployment.
 - **Not a general-purpose load tester** — Kates understands Kafka semantics (ISR tracking, consumer rebalancing, partition leadership). Use k6, Gatling, or Locust for HTTP/gRPC load testing.
-- **Not a Kafka management UI** — for browsing topics, consumer groups, and cluster state in a web interface, use [Kafka UI](https://github.com/provectus/kafka-ui) (which Kates deploys alongside).
+- **Not a Kafka management UI** — for browsing topics, consumer groups, and cluster state in a web interface, use [Kafka UI](https://github.com/kafbat/kafka-ui) (which Kates deploys alongside).
 - **Not a production monitoring system** — Kates is designed for testing and validation environments. For production monitoring, use Prometheus + Grafana directly (which Kates also deploys for its own observability).
 

--- a/docs/book/02-architecture.md
+++ b/docs/book/02-architecture.md
@@ -114,16 +114,16 @@ The in-process Kafka benchmark engine. Each test launches `WorkerState` threads 
 
 - **Produce** messages with configurable record size, acknowledgment mode, and throughput throttling
 - **Consume** messages with configurable consumer group, fetch settings, and poll timeout
-- **Record latency** in a lock-free `LatencyHistogram` (1024 logarithmic buckets, microsecond precision)
+- **Record latency** in a `LatencyHistogram` backed by HdrHistogram (1µs–60s range, microsecond precision)
 - **Track integrity** — sequence numbers, acknowledgment gaps, and consumer-side deduplication
 
 ### LatencyHistogram
 
-The histogram is the heart of latency measurement. It uses **logarithmic bucketing** to provide high resolution at low latencies (sub-millisecond) while covering tails up to 10+ seconds.
+The histogram is the heart of latency measurement. It is backed by **HdrHistogram** (configured for 1µs–60s with 3 significant value digits), which provides high resolution at low latencies (sub-millisecond) while covering tails up to 60 seconds.
 
 ```mermaid
 graph LR
-    subgraph Internal["1024 Logarithmic Buckets"]
+    subgraph Internal["HdrHistogram (1µs–60s)"]
         B1["0.001ms"] --> B2["0.01ms"] --> B3["0.1ms"] --> B4["1ms"] --> B5["10ms"] --> B6["100ms"] --> B7["1000ms"]
     end
     
@@ -144,7 +144,7 @@ Key methods:
 
 | Method | Lock | Purpose |
 |--------|------|---------|
-| `record(latencyUs)` | Read | Record a single latency observation |
+| `recordLatency(latencyMs)` | Write | Record a single latency observation |
 | `getPercentile(p)` | Read | Compute p50/p95/p99 from cumulative distribution |
 | `exportBuckets()` | Read | Compress to 25 heatmap ranges (non-destructive) |
 | `snapshotAndReset()` | Write | Atomic capture + reset for windowed collection |
@@ -198,16 +198,16 @@ graph TB
 
 | Type | Description | Implementation |
 |------|-------------|----------------|
-| `POD_KILL` | Immediately terminate a broker pod | `kubectl delete pod --grace-period=0` |
-| `POD_DELETE` | Gracefully delete a broker pod | `kubectl delete pod` |
+| `POD_KILL` | Immediately terminate a broker pod | Kubernetes API — force-delete pod (grace period 0) |
+| `POD_DELETE` | Gracefully delete a broker pod | Kubernetes API — delete pod (configurable grace period) |
 | `NETWORK_PARTITION` | Isolate a broker from the cluster | Litmus `pod-network-partition` |
 | `NETWORK_LATENCY` | Inject latency into broker network | Litmus `pod-network-latency` |
 | `CPU_STRESS` | Saturate CPU on a broker node | Litmus `pod-cpu-hog` |
 | `DISK_FILL` | Fill the broker's persistent volume | Litmus `disk-fill` |
 | `ROLLING_RESTART` | Restart all brokers sequentially | Kubernetes rolling update |
 | `LEADER_ELECTION` | Force leader re-election for a partition | Kill the current leader broker |
-| `SCALE_DOWN` | Reduce the number of broker replicas | Strimzi scale operation |
-| `NODE_DRAIN` | Drain a Kubernetes node | `kubectl drain` |
+| `SCALE_DOWN` | Reduce the number of broker replicas | Kubernetes API — scale StatefulSet down by one replica |
+| `NODE_DRAIN` | Drain a Kubernetes node | Litmus `node-drain` |
 
 ### Safety Guardrails
 
@@ -220,7 +220,7 @@ The `DisruptionSafetyGuard` validates every disruption plan before execution:
 
 ## CLI Architecture
 
-The CLI is a **standalone Go binary** built with Cobra. It communicates with the backend exclusively through the REST API.
+The CLI is a **standalone Go binary** built with Cobra. It splits its work between two channels: it calls the backend's REST API for test, report, and disruption operations, and it shells out to `kubectl`, `helm`, and `kind` (via `os/exec`) for cluster provisioning and lifecycle tasks such as `kates deploy`, `kates cluster`, and `kates portforward`.
 
 ```mermaid
 graph TD
@@ -257,7 +257,7 @@ Key design decisions:
 
 - **Multi-context support** — like `kubectl`, the CLI supports named contexts for targeting different Kates instances
 - **Rich terminal output** — tables, colored badges, metric bars, sparkline charts, and ASCII banners
-- **Scaffold templates** — `kates test scaffold --type LOAD` generates ready-to-use YAML scenario files
+- **Scaffold templates** — `kates test scaffold export <name>` writes a ready-to-use YAML scenario file to the current directory (browse the library with `kates test scaffold list`, optionally filtered by `--type LOAD`)
 - **Streaming watch** — `kates test watch` and `kates disruption watch` provide real-time progress updates
 
 ## Data Flow
@@ -348,7 +348,7 @@ sequenceDiagram
 | Operator | Strimzi | 1.0.0 | Kafka lifecycle management |
 | Chaos | LitmusChaos | Latest | Advanced chaos experiments |
 | Monitoring | Prometheus + Grafana | Latest | Metrics collection and visualization |
-| Tracing | Jaeger (OTLP) | 1.64 | Distributed trace collection |
+| Tracing | Jaeger (OTLP) | 2.15.0 | Distributed trace collection |
 | Registry | Apicurio | Latest | Schema registry for Kafka |
 | Database | PostgreSQL | Latest | Test results and schedule persistence |
 | Backup | Velero + MinIO | Latest | Cluster backup and restore |
@@ -428,9 +428,17 @@ erDiagram
 | V2 | `V2__create_schedules_table.sql` | `scheduled_test_runs` for recurring test automation |
 | V3 | `V3__create_disruption_reports.sql` | `disruption_reports` with SLA grade tracking |
 | V4 | `V4__create_disruption_schedules.sql` | `disruption_schedules` for recurring chaos tests |
-| V5–V9 | Various | Connection pooling, batch optimizations, additional indexes |
+| V5 | `V5__create_audit_events.sql` | `audit_events` table for action/event auditing |
+| V6 | `V6__create_webhook_deliveries.sql` | `webhook_deliveries` tracking for outbound webhooks |
+| V7 | `V7__create_profiles.sql` | `profiles` table storing baseline performance profiles |
+| V8 | `V8__create_snapshots.sql` | `snapshots` table for cluster topology captures |
+| V9 | `V9__add_test_tags.sql` | `tags` JSONB column + GIN index on `test_runs` |
 | V10 | `V10__add_composite_indexes.sql` | Composite indexes for test_type + status queries |
 | V11 | `V11__labels_jsonb.sql` | JSONB labels column for flexible test categorization |
+| V12 | `V12__cdc_phases_jsonb.sql` | `cdc_phases_json` column on `test_runs` |
+| V13 | `V13__create_outbox_events.sql` | `outbox_events` table for the transactional outbox pattern |
+| V14 | `V14__create_processed_events.sql` | `processed_events` idempotency-key table for consumer dedup |
+| V15 | `V15__create_webhook_dlq.sql` | `webhook_dlq` dead-letter table for failed webhook deliveries |
 
 ## Graceful Degradation
 
@@ -439,7 +447,7 @@ Distributed systems fail in partial ways. Kates is designed to degrade gracefull
 | Failure Scenario | What Happens | Recovery |
 |------------------|-------------|----------|
 | **Kafka unreachable** | Running tests fail with a connection error. The CLI reports `Kafka: ❌ Disconnected` in health checks. No new tests can be created until Kafka is reachable. Existing test results in PostgreSQL remain accessible. | The backend reconnects automatically when Kafka becomes available. No manual intervention required. |
-| **PostgreSQL down** | Test results from running tests are buffered in the `kates-results` Kafka topic. The backend cannot persist results or serve historical data via the API. The CLI's `test list`, `report show`, and `trend` commands return errors. | On reconnect, the backend replays unconsumed results from the Kafka topic, so no test data is lost. The replay window is limited by the topic's retention period (default: 7 days). |
+| **PostgreSQL down** | Test results from running tests are buffered in the `kates-results` Kafka topic. The backend cannot persist results or serve historical data via the API. The CLI's `test list`, `report show`, and `trend` commands return errors. | On reconnect, the backend replays unconsumed results from the Kafka topic, so no test data is lost. The replay window is limited by the topic's retention period. |
 | **Test interrupted mid-run** | The backend marks the test as `INTERRUPTED` and saves whatever results were collected before the interruption. Partial reports are available via `kates report show`. The test's Kafka consumer group offsets are committed, so no duplicate processing occurs on restart. | You can re-run the test. The interrupted run remains in history for comparison. |
 | **Kates backend crashes during a test** | The Kafka producer/consumer threads stop. In-flight messages may not be acknowledged. When the backend restarts (Kubernetes will restart the pod), it reads test state from PostgreSQL and the `kates-results` topic to reconstruct the last known state. | Kubernetes restarts the pod automatically. Tests that were running are marked as `INTERRUPTED` on recovery. |
 

--- a/docs/book/03-cluster.md
+++ b/docs/book/03-cluster.md
@@ -67,7 +67,7 @@ You can verify the zone distribution at any time with `kates cluster topology`. 
 
 | Component | Memory (req=limit) | CPU (req / limit) | Storage | JVM Heap |
 |-----------|:------------------:|:-----------------:|:-------:|:--------:|
-| Controller | 1Gi | 500m / 1000m | 5Gi | Default |
+| Controller | 1Gi | 500m / 1000m | 5Gi | 512m fixed |
 | Broker | 4Gi | 1000m / 2000m | 50Gi | 2Gi fixed |
 | **Total cluster** | **15Gi** | **4.5 / 9 cores** | **165Gi** | — |
 
@@ -151,7 +151,7 @@ helm upgrade krafter charts/kafka-cluster -n kafka \
   --reuse-values
 ```
 
-After the new broker joins, existing partitions won't automatically rebalance. Use Cruise Control or `kates rebalance` to redistribute partitions.
+After the new broker joins, existing partitions won't automatically rebalance. Use Cruise Control to redistribute partitions — the chart provisions `KafkaRebalance` resources (`full-rebalance` and `add-broker-rebalance`) for exactly this.
 
 ### Testing Single-Zone Failures
 
@@ -189,11 +189,11 @@ Remember to re-apply zone labels after testing. Without rack awareness, a single
 | `tls` | 9093 | internal | mTLS | Yes | Encrypted internal communication |
 | `external` | 9094 | nodeport | SCRAM-SHA-512 | Yes | Access from outside the cluster |
 
-Performance tests use port 9092 (plain) for baseline measurements. TLS adds measurable CPU overhead — test both to quantify the encryption cost on a memory-constrained cluster. On this cluster, expect 10–15% throughput reduction and 20–30% latency increase with TLS enabled, due to the limited CPU budget per broker.
+Performance tests use port 9092 (plain) for baseline measurements. TLS adds measurable CPU overhead — test both to quantify the encryption cost on a memory-constrained cluster. Because the CPU budget per broker is limited here, that overhead is more pronounced than on production hardware, so measure it directly rather than assuming a fixed figure.
 
 ## Topics
 
-Kates provisions five declarative topics via `KafkaTopic` CRDs:
+Kates provisions its core application topics via `KafkaTopic` CRDs:
 
 | Topic | Partitions | Retention | Compression | Purpose |
 |-------|:----------:|-----------|:-----------:|---------|
@@ -214,7 +214,7 @@ Beyond the brokers and controllers, the cluster includes several components that
 | **Cruise Control** | Automated partition rebalancing based on resource utilization | Can trigger unexpected partition movements during long tests — be aware of this if latency shifts mid-run |
 | **Kafka Exporter** | Consumer lag and topic offset metrics | Provides the lag data that `kates cluster watch` displays in sparklines |
 | **Drain Cleaner** | Graceful pod rolling during node drains | Ensures broker restarts during chaos tests are clean (finalizes log segments, flushes buffers) |
-| **Entity Operator** | Topic and User lifecycle management via CRDs | Creates and reconciles the `KafkaTopic` and `KafkaUser` resources listed above |
+| **Entity Operator** | Topic and User lifecycle management via CRDs | Creates and reconciles the `KafkaTopic` and `KafkaUser` resources declared in the chart |
 
 For deep operational details on each component, see [Chapter 15: Kafka Deployment Engineering](15-kafka-deployment.md).
 
@@ -232,22 +232,22 @@ For deep operational details on each component, see [Chapter 15: Kafka Deploymen
 You don't need to memorize the topology — Kates provides built-in cluster inspection commands that give you a live view:
 
 ```bash
-# Cluster overview — brokers, controllers, health
-kates cluster
+# Cluster overview — brokers, controllers, metadata
+kates cluster info
 
 # Full topology — node pools, PVCs, services, network policies
 kates cluster topology
 
 # Topic details with partition layout
 kates cluster topics
-kates cluster topic <topic-name>
+kates cluster topics describe <topic-name>
 
 # Consumer group status with lag
 kates cluster groups
-kates cluster group <group-name>
+kates cluster groups describe <group-id>
 
 # Broker configuration
-kates cluster brokers
+kates cluster broker configs <broker-id>
 
 # Full health check
 kates health

--- a/docs/book/04-performance-theory.md
+++ b/docs/book/04-performance-theory.md
@@ -64,7 +64,7 @@ sequenceDiagram
     Note over Producer,Follower: Total latency = sum of all steps
 ```
 
-Each step adds latency:
+Each step adds latency. The durations below were measured on a local Kind cluster and are illustrative — absolute numbers vary with host hardware:
 
 | Step | Typical Duration | Variable? |
 |------|-----------------|-----------|
@@ -75,7 +75,7 @@ Each step adds latency:
 | Network: follower → leader (ACK) | \< 1ms (Kind) | Low |
 | Network: leader → producer (ACK) | \< 1ms (Kind) | Low |
 
-Under normal conditions, end-to-end latency on the Kind cluster is **2–10ms**. Under load, it can spike to **100ms+** as internal queues fill.
+Under normal conditions, end-to-end latency on a local Kind cluster typically lands around **2–10ms**, depending on the host. Under load, it can spike to **100ms+** as internal queues fill.
 
 ## Why Averages Lie
 
@@ -99,7 +99,7 @@ Percentiles tell you about the **distribution** of latency, not just the center:
 | **P99.9** | 99.9% of requests are faster than this | Your "everything except rare outliers" |
 | **Max** | Worst single observation | Your "worst case" |
 
-Kates reports P50, P95, P99, and Max for every test run.
+Kates reports the mean plus P50, P95, P99, P99.9, and Max for every test run.
 
 ### The Long Tail Problem
 
@@ -123,7 +123,7 @@ In Kafka, tail latency is caused by:
 - **Controller elections** — KRaft metadata operations can cause brief pauses
 
 ::: {.callout-tip}
-GC pauses are the most common source of tail latency in Kates benchmarks. Switching to **ZGC** (`-XX:+UseZGC -XX:+ZGenerational`) reduces GC pauses to under 1ms regardless of heap size. Kates deploys with ZGC by default — see [Chapter 12: Deployment](12-deployment.md#jvm-tuning) for details.
+GC pauses are the most common source of tail latency in Kates benchmarks. Switching to **ZGC** reduces GC pauses to under 1ms regardless of heap size. Kates deploys with generational ZGC by default (`-XX:+UseZGC -XX:+ZGenerational` on its JDK 21 base image; newer JDKs make generational mode the default) — see [Chapter 12: Deployment](12-deployment.md#jvm-tuning) for details.
 :::
 
 
@@ -160,7 +160,9 @@ During the stall, the tool should have sent 19 more requests (at t=30, 40, 50...
 
 ### How Kates Handles It
 
-Kates uses a throughput-stable measurement loop. The producer maintains a fixed target rate regardless of response times. If the system stalls, the producer detects the gap and records corrected latencies for the missed window. This is implemented in the `LatencyHistogram` — all observations are recorded, including the time spent waiting.
+Kates mitigates the classic closed-loop form of coordinated omission by sending asynchronously: the producer loop never waits for an acknowledgment before dispatching the next record, and when a target rate is configured it keeps pacing sends at that rate regardless of response times. A slow response therefore does not hold back subsequent sends.
+
+Know the limits, though: Kates does not apply coordinated-omission correction. The `LatencyHistogram` records only the observations that actually occurred — there is no gap detection and no back-filling of latencies for send slots missed during a stall. If the producer itself blocks (for example, its internal buffer fills while a broker pauses), the percentiles for that window understate what a steady stream of clients would have experienced. For stall-heavy workloads, cross-check the percentiles against the latency heatmap, which makes those windows visible.
 
 ## Heatmaps: Seeing the Full Picture
 
@@ -190,7 +192,7 @@ Kates exports heatmap data in two formats:
 - **JSON** — structured data for Grafana visualization
 - **CSV** — tabular data for spreadsheet analysis
 
-Each heatmap row contains counts across 25 logarithmic latency buckets, sampled every second during the test. For full details on heatmap export commands, bucket boundaries, and reading patterns, see [Chapter 9: Observability — Latency Heatmaps](09-observability.md#latency-heatmaps).
+Each heatmap row contains counts across logarithmic latency buckets, snapshotted each time the running test's status is polled. For full details on heatmap export commands, bucket boundaries, and reading patterns, see [Chapter 9: Observability — Latency Heatmaps](09-observability.md#latency-heatmaps).
 
 ## Statistical Significance
 
@@ -204,7 +206,7 @@ Running a test once and drawing conclusions is dangerous. Performance measuremen
 
 ### Warm-Up Phase
 
-Always discard the first few seconds of data. Kates test types like LOAD and STRESS include configurable warm-up phases where the engine runs at reduced throughput before measuring at full speed.
+Always discard the first few seconds of data. Multi-phase Kates scenarios support a dedicated WARMUP phase that runs at a reduced target throughput ahead of the steady-state phase; results are recorded per phase, so warm-up numbers stay out of your steady-state measurements.
 
 ### Multiple Runs
 
@@ -234,4 +236,4 @@ There is no universal "good" latency or throughput. It depends entirely on your 
 | Batch data pipeline | \< 1s | 1M+ rec/s |
 | Financial transactions | \< 5ms | 1K–10K rec/s |
 
-Kates lets you define SLA thresholds per test type, so "good" is whatever you define it to be.
+Kates lets you define SLA thresholds per test scenario, so "good" is whatever you define it to be.

--- a/docs/book/05-test-types.md
+++ b/docs/book/05-test-types.md
@@ -1,6 +1,6 @@
 # Chapter 5: Test Types Deep Dive
 
-Kates supports eight distinct test types, each designed to answer a specific question about your Kafka cluster's behavior. This chapter explains the methodology, use case, and configuration for every type.
+This chapter covers the eight core Kates test types, each designed to answer a specific question about your Kafka cluster's behavior — the methodology, use case, and configuration for every type. (Kates also has specialized `TUNE_*` parameter-sweep types, covered in [Chapter 10](10-cli-reference.md), and an `INTEGRATION_CDC` type.)
 
 ## Test Type Overview
 
@@ -33,7 +33,7 @@ A LOAD test sends a fixed number of records at a controlled, sustainable rate. I
 graph LR
     subgraph Load["Load Profile"]
         direction LR
-        T1["Warm-up<br/>25% rate<br/>10s"] --> T2["Steady State<br/>100% rate<br/>Duration"] --> T3["Cool-down<br/>Drain<br/>5s"]
+        T1["Start<br/>producers + consumers"] --> T2["Steady State<br/>fixed rate until records sent<br/>or duration reached"] --> T3["Collect<br/>results"]
     end
 ```
 
@@ -48,12 +48,12 @@ graph LR
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `records` | 100,000 | Total messages to produce |
+| `records` | 1,000,000 | Total messages to produce |
 | `recordSizeBytes` | 1024 | Message payload size |
-| `producers` | 1 | Number of concurrent producers |
-| `consumers` | 0 | Number of concurrent consumers |
+| `parallelProducers` | 1 | Number of concurrent producers |
+| `numConsumers` | 1 | Number of concurrent consumers |
 | `acks` | `all` | Producer acknowledgment mode |
-| `topic` | Auto-generated | Target topic name |
+| `topic` | `load-test` | Target topic name (unless overridden) |
 | `partitions` | 3 | Topic partition count |
 | `replicationFactor` | 3 | Topic replication factor |
 
@@ -94,6 +94,8 @@ scenarios:
 
 ### Interpreting Results
 
+Healthy ranges are environment-dependent — treat these as starting points and calibrate against your own baseline:
+
 | Metric | Healthy Range | Warning |
 |--------|:---:|---------|
 | P99 Latency | \< 50ms | > 200ms suggests resource contention |
@@ -113,13 +115,13 @@ For iterative parameter tuning, use `kates lab` instead of individual `test crea
 
 ### Methodology
 
-A STRESS test **ramps throughput progressively** until the cluster can no longer keep up. It finds the saturation point and characterizes the degradation curve.
+A STRESS test pushes the cluster well past its comfortable operating point to find the saturation point and characterize the degradation curve. How the load is applied depends on the backend: the default native backend runs several **concurrent unthrottled producers** (`parallelProducers`, default 3), while the Trogdor backend (`--backend trogdor`) **ramps throughput progressively** through five steps, each getting a fifth of the test duration:
 
 ```mermaid
 graph LR
-    subgraph Stress["Load Profile"]
+    subgraph Stress["Load Profile (Trogdor backend)"]
         direction LR
-        P1["Phase 1<br/>25% capacity<br/>30s"] --> P2["Phase 2<br/>50% capacity<br/>30s"] --> P3["Phase 3<br/>75% capacity<br/>30s"] --> P4["Phase 4<br/>100% capacity<br/>30s"] --> P5["Phase 5<br/>125%+ capacity<br/>Until failure"]
+        P1["Phase 1<br/>10K msg/s"] --> P2["Phase 2<br/>25K msg/s"] --> P3["Phase 3<br/>50K msg/s"] --> P4["Phase 4<br/>100K msg/s"] --> P5["Phase 5<br/>Unlimited<br/>until duration ends"]
     end
 ```
 
@@ -133,9 +135,9 @@ graph LR
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `producers` | 1–8 (ramping) | Progressive increase per phase |
-| `durationSeconds` | 300 | Total test duration across phases |
-| `records` | 1,000,000+ | Enough to sustain all phases |
+| `parallelProducers` | 3 | Concurrent producers (native backend) |
+| `durationSeconds` | 900 | Total test duration (Trogdor splits it evenly across the ramp steps) |
+| `records` | 5,000,000 | Enough to sustain the full run |
 | `recordSizeBytes` | 1024 | Message size |
 
 ### Interpreting Results
@@ -171,13 +173,13 @@ graph TD
 
 ### Methodology
 
-A SPIKE test simulates a flash-sale or viral event — a sudden, dramatic increase in traffic followed by a return to normal.
+A SPIKE test simulates a flash-sale or viral event — a sudden, dramatic increase in traffic followed by a return to normal. On the Trogdor backend, the baseline → spike → recovery sequence is automated; the default native backend instead runs a single unthrottled burst producer, so you measure the burst itself and observe recovery in your monitoring.
 
 ```mermaid
 graph LR
-    subgraph Spike["Load Profile"]
+    subgraph Spike["Load Profile (Trogdor backend)"]
         direction LR
-        S1["Baseline<br/>Normal rate<br/>30s"] --> S2["SPIKE!<br/>10x rate<br/>15s"] --> S3["Recovery<br/>Normal rate<br/>60s"]
+        S1["Baseline<br/>1K msg/s<br/>60s"] --> S2["SPIKE!<br/>3 unthrottled producers<br/>120s"] --> S3["Recovery<br/>1K msg/s<br/>60s"]
     end
 ```
 
@@ -191,9 +193,10 @@ graph LR
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `producers` | 1 → 10 → 1 | Sudden increase then decrease |
-| `records` | Per-phase targets | Different record counts per phase |
-| `durationSeconds` | 120 | Enough for baseline + spike + recovery |
+| `records` | 2,000,000 | Total records for the burst |
+| `recordSizeBytes` | 1024 | Message size |
+| `durationSeconds` | 300 | Enough for baseline + spike + recovery |
+| `acks` | `1` | Latency-oriented default for burst traffic |
 
 ### Key Metrics
 
@@ -217,7 +220,7 @@ An ENDURANCE (soak) test runs at a moderate, realistic load for an **extended pe
 graph LR
     subgraph Endurance["Load Profile"]
         direction LR
-        E1["Warm-up<br/>10min"] --> E2["Sustained Load<br/>60% capacity<br/>4-24 hours"] --> E3["Cool-down<br/>5min"]
+        E1["Sustained rate-limited load<br/>5,000 msg/s default<br/>1h default — extend to 4-24h for leak hunting"]
     end
 ```
 
@@ -235,9 +238,10 @@ graph LR
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `durationSeconds` | 14400 (4h) | Long enough to expose leaks |
-| `producers` | 2 | Moderate, sustainable load |
-| `records` | 10,000,000+ | Enough for the full duration |
+| `durationSeconds` | 3600 (1h) | Override with longer values to expose slow leaks |
+| `parallelProducers` | 1 | Moderate, sustainable load |
+| `targetThroughput` | 5,000 msg/s | Rate limit that keeps the load sustainable |
+| `records` | 10,000,000 | Enough for the full duration |
 
 ---
 
@@ -247,13 +251,13 @@ graph LR
 
 ### Methodology
 
-A VOLUME test focuses on **data size** rather than request rate. It sends large messages or large total volumes to stress the storage and replication subsystems.
+A VOLUME test focuses on **data size** rather than request rate. It sends large messages or large total volumes to stress the storage and replication subsystems. The default native backend runs a single producer with large records (10 KB by default); the Trogdor backend runs two workloads in parallel:
 
 ```mermaid
-graph LR
-    subgraph Volume["Load Profile"]
-        direction LR
-        V1["Small records<br/>1KB × 100K"] --> V2["Medium records<br/>10KB × 50K"] --> V3["Large records<br/>100KB × 10K"] --> V4["Jumbo records<br/>500KB × 1K"]
+graph TB
+    subgraph Volume["Volume workloads (Trogdor backend, run in parallel)"]
+        V1["Large messages<br/>50K × 100KB"]
+        V2["High count<br/>5M × 1KB"]
     end
 ```
 
@@ -267,8 +271,8 @@ graph LR
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `recordSizeBytes` | 10241.0.000 | Large message sizes |
-| `records` | Variable | Enough to stress storage |
+| `recordSizeBytes` | 10,240 | Large messages (10 KB) |
+| `records` | 2,000,000 | Enough to stress storage |
 | `acks` | `all` | Full replication to measure real cost |
 
 **Scenario file equivalent:**
@@ -294,13 +298,13 @@ scenarios:
 
 ### Methodology
 
-A CAPACITY test removes all artificial throttling and pushes the cluster to its maximum throughput. It finds the ceiling and measures what metric (CPU, disk, memory, network) is the bottleneck.
+A CAPACITY test removes all artificial throttling and pushes the cluster to its maximum throughput. It finds the ceiling and measures what metric (CPU, disk, memory, network) is the bottleneck. The default native backend runs `parallelProducers` (default 5) unthrottled producers concurrently; the Trogdor backend probes stepped throughput targets:
 
 ```mermaid
 graph LR
-    subgraph Capacity["Load Profile"]
+    subgraph Capacity["Probe steps (Trogdor backend)"]
         direction LR
-        C1["Phase 1<br/>1 producer<br/>no throttle"] --> C2["Phase 2<br/>2 producers<br/>no throttle"] --> C3["Phase 3<br/>4 producers<br/>no throttle"] --> C4["Phase 4<br/>8 producers<br/>no throttle"] --> C5["Phase 5<br/>16 producers<br/>no throttle"]
+        C1["5K msg/s"] --> C2["10K msg/s"] --> C3["20K msg/s"] --> C4["40K msg/s"] --> C5["80K msg/s"] --> C6["Unlimited"]
     end
 ```
 
@@ -308,14 +312,14 @@ graph LR
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `producers` | 1–16 (stepped) | Each phase adds producers |
-| `throughput` | -1 (unlimited) | No rate limiting |
+| `parallelProducers` | 5 | Concurrent unthrottled producers (native backend) |
 | `recordSizeBytes` | 1024 | Standard message size |
-| `records` | 2,000,000+ | Enough for all phases |
+| `records` | 10,000,000 | Enough for the full run |
+| `durationSeconds` | 1200 | Test duration |
 
 ### Interpreting Results
 
-The output is a throughput curve. Max throughput is where adding more producers stops increasing total rec/s:
+The output is a throughput curve, built by running a series of CAPACITY tests with increasing `--producers` counts. Max throughput is where adding more producers stops increasing total rec/s (illustrative numbers):
 
 | Producers | Throughput | Interpretation |
 |:-:|:-:|---|
@@ -356,9 +360,10 @@ sequenceDiagram
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `producers` | 1 | Single producer for clean measurement |
-| `consumers` | 1 | Single consumer to capture delivery |
-| `records` | 10,000 | Fewer records, focus on latency quality |
+| `parallelProducers` | 1 | Single producer for clean measurement |
+| `numConsumers` | 1 | Single consumer to capture delivery |
+| `records` | 500,000 | Records to measure |
+| `targetThroughput` | 10,000 msg/s | Rate-limited to keep latency measurements clean |
 
 **Scenario file equivalent:**
 
@@ -427,12 +432,13 @@ graph TB
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `records` | 100,000 | Messages to verify |
-| `acks` | `all` | Required for integrity guarantees |
-| `idempotenceEnabled` | `true` | Kafka producer idempotency |
-| `transactionsEnabled` | `false` | Optional exactly-once |
-| `consumers` | 1 | Consumer for verification |
-| `consumerGroup` | Auto-generated | Consumer group name |
+| `records` | 1,000,000 | Messages to verify |
+| `acks` | `all` | Forced to `all` for integrity guarantees |
+| `enableIdempotence` | `false` | Kafka producer idempotency — enable it for duplicate detection |
+| `enableTransactions` | `false` | Optional exactly-once |
+| `enableCrc` | `true` | Per-record CRC payload verification |
+| `numConsumers` | 1 | Consumer for verification |
+| `consumerGroup` | `integrity-cg` | Consumer group name (unless overridden) |
 
 **Scenario file equivalent:**
 
@@ -454,29 +460,61 @@ scenarios:
 
 ### Integrity + Chaos
 
-The real power of INTEGRITY tests emerges when combined with chaos engineering:
+The real power of INTEGRITY tests emerges when combined with chaos engineering. `INTEGRITY` is not a chaos test by itself — the combination is orchestrated by `kates resilience run`, which pairs a test request with a chaos experiment (see [Chapter 7](07-chaos-practice.md)):
 
-```bash
-# Generate a chaos-aware integrity test scaffold
-kates test scaffold --type INTEGRITY_CHAOS -o integrity-chaos.yaml
+```yaml
+# resilience-integrity.yaml
+testRequest:
+  type: INTEGRITY
+  spec:
+    numRecords: 100000
+    enableIdempotence: true
 
-# Run it — produces messages while killing a broker
-kates test apply -f integrity-chaos.yaml --wait
+chaosSpec:
+  experimentName: kafka-broker-pod-kill
+  targetNamespace: kafka
+  disruptionType: POD_KILL
+  chaosDurationSec: 30
+
+steadyStateSec: 30
 ```
 
-This test produces messages, kills a broker mid-test, waits for recovery, and then verifies that **every single message** was persisted correctly. It is the ultimate validation of Kafka's durability guarantees.
+```bash
+# Run it — produces messages while killing a broker
+kates resilience run -f resilience-integrity.yaml
+```
+
+This produces messages, kills a broker mid-test, waits for recovery, and then verifies that **every single message** was persisted correctly. It is the ultimate validation of Kafka's durability guarantees. For a standalone transactional integrity scenario, export the built-in template instead: `kates test scaffold export integrity-tx`.
 
 ## Scenario Files
 
-All test types support YAML scenario files for reproducible, version-controlled test definitions. See [Chapter 13: Scenario Files & SLA Gates](13-scenario-files.md) for the complete YAML schema reference, including all 22 spec fields and 9 SLA validation gates.
+All test types support YAML scenario files for reproducible, version-controlled test definitions. See [Chapter 13: Scenario Files & SLA Gates](13-scenario-files.md) for the complete YAML schema reference, including the full spec field list and the SLA validation gates.
+
+The CLI ships a curated library of built-in templates. Browse it with `list` (optionally filtered by `--type`), preview with `show`, and write a ready-to-edit file with `export`:
 
 ```bash
-# Generate a scaffold for any test type
+# Browse the built-in template library
+kates test scaffold list
 kates test scaffold --type LOAD
-kates test scaffold --type STRESS
-kates test scaffold --type SPIKE
-kates test scaffold --type INTEGRITY_CHAOS
+
+# Preview and export a template
+kates test scaffold show quick-load
+kates test scaffold export quick-load
 
 # Apply a scenario
-kates test apply -f scenario.yaml --wait
+kates test apply -f quick-load.yaml --wait
 ```
+
+CLI flags and scenario-file spec keys use different names for the same setting. The canonical mapping:
+
+| CLI flag (`kates test create`) | Scenario YAML key (`spec:`) | Meaning |
+|---|---|---|
+| `--records` | `records` | Total records |
+| `--producers` | `parallelProducers` | Concurrent producers |
+| `--consumers` | `numConsumers` | Concurrent consumers |
+| `--record-size` | `recordSizeBytes` | Record size in bytes |
+| `--duration` | `durationSeconds` | Test duration in seconds |
+| `--acks` | `acks` | Producer acknowledgment mode |
+| `--topic` | `topic` | Topic name |
+| `--throughput` | `targetThroughput` | Rate limit in msg/s (-1 = unlimited) |
+| — | `enableIdempotence`, `enableTransactions`, `enableCrc` | Integrity options (scenario files only) |

--- a/docs/book/06-chaos-theory.md
+++ b/docs/book/06-chaos-theory.md
@@ -96,8 +96,9 @@ Chaos experiments in a toy environment prove nothing. The Kind cluster in this p
 One-off chaos tests are useful; scheduled, repeating chaos tests are powerful. Kates supports cron-based scheduling:
 
 ```bash
-# Run an integrity chaos test every night at 2 AM
-kates schedule create --type INTEGRITY --records 100000 --cron "0 2 * * *"
+# Run an integrity test every night at 2 AM
+# (integrity.json holds the test request, e.g. {"type": "INTEGRITY", "spec": {"numRecords": 100000}})
+kates schedule create --name "Nightly Integrity" --cron "0 2 * * *" --request integrity.json
 ```
 
 ### 5. Minimize Blast Radius
@@ -181,7 +182,7 @@ sequenceDiagram
     Note over P,F2: Gap = detection time + election time
 ```
 
-Key timing:
+Key timing (with default broker and client configs):
 
 | Phase | Typical Duration | Depends On |
 |-------|:---:|---|
@@ -220,7 +221,7 @@ sequenceDiagram
     C3->>Coord: JoinGroup
     Coord->>C1: Rebalance triggered
     Coord->>C2: Rebalance triggered
-    Note over C1,C2: All consumers stop processing
+    Note over C1,C2: All consumers stop processing<br/>(classic eager protocol)
     C1->>Coord: JoinGroup (re-negotiate)
     C2->>Coord: JoinGroup (re-negotiate)
     C3->>Coord: JoinGroup
@@ -230,7 +231,7 @@ sequenceDiagram
     Note over C1,C3: Processing resumes
 ```
 
-During rebalancing, **all consumers in the group stop processing**. This "stop-the-world" pause can last seconds to minutes depending on group size and partition count.
+The diagram shows the classic **eager** protocol, where all consumers in the group stop processing during a rebalance — a "stop-the-world" pause that can last seconds to minutes depending on group size and partition count. Cooperative incremental rebalancing (KIP-429) shrinks the pause to only the partitions that actually move, and the next-generation consumer group protocol (KIP-848, `group.protocol=consumer`) removes the global synchronization barrier entirely. Kates test workloads can exercise either protocol via the per-test-type `group-protocol` setting (default: `classic`).
 
 ## Key Metrics During Chaos
 
@@ -265,12 +266,6 @@ The `make gameday` command automates this entire pipeline. Each phase is logged 
 ```bash
 # Run the full 7-phase pipeline
 make gameday
-
-# Run with a specific disruption playbook
-make gameday PLAYBOOK=leader-cascade
-
-# Dry run (pre-flight only, no chaos injected)
-make gameday DRY_RUN=true
 ```
 
 ## Fault Injection Approaches
@@ -280,7 +275,7 @@ Kates supports multiple fault injection backends. Choose based on your environme
 | Feature | LitmusChaos | Trogdor | Manual kubectl |
 |---------|:-----------:|:-------:|:--------------:|
 | **Scope** | General-purpose Kubernetes chaos | Kafka-specific fault injection | Ad-hoc pod/network operations |
-| **Installation** | Helm chart + CRDs | Bundled with Kafka (Confluent) | None (built into Kubernetes) |
+| **Installation** | Helm chart + CRDs | Bundled with Apache Kafka | None (built into Kubernetes) |
 | **Kafka awareness** | Low — operates at pod/network level | High — understands partitions, brokers, topics | None |
 | **Experiment types** | Pod kill, network chaos, CPU/memory stress, disk fill | Broker bounce, network degrade, produce/consume workloads | Pod delete, node drain, network policy changes |
 | **Scheduling** | CronWorkflows via Argo or native ChaosSchedule | Trogdor coordinator API | Cron jobs or CI/CD triggers |
@@ -288,7 +283,7 @@ Kates supports multiple fault injection backends. Choose based on your environme
 | **Blast radius control** | Annotations, labels, namespace selectors | Agent-level targeting | Manual — requires discipline |
 | **Reproducibility** | Declarative YAML ChaosExperiments | Declarative JSON task specs | Script-dependent |
 | **Best for** | Production chaos with safety guardrails | Kafka-internal workload simulation | Quick smoke tests, debugging |
-| **Kates integration** | Native — `kates disruption run` uses LitmusChaos | Partial — can be triggered via `chaosSpec` | Manual — run alongside Kates tests |
+| **Kates integration** | Native — `kates disruption run` uses LitmusChaos | Optional — selectable test workload backend (`backend: trogdor` in the test request) | Manual — run alongside Kates tests |
 
 ::: {.callout-tip}
 For most Kates users, **LitmusChaos** is the recommended default. It provides the best balance of safety, observability, and Kubernetes-native integration. Use Trogdor when you need Kafka-internal fault injection (e.g., simulating slow brokers at the protocol level), and manual kubectl for quick one-off debugging sessions.

--- a/docs/book/07-chaos-practice.md
+++ b/docs/book/07-chaos-practice.md
@@ -13,8 +13,8 @@ graph TB
     subgraph Validation["Pre-Flight Validation"]
         SG[Safety Guard]
         SG --> CHK1[Max affected<br/>brokers check]
-        SG --> CHK2[ISR health<br/>check]
-        SG --> CHK3[Quorum<br/>protection]
+        SG --> CHK2[Target broker<br/>pods exist]
+        SG --> CHK3[At least one broker<br/>survives the plan]
     end
     
     subgraph Execution["Step-by-Step Execution"]
@@ -47,51 +47,53 @@ graph TB
 
 ## Disruption Types
 
-Kates supports 10 disruption types across two implementation backends:
+Kates supports 13 disruption types (the `DisruptionType` enum), implemented by two backends:
 
 ### Direct Kubernetes API
 
-These disruptions use the Kubernetes API directly — no additional tooling required:
+The `KubernetesChaosProvider` implements these disruptions against the Kubernetes API directly — no additional tooling required:
 
 | Type | Implementation | Effect |
 |------|---------------|--------|
-| `POD_KILL` | `kubectl delete pod --grace-period=0` | Immediate broker termination, simulates SIGKILL |
-| `POD_DELETE` | `kubectl delete pod` | Graceful shutdown, broker flushes and shuts down |
-| `ROLLING_RESTART` | Sequential pod deletions with readiness checks | Simulates operator-managed rolling updates |
-| `LEADER_ELECTION` | Kill the pod hosting the leader for a specific partition | Forces leader election for targeted partition |
-| `SCALE_DOWN` | Modify Strimzi Kafka CR `replicas` field | Reduces broker count through the operator |
-| `NODE_DRAIN` | `kubectl drain --delete-emptydir-data` | Evicts all pods from a node, simulates AZ failure |
+| `POD_KILL` | Delete pod with grace period 0 | Immediate broker termination, simulates SIGKILL |
+| `POD_DELETE` | Delete pod with configurable grace period | Graceful shutdown, broker flushes and shuts down |
+| `ROLLING_RESTART` | Rolling restart of the matching StatefulSets | Simulates operator-managed rolling updates |
+| `LEADER_ELECTION` | Resolve the partition leader, then force-delete its pod | Forces leader election for targeted partition |
+| `SCALE_DOWN` | Scale the matching StatefulSets down by one replica | Reduces broker count |
+| `NETWORK_PARTITION` | Deny-all NetworkPolicy applied to the target pod | Isolates a broker from the cluster network |
+| `CPU_STRESS` | Stress ephemeral container injected into the pod | Saturates CPU on the broker pod |
+| `IO_STRESS` | Stress ephemeral container injected into the pod | Injects disk I/O pressure on broker storage |
 
 ### LitmusChaos Integration
 
-These disruptions leverage LitmusChaos CRDs for more sophisticated fault injection:
+When LitmusChaos is installed, the `LitmusChaosProvider` maps every disruption type to a Litmus experiment (for example, `POD_KILL` and `POD_DELETE` both map to `pod-delete`). Five types are only available through Litmus:
 
 | Type | Litmus Experiment | Effect |
 |------|-------------------|--------|
-| `NETWORK_PARTITION` | `pod-network-partition` | Isolates a broker from the cluster network |
 | `NETWORK_LATENCY` | `pod-network-latency` | Adds configurable latency to broker traffic |
-| `CPU_STRESS` | `pod-cpu-hog` | Saturates CPU on the broker pod |
+| `MEMORY_STRESS` | `pod-memory-hog` | Consumes memory on the broker pod |
+| `DNS_ERROR` | `pod-dns-error` | Injects DNS resolution failures on broker pods |
 | `DISK_FILL` | `disk-fill` | Fills the broker's PVC, triggering out-of-space errors |
+| `NODE_DRAIN` | `node-drain` | Drains the node hosting a broker, simulates node/AZ failure |
 
 ### The Hybrid Provider
 
 ```mermaid
 graph TD
-    DO[DisruptionOrchestrator] --> HCP[HybridChaosProvider]
+    DO[DisruptionOrchestrator] --> HCP[HybridChaosProvider<br/>startup: are Litmus CRDs installed?]
     
-    HCP --> KCP[KubernetesChaosProvider<br/>POD_KILL, POD_DELETE,<br/>ROLLING_RESTART, LEADER_ELECTION,<br/>SCALE_DOWN, NODE_DRAIN]
+    HCP -->|Litmus detected| LCP[LitmusChaosProvider<br/>all types via Litmus experiments]
+    HCP -->|Litmus not found| KCP[KubernetesChaosProvider<br/>direct API subset]
     
-    HCP --> LCP[LitmusChaosProvider<br/>NETWORK_PARTITION,<br/>NETWORK_LATENCY,<br/>CPU_STRESS, DISK_FILL]
-    
-    KCP --> K8S[Kubernetes API]
     LCP --> LIT[LitmusChaos CRDs]
+    KCP --> K8S[Kubernetes API]
 ```
 
-The `HybridChaosProvider` routes each disruption to the appropriate backend based on its type. This allows you to use simple Kubernetes-native operations where possible, and Litmus only where advanced network or resource injection is needed.
+The `HybridChaosProvider` (selected with `kates.chaos.provider=hybrid`) picks its backend once, at startup: it checks whether the Litmus CRDs (`chaosengines.litmuschaos.io`) exist in the cluster. If they do, it delegates **all** fault injection to the `LitmusChaosProvider`; otherwise it falls back to the direct `KubernetesChaosProvider`. There is no per-type routing — a single delegate handles every disruption for the lifetime of the process.
 
 ## Built-In Playbooks
 
-Kates ships with 6 production-tested playbooks located in `kates/src/main/resources/playbooks/`. Each playbook is a YAML file that defines a complete disruption scenario with safety parameters, fault steps, and observation windows.
+Kates ships with a set of built-in playbooks located in `kates/src/main/resources/playbooks/` — that directory is the source of truth for the YAML shown below. Each playbook is a YAML file that defines a complete disruption scenario with safety parameters, fault steps, and observation windows.
 
 ### leader-cascade
 
@@ -198,7 +200,7 @@ graph TB
     end
     
     subgraph During["During AZ Failure"]
-        N1b[Node: alpha ❌<br/>DRAINED]
+        N1b[Node: alpha ❌<br/>Broker 0 killed]
         N2b[Node: sigma ✅<br/>Broker 1]
         N3b[Node: gamma ✅<br/>Broker 2]
     end
@@ -325,25 +327,26 @@ The `DisruptionSafetyGuard` validates every plan before execution:
 
 ```mermaid
 graph TD
-    PLAN[Disruption Plan] --> V1{Max affected<br/>brokers ≤ N?}
-    V1 -->|Yes| V2{Current ISR<br/>healthy?}
-    V1 -->|No| REJECT1["❌ Rejected:<br/>Too many brokers affected"]
-    V2 -->|Yes| V3{KRaft quorum<br/>maintained?}
-    V2 -->|No| REJECT2["❌ Rejected:<br/>Cluster already degraded"]
-    V3 -->|Yes| V4{Auto-rollback<br/>configured?}
-    V3 -->|No| REJECT3["❌ Rejected:<br/>Would break quorum"]
-    V4 -->|Yes| EXECUTE["✅ Execute with<br/>rollback enabled"]
-    V4 -->|No| WARN["⚠ Execute with<br/>warning"]
+    PLAN[Disruption Plan] --> V1{Broker pods found<br/>for target label?}
+    V1 -->|No| REJECT1["❌ Rejected:<br/>No broker pods found"]
+    V1 -->|Yes| V2{Affected brokers ≤<br/>maxAffectedBrokers?}
+    V2 -->|No| REJECT2["❌ Rejected:<br/>Too many brokers affected"]
+    V2 -->|Yes| V3{At least one broker<br/>left untouched?}
+    V3 -->|No| REJECT3["❌ Rejected:<br/>Would affect ALL brokers"]
+    V3 -->|"Yes, but only one"| WARN["⚠ Execute with warning:<br/>only 1 broker remains"]
+    V3 -->|Yes| EXECUTE["✅ Execute"]
 ```
+
+The guard also emits per-step warnings — for example, `SCALE_DOWN` without `autoRollback`, or a `NETWORK_PARTITION` with no duration (the NetworkPolicy would persist until cleanup).
 
 ### Guardrail Parameters
 
 | Parameter | Purpose | Default |
 |-----------|---------|---------|
-| `maxAffectedBrokers` | Maximum brokers to disrupt simultaneously | 1 |
-| `autoRollback` | Automatically restore if health deteriorates | true |
-| `isrTrackingTopic` | Topic to monitor for ISR health | `__consumer_offsets` |
-| `requireRecovery` | Wait for cluster recovery between steps | true |
+| `maxAffectedBrokers` | Maximum brokers to disrupt simultaneously (checked only when > 0) | `-1` (no limit) |
+| `autoRollback` | Automatically restore if health deteriorates | `true` |
+| `isrTrackingTopic` | Topic to monitor for ISR health | unset |
+| `requireRecovery` | Wait for cluster recovery between steps | `false` |
 
 ## Kafka Intelligence
 
@@ -374,52 +377,54 @@ During execution, Kates captures ISR snapshots:
 kates disruption kafka-metrics <id>
 ```
 
-Output includes:
+Output includes, per step:
 
-- ISR state before disruption
-- ISR state during disruption (which replicas fell out)
-- ISR state after recovery (when all replicas caught up)
-- Time to full ISR recovery
+- Time to full ISR recovery (or `NOT RECOVERED`)
+- Minimum ISR depth reached during the disruption
+- Peak number of under-replicated partitions
+- Total partitions tracked
 
 ### Consumer Lag Monitoring
 
 For consumer-facing tests, Kates tracks consumer group lag:
 
-- Peak lag during disruption
-- Lag recovery rate (messages/second of drain)
-- Time to zero lag
+- Baseline lag before the fault
+- Peak lag during disruption, and the spike over baseline
+- Time to lag recovery
 
 ## SLA Grading
 
-Every disruption report includes an **SLA grade** — a structured verdict on whether the cluster met its resilience targets.
+Every disruption report includes an **SLA grade** — a structured verdict on whether the cluster met its resilience targets. The thresholds are not built in: you define them in the plan's `sla` block (an `SlaDefinition`), and the `SlaGrader` checks each step's post-disruption metrics against them. A plan with no SLA constraints grades `A` with zero checks.
 
 ```mermaid
 graph TD
-    subgraph Metrics["Collected Metrics"]
-        M1[Recovery Time]
-        M2[Max Latency Spike]
-        M3[Messages Lost]
-        M4[ISR Recovery Time]
-        M5[Consumer Lag Peak]
+    subgraph Metrics["Post-Disruption Metrics (per step)"]
+        M1[Avg / P99 / P999 Latency]
+        M2[Throughput]
+        M3[Error Rate]
+        M4["Recovery Time (RTO)"]
+        M5[Data Loss %]
     end
     
-    subgraph Thresholds["SLA Thresholds"]
-        T1["Recovery ≤ 30s"]
-        T2["Latency ≤ 500ms"]
-        T3["Loss = 0"]
-        T4["ISR ≤ 60s"]
-        T5["Lag ≤ 10,000"]
+    subgraph Thresholds["SLA Thresholds (plan's sla block)"]
+        T1[maxAvgLatencyMs<br/>maxP99LatencyMs<br/>maxP999LatencyMs]
+        T2[minThroughputRecPerSec]
+        T3[maxErrorRate]
+        T4[maxRtoMs]
+        T5[maxDataLossPercent]
     end
     
-    subgraph Verdict
-        PASS["PASS ✅<br/>All thresholds met"]
-        WARN["WARN ⚠<br/>Some marginal"]
-        FAIL["FAIL ❌<br/>Thresholds breached"]
+    subgraph Verdict["Letter Grade"]
+        A["A ✅<br/>All checks passed"]
+        BCD["B / C / D ⚠<br/>By fraction of failed checks"]
+        F["F ❌<br/>Any CRITICAL violation"]
     end
     
     Metrics --> Thresholds
     Thresholds --> Verdict
 ```
+
+Each violation is classified `WARNING` or `CRITICAL` — a breach far past its threshold (for example, P99 latency or recovery time at more than twice the limit, throughput below half the minimum, or any data loss over the cap) is `CRITICAL`. The grade is `A` when every check passes, `F` if any violation is critical, and otherwise `B`, `C`, or `D` depending on the fraction of checks that failed (more than 25% → `C`, more than 50% → `D`).
 
 ### CI/CD Integration
 
@@ -472,13 +477,13 @@ During execution, Kates provides real-time progress via Server-Sent Events (SSE)
 kates disruption watch <id>
 ```
 
-The CLI displays:
+The CLI displays each event as it arrives:
 
-- Current step name and status
-- ISR state changes
-- Consumer lag updates
-- Recovery progress
-- Final SLA verdict
+- Step start and completion
+- Baseline and post-fault metrics capture
+- Fault injection and recovery waiting
+- Rollback events
+- Final SLA grade and completion status
 
 ## Resilience Testing: Performance + Chaos Combined
 
@@ -512,34 +517,34 @@ graph LR
 ```
 
 ```bash
-# Create a resilience test config
-cat > resilience-test.json << 'EOF'
-{
-  "testRequest": {
-    "testType": "LOAD",
-    "spec": {
-      "records": 100000,
-      "producers": 4,
-      "recordSizeBytes": 1024,
-      "acks": "all"
-    }
-  },
-  "chaosSpec": {
-    "experimentName": "kafka-pod-kill",
-    "targetNamespace": "kafka"
-  },
-  "steadyStateSec": 30
-}
+# Create a resilience test config (YAML or JSON)
+cat > resilience-test.yaml << 'EOF'
+testRequest:
+  type: LOAD
+  spec:
+    numRecords: 100000
+    numProducers: 4
+    recordSize: 1024
+    acks: all
+
+chaosSpec:
+  experimentName: kafka-pod-kill
+  disruptionType: POD_KILL
+  targetNamespace: kafka
+  targetLabel: "strimzi.io/component-type=kafka"
+  chaosDurationSec: 30
+
+steadyStateSec: 30
 EOF
 
 # Run it
-kates resilience run --config resilience-test.json
+kates resilience run -f resilience-test.yaml
 ```
 
-The output shows:
+The CLI prints the chaos outcome, a pre-chaos baseline and post-chaos summary (throughput, P99 latency, error rate), and an **Impact Analysis** table with the percentage change of each metric — `throughputRecPerSec`, `avgLatencyMs`, `p99LatencyMs`, `maxLatencyMs`, and `errorRate`. With illustrative numbers:
 
-| Metric | Pre-Chaos | Post-Chaos | Change |
-|--------|:-:|:-:|:-:|
-| Throughput (rec/s) | 45,000 | 38,000 | -15.6% ▼ |
-| P99 Latency (ms) | 12.3 | 85.7 | +596.7% ▲ |
-| Error Rate | 0.0% | 0.3% | +0.3% |
+| Metric | Change | |
+|--------|-------:|:-:|
+| `throughputRecPerSec` | -15.6% | ▼ |
+| `p99LatencyMs` | +596.7% | ▲ |
+| `errorRate` | +0.3% | |

--- a/docs/book/08-data-integrity.md
+++ b/docs/book/08-data-integrity.md
@@ -56,23 +56,22 @@ graph TB
 
 ## Sequence Number Tracking
 
-Each message in an INTEGRITY test carries a metadata payload:
+Each message in an INTEGRITY test carries a 28-byte binary header (`SequencedPayload`), zero-padded to the configured record size:
 
-```json
-{
-  "seq": 42,
-  "producerId": "p-0",
-  "timestampMs": 1708012345678,
-  "crc32": "a1b2c3d4"
-}
+```
+[8 bytes] sequence number   (long)
+[8 bytes] timestamp nanos   (long)
+[8 bytes] run ID hash       (long)
+[4 bytes] CRC32             (int — checksum of the first 24 bytes)
+[N bytes] zero padding      (to match target record size)
 ```
 
 | Field | Purpose |
 |-------|---------|
-| `seq` | Monotonically increasing sequence number |
-| `producerId` | Identifies which producer sent the message |
-| `timestampMs` | Wall-clock time of production |
-| `crc32` | CRC32 checksum of the payload for corruption detection |
+| `sequence` | Monotonically increasing sequence number |
+| `timestampNanos` | Monotonic send timestamp, used for RTO computation |
+| `runIdHash` | Stable hash of the run ID, isolates records from other runs |
+| `crc32` | CRC32 checksum of the header for corruption detection |
 
 ### Producer-Side Tracking
 
@@ -80,7 +79,8 @@ The producer maintains:
 
 - **Total sent** — total messages submitted to the Kafka producer
 - **Total ACKed** — messages for which the broker confirmed persistence
-- **ACK gaps** — sequence numbers that were sent but never ACKed (timeout or error)
+- **Total failed** — sends that returned an error in the producer callback
+- **Failure windows** — continuous periods between a failed send and the next successful ACK, used to compute producer-side RTO
 
 ### Consumer-Side Verification
 
@@ -120,29 +120,73 @@ Expected result: **zero data loss**. If messages are ACKed with `acks=all`, Kafk
 
 ### Idempotent Integrity
 
-Enables Kafka's producer idempotency to verify exactly-once delivery to the log:
+Enables Kafka's producer idempotency to verify exactly-once delivery to the log. Idempotence is off by default; enable it with the `enableIdempotence` field in a scenario file:
+
+```yaml
+scenarios:
+  - name: "Idempotent Integrity"
+    type: INTEGRITY
+    spec:
+      records: 100000
+      acks: "all"
+      enableIdempotence: true
+```
 
 ```bash
-kates test create --type INTEGRITY --records 100000 --wait
-# Idempotency is enabled by default
+kates test apply -f idempotent-integrity.yaml --wait
 ```
 
 With idempotency, even if the producer retries a send (due to transient network errors), the broker deduplicates it. The consumer should see each sequence number exactly once.
 
 ### Transactional Integrity
 
-Enables Kafka transactions for the strongest guarantee — exactly-once processing:
+Enables Kafka transactions for the strongest guarantee — exactly-once processing. The built-in `integrity-tx` template ships with transactions, idempotence, and CRC verification already enabled:
 
 ```bash
-# Scaffold a transactional integrity test
-kates test scaffold --type INTEGRITY -o integrity-tx.yaml
-# Edit the YAML to enable transactions
+# Export the built-in transactional integrity template, then run it
+kates test scaffold export integrity-tx
 kates test apply -f integrity-tx.yaml --wait
+```
+
+The exported `integrity-tx.yaml`:
+
+```yaml
+scenarios:
+  - name: "Transactional Integrity Verification"
+    type: INTEGRITY
+    spec:
+      records: 200000
+      parallelProducers: 4
+      recordSizeBytes: 512
+      acks: "all"
+      compressionType: "zstd"
+      enableIdempotence: true
+      enableTransactions: true
+      enableCrc: true
+      replicationFactor: 3
+      minInsyncReplicas: 2
+      numConsumers: 4
+    validate:
+      maxDataLossPercent: 0
+      maxDuplicatePercent: 0
+      maxOutOfOrder: 0
+      maxCrcFailures: 0
+      maxP99LatencyMs: 150
 ```
 
 ## Integrity Under Chaos
 
-The real power of integrity testing emerges when combined with fault injection. Kates provides a dedicated `INTEGRITY_CHAOS` scaffold:
+The real power of integrity testing emerges when combined with fault injection. There is no dedicated scaffold for this — you run an INTEGRITY test and inject a disruption (Chapter 7) while it is producing:
+
+```bash
+# Terminal 1 — start the integrity test
+kates test apply -f integrity-tx.yaml --wait
+
+# Terminal 2 — inject a broker failure while the test produces
+kates disruption run --config disruption-plan.json
+```
+
+The combined flow looks like this:
 
 ```mermaid
 sequenceDiagram
@@ -184,40 +228,39 @@ sequenceDiagram
 
 ### Timeline Events
 
-The integrity test records a timeline of significant events:
+The verifier records a diagnostic timeline of integrity violations — CRC failures, ordering violations, lost ranges — plus a final summary event. `kates test get <id>` prints the last 20 events automatically in its "Integrity Timeline" section:
 
 ```bash
 kates test get <id>
 ```
 
-Output includes:
+An example timeline from a run that lost one record (timestamps are epoch milliseconds):
 
 | Timestamp | Type | Detail |
 |:-:|---|---|
-| 1708012345000 | PRODUCE_START | Started producing 100,000 records |
-| 1708012375000 | FAULT_INJECTED | Killed broker-0 |
-| 1708012376000 | ISR_SHRINK | Partition 0 ISR: [0,1,2] → [1,2] |
-| 1708012378000 | LEADER_CHANGE | Partition 0 leader: 0 → 1 |
-| 1708012380000 | PRODUCE_ERROR | Timeout on 3 messages (retrying) |
-| 1708012395000 | BROKER_RECOVERY | Broker 0 rejoined |
-| 1708012410000 | ISR_EXPAND | Partition 0 ISR: [1,2] → [0,1,2] |
-| 1708012415000 | PRODUCE_COMPLETE | All 100,000 records produced |
-| 1708012420000 | CONSUME_COMPLETE | All 100,000 records consumed |
-| 1708012420001 | VERDICT | PASS — zero data loss |
+| 1767970801123 | CRC_FAILURE | partition=2 seq=45231 |
+| 1767970802456 | OUT_OF_ORDER | partition=1 expected=78441 actual=78439 |
+| 1767970803010 | LOST_RANGE | from=45231 to=45231 count=1 |
+| 1767970803011 | SUMMARY | verdict=DATA_LOSS lost=1 duplicates=0 |
+
+A clean run contains only the final `SUMMARY` event.
 
 ## Interpreting Integrity Results
 
 ### PASS — Zero Data Loss
 
 ```
-  ✓ Data Integrity
-    Sent       100,000
-    Acked      100,000
-    Received   100,000
-    Lost            0
-    Duplicates      0
-    Mode       idempotent
-    Verdict    PASS ✅
+  ▸ Data Integrity
+  Sent                     100.0K
+  Acked                    100.0K
+  Consumed                 100.0K
+  Lost                     0
+  Duplicates               0
+  Data Loss                0.0000%
+  CRC Failures             0
+  Out of Order             0
+  Mode                     idempotent
+  Verdict                  ● PASS
 ```
 
 This is the expected result for a properly configured cluster with `acks=all` and `min.insync.replicas=2`, even during single-broker failures.
@@ -225,15 +268,25 @@ This is the expected result for a properly configured cluster with `acks=all` an
 ### DATA_LOSS — Messages Missing
 
 ```
-  ✗ Data Integrity
-    Sent       100,000
-    Acked       99,997
-    Received    99,995
-    Lost            2
-    Duplicates      0
-    Lost Ranges [45231-45231], [78442-78442]
-    Verdict    DATA_LOSS ❌
+  ▸ Data Integrity
+  Sent                     100.0K
+  Acked                    100.0K
+  Consumed                 100.0K
+  Lost                     2
+  Duplicates               0
+  Data Loss                0.0020%
+  CRC Failures             0
+  Out of Order             0
+  Verdict                  ○ DATA_LOSS
+
+  ▸ Lost Ranges
+  From Seq  To Seq  Count
+  ────────  ──────  ─────
+  45231     45231   1
+  78442     78442   1
 ```
+
+(Counts are abbreviated in the display — the `Lost` count, `Data Loss` percentage, and `Lost Ranges` table carry the exact numbers.)
 
 Data loss indicates a serious issue. Common causes:
 
@@ -244,19 +297,23 @@ Data loss indicates a serious issue. Common causes:
 | Unclean leader election | `unclean.leader.election.enable=true` |
 | Log truncation | Follower promoted with less data than old leader |
 
-### DATA_LOSS with ACK Gaps
+### PASS with Unacked Messages
 
 ```
-  ✗ Data Integrity
-    Sent       100,000
-    Acked       99,990
-    Received    99,990
-    Lost            0
-    ACK Gaps       10
-    Verdict    PASS (with warnings) ⚠
+  ▸ Data Integrity
+  Sent                     100.0K
+  Acked                    100.0K
+  Consumed                 100.0K
+  Lost                     0
+  Duplicates               0
+  Data Loss                0.0000%
+  CRC Failures             0
+  Out of Order             0
+  Producer RTO             2340 ms
+  Verdict                  ● PASS
 ```
 
-This means 10 messages were never ACKed (producer timeout), but no ACKed messages were lost. The 10 unacked messages may or may not be in the log — this is expected behavior when a broker crashes during a produce request.
+In this run some messages were never ACKed — the producer hit errors during a broker failure, visible as a non-zero `Producer RTO` (the longest window between a failed send and the next successful ACK). Only ACKed messages carry a durability promise, so unacked sends are excluded from the loss calculation and the verdict remains PASS. The unacked messages may or may not be in the log — this is expected behavior when a broker crashes during a produce request.
 
 ## Best Practices
 
@@ -295,41 +352,37 @@ This section walks through a full data integrity verification from start to fini
 ### Step 1 — Run the INTEGRITY Test
 
 ```bash
-kates test create \
-  --type INTEGRITY \
-  --records 100000 \
-  --acks all \
-  --enable-idempotence \
-  --enable-crc \
-  --wait \
-  --label walkthrough=demo
+# Export the built-in transactional integrity template, then run it
+kates test scaffold export integrity-tx
+kates test apply -f integrity-tx.yaml --wait
 ```
+
+This runs a 200,000-record INTEGRITY test with `acks=all`, idempotence, transactions, and CRC verification enabled (the template contents are shown in the Transactional Integrity section above). For a quick ad-hoc run without a scenario file:
+
+```bash
+kates test create --type INTEGRITY --records 100000 --acks all --wait
+```
+
+Ad-hoc `create` runs use the backend defaults: CRC verification is on, but idempotence and transactions stay off — those are scenario-file fields (`enableIdempotence`, `enableTransactions`).
 
 ### Step 2 — Observe Output During the Test
 
-While the test runs, you'll see real-time progress:
+With `--wait`, `kates test apply` shows a spinner per scenario and a summary table once each test finishes, including the SLA gates from the `validate:` block:
 
 ```
-  ▸ Integrity Test (INTEGRITY)
-    Topic:       kates-integrity-f8a2c1d3
-    Records:     100,000
-    Acks:        all
-    Idempotent:  true
-    CRC:         enabled
+  Applying 1 scenario(s) from integrity-tx.yaml
 
-    Phase 1/4: Producing...
-      [████████████████████████████████████████] 100,000/100,000 (100%)
-      Produced:  100,000 records in 6.2s (16,129 rec/s)
-      ACK gaps:  0
+  ▸ Transactional Integrity Verification (INTEGRITY)...
+  ✓   Created: a1b2c3d4e5f6…
+  ✓ Transactional Integrity Verification → ● DONE
 
-    Phase 2/4: Waiting for cluster stabilization... (5s)
-
-    Phase 3/4: Consuming...
-      [████████████████████████████████████████] 100,000/100,000 (100%)
-      Consumed:  100,000 records in 3.8s (26,315 rec/s)
-
-    Phase 4/4: Verifying sequences...
+  ▸ Summary
+  Scenario                               ID             Status  Note
+  ─────────────────────────────────────  ─────────────  ──────  ──────────
+  Transactional Integrity Verification   a1b2c3d4e5f6…  DONE    ✓ SLA Pass
 ```
+
+Internally the test runs its produce phase to completion, then consumes everything back from the beginning, then reconciles ACKed against consumed sequence numbers. The topic is named after the test type (`integrity-test`) unless overridden with the `topic` spec field.
 
 ### Step 3 — Read the Verification Report
 
@@ -337,64 +390,74 @@ While the test runs, you'll see real-time progress:
 kates test get <id>
 ```
 
-A successful run produces:
+The report starts with the test details, configuration, and per-phase results; for INTEGRITY tests it ends with a Data Integrity section. A successful `integrity-tx` run produces:
 
 ```
-  ✓ Data Integrity Verification Report
-  ┌────────────────────┬────────────┐
-  │ Field              │ Value      │
-  ├────────────────────┼────────────┤
-  │ Produced           │ 100,000    │
-  │ ACKed              │ 100,000    │
-  │ Consumed           │ 100,000    │
-  │ Lost               │ 0          │
-  │ Duplicated         │ 0          │
-  │ Out-of-Order       │ 0          │
-  │ CRC Failures       │ 0          │
-  │ Corrupted          │ 0          │
-  │ Mode               │ idempotent │
-  │ Verdict            │ PASS ✅    │
-  └────────────────────┴────────────┘
+  ▸ Data Integrity
+  Sent                     200.0K
+  Acked                    200.0K
+  Consumed                 200.0K
+  Lost                     0
+  Duplicates               0
+  Data Loss                0.0000%
+  CRC Failures             0
+  Out of Order             0
+  Mode                     idempotent transactional
+  Verdict                  ● PASS
 ```
 
 ### Step 4 — Interpret Each Field
 
 | Field | Meaning | Expected Value | Concern If... |
 |-------|---------|:--------------:|---------------|
-| **Produced** | Total messages submitted to the Kafka producer | Matches `--records` | Lower than expected: producer errors or timeouts |
-| **ACKed** | Messages confirmed persisted by the broker | Equal to Produced | Less than Produced: broker rejected or timed out messages |
-| **Consumed** | Messages read back from the topic | Equal to ACKed | Less than ACKed: **data loss detected** |
+| **Sent** | Total messages submitted to the Kafka producer | Matches `records` | Lower than expected: producer errors or timeouts |
+| **Acked** | Messages confirmed persisted by the broker | Equal to Sent | Less than Sent: broker rejected or timed out messages |
+| **Consumed** | Messages read back from the topic | Equal to Acked | Less than Acked: **data loss detected** |
 | **Lost** | ACKed messages that were not consumed | `0` | Any non-zero value: serious durability issue |
-| **Duplicated** | Messages received more than once | `0` (with idempotency) | Non-zero without idempotency is expected; non-zero with idempotency is a bug |
-| **Out-of-Order** | Messages received in wrong sequence within a partition | `0` | Non-zero: possible log truncation or unclean election |
+| **Duplicates** | Messages received more than once | `0` (with idempotency) | Non-zero without idempotency is expected; non-zero with idempotency is a bug |
+| **Data Loss** | Lost as a percentage of Sent | `0.0000%` | Any non-zero value: serious durability issue |
 | **CRC Failures** | Messages whose CRC32 checksum didn't match | `0` | Non-zero: data corruption in transit or at rest |
-| **Corrupted** | Messages with unparseable payload | `0` | Non-zero: serialization issue or disk corruption |
+| **Out of Order** | Messages received with a lower sequence than a prior message in the same partition | `0` | Non-zero: possible log truncation or unclean election |
+| **Producer RTO** | Longest window between a failed send and the next successful ACK (shown only after producer stalls) | Absent | Large values: slow leader failover |
+| **Consumer RTO** | Duration of the first gap observed in the consumed sequence stream (shown only after consumer stalls) | Absent | Large values: slow recovery on the read path |
 
 ### Step 5 — What a Failure Looks Like
 
-If the test detects data loss, the output changes to:
+If the test detects data loss, the Data Integrity section changes to:
 
 ```
-  ✗ Data Integrity Verification Report
-  ┌────────────────────┬───────────────────────────────────┐
-  │ Field              │ Value                             │
-  ├────────────────────┼───────────────────────────────────┤
-  │ Produced           │ 100,000                           │
-  │ ACKed              │ 99,998                            │
-  │ Consumed           │ 99,995                            │
-  │ Lost               │ 3                                 │
-  │ Duplicated         │ 0                                 │
-  │ Lost Ranges        │ [23401-23401], [67882-67883]      │
-  │ CRC Failures       │ 1                                 │
-  │ Corrupted          │ 1                                 │
-  │ Verdict            │ DATA_LOSS ❌                      │
-  └────────────────────┴───────────────────────────────────┘
+  ▸ Data Integrity
+  Sent                     200.0K
+  Acked                    200.0K
+  Consumed                 200.0K
+  Lost                     3
+  Duplicates               0
+  Data Loss                0.0015%
+  CRC Failures             1
+  Out of Order             0
+  Mode                     idempotent transactional
+  Verdict                  ○ DATA_LOSS
 
-  Investigation pointers:
-    • Lost messages at seq 23401: single gap — likely broker crash during ACK
-    • Lost messages at seq 67882-67883: consecutive gap — possible log truncation
-    • CRC failure: message payload corrupted — check disk health
+  ▸ Lost Ranges
+  From Seq  To Seq  Count
+  ────────  ──────  ─────
+  23401     23401   1
+  67882     67883   2
+
+  ▸ Integrity Timeline
+  Timestamp      Type         Detail
+  ─────────────  ───────────  ─────────────────────────────────
+  1767970801123  CRC_FAILURE  partition=2 seq=51200
+  1767970803010  LOST_RANGE   from=23401 to=23401 count=1
+  1767970803010  LOST_RANGE   from=67882 to=67883 count=2
+  1767970803011  SUMMARY      verdict=DATA_LOSS lost=3 duplicates=0
 ```
+
+Reading this report:
+
+- Lost message at seq 23401: single gap — likely a broker crash during ACK
+- Lost messages at seq 67882-67883: consecutive gap — possible log truncation
+- CRC failure: message payload corrupted — check disk health
 
 ### What to Investigate on Failure
 
@@ -402,4 +465,4 @@ If the test detects data loss, the output changes to:
 2. **Check `min.insync.replicas`** — if set to `1`, a single broker failure can cause data loss. Set to `2`.
 3. **Check for unclean leader election** — run `kubectl logs <broker-pod> -n kafka | grep 'unclean'`. Disable `unclean.leader.election.enable` in production.
 4. **Check disk health** — CRC failures suggest disk corruption. Run `kubectl exec <broker-pod> -n kafka -- df -h` and check for I/O errors in `dmesg`.
-5. **Check timeline events** — run `kates test get <id> --timeline` to see exactly when failures occurred relative to broker events.
+5. **Check timeline events** — run `kates test get <id>`; the Integrity Timeline section prints automatically and shows exactly which sequences failed CRC checks, arrived out of order, or were lost.

--- a/docs/book/09-observability.md
+++ b/docs/book/09-observability.md
@@ -20,7 +20,7 @@ graph TB
     end
     
     subgraph Collection["Collection"]
-        JMX[JMX Exporter<br/>Sidecar]
+        JMX[JMX Exporter<br/>Agent]
         API[Kates REST API]
         OTLP[OTLP Collector]
     end
@@ -46,7 +46,7 @@ graph TB
     OTEL --> OTLP --> JAEGER --> JUI
 ```
 
-Each Kafka broker runs a **JMX Exporter sidecar** that scrapes JMX MBeans and exposes them as Prometheus metrics on `/metrics`. Prometheus scrapes these endpoints (plus the Kates engine's own `/q/metrics`) every 15 seconds. Grafana queries Prometheus to render dashboards. Meanwhile, the Kates engine writes test results to PostgreSQL and exposes them through its REST API — which the CLI consumes for terminal dashboards, trend charts, and heatmap exports.
+Each Kafka broker exposes its JMX MBeans as Prometheus metrics through the **JMX Prometheus Exporter agent**, configured by the kafka-cluster chart's metrics ConfigMap (`charts/kafka-cluster/templates/metrics-configmap.yaml`). Prometheus scrapes these endpoints (plus the Kates engine's own `/q/metrics`) on its scrape interval — 30 seconds by default. Grafana queries Prometheus to render dashboards. Meanwhile, the Kates engine writes test results to PostgreSQL and exposes them through its REST API — which the CLI consumes for terminal dashboards, trend charts, and heatmap exports.
 
 ---
 
@@ -68,13 +68,13 @@ Check **Bytes In/Out (rate)** to understand the data volume. If bytes out signif
 
 ### Step 3: Investigate Latency Sources
 
-If your P99 was higher than expected, open **Kafka Broker Internals**. Look at **Request Queue Size** — if it was growing during the test, requests were arriving faster than the broker could process them. A healthy cluster keeps this near zero.
+If your P99 was higher than expected, open the **Broker Internals** row of the **Kafka Performance Testing** dashboard. Look at **Request / Response Queue Size** — if it was growing during the test, requests were arriving faster than the broker could process them. A healthy cluster keeps this near zero.
 
-Check **Purgatory Size** — this tells you how many produce requests were waiting for follower acknowledgments. With `acks=all`, every produce request sits in purgatory until all ISR members replicate it. A growing purgatory means replication is the bottleneck.
+With `acks=all`, every produce request is parked in the broker's produce purgatory until all ISR members replicate it. There is no dedicated purgatory panel, but a clean request queue combined with high produce latency usually means replication — not request processing — is the bottleneck; verify that in the next step.
 
 ### Step 4: Verify Replication
 
-Finally, open the **Kafka Replication** dashboard. During a normal test, **ISR Count per Partition** should equal your replication factor (3) for every partition, for the entire duration. **Replica Lag (bytes)** should stay near zero. If it spiked, followers were struggling to keep up — likely because of disk I/O pressure or network saturation.
+Finally, open the **Replication** row of the **Kafka Performance Testing** dashboard. During a normal test, **ISR Shrinks / Expands** should stay flat at zero and **Under-Replicated Partitions** should be zero for the entire duration. If ISRs shrank during the test, followers were struggling to keep up — likely because of disk I/O pressure or network saturation.
 
 ::: {.callout-tip}
 Get in the habit of following this sequence — cluster health → performance → internals → replication — after every test. It takes 60 seconds and catches problems that aggregate metrics hide. If a test result surprises you, the dashboards will almost always explain why.
@@ -85,11 +85,13 @@ Get in the habit of following this sequence — cluster health → performance �
 
 ## Kafka Grafana Dashboards
 
-Kates deploys six Kafka-focused Grafana dashboards, each targeting a specific monitoring dimension. For the full dashboard and metrics reference, see [docs/monitoring.md](https://github.com/bmscomp/kates/blob/main/docs/monitoring.md).
+The monitoring chart ships a set of Kafka- and Strimzi-focused Grafana dashboards alongside the Kates-specific ones covered in the next section — every JSON file in [`charts/monitoring/dashboards/`](https://github.com/bmscomp/kates/tree/main/charts/monitoring/dashboards) is deployed. This section is organized by monitoring dimension rather than by file; each subsection notes which dashboard file its panels live on.
 
 ### Kafka Cluster Health
 
 This is the primary ops dashboard — your first stop after any test or chaos experiment. It answers the most fundamental question: "Is my cluster healthy right now?" If anything here is red, stop investigating performance and fix the cluster first.
+
+**Files:** `kafka-dashboard.json` (UID `kafka-cluster-health`); the under-replicated, controller, and node-affinity stats are on the broader `kafka-all-metrics-dashboard.json` (UID `kafka-all-metrics`).
 
 | Panel | What It Shows | Alert Threshold |
 |-------|---------------|-----------------|
@@ -105,11 +107,12 @@ This is the primary ops dashboard — your first stop after any test or chaos ex
 
 This dashboard shows the workload patterns hitting your cluster. Use it to verify that your test is generating the load you expect, and to spot asymmetries across brokers or topics.
 
+**Files:** `kafka-performance-dashboard.json` (UID `kafka-performance`) for the test-topic view; the per-broker throughput timeseries are in the **Throughput** row of `kafka-perf-global-dashboard.json` (UID `kafka-perf-global`).
+
 | Panel | Metric |
 |-------|--------|
 | Messages In (rate) | `kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec` |
 | Bytes In/Out (rate) | `kafka.server:type=BrokerTopicMetrics,name=Bytes{In,Out}PerSec` |
-| Request Rate | `kafka.network:type=RequestMetrics,name=RequestsPerSec` |
 | Topic Size Growth | `kafka.log:type=Log,name=Size` |
 
 **Messages In (rate)** should match your configured producer throughput. If it plateaus below your target, the cluster has hit a bottleneck — check broker internals. **Topic Size Growth** matters for long-running tests: if your topic is growing faster than log retention can clean, you'll run out of disk.
@@ -118,45 +121,49 @@ This dashboard shows the workload patterns hitting your cluster. Use it to verif
 
 When performance numbers look off, this is where you diagnose the root cause. These metrics reveal what's happening *inside* each broker — the queues, threads, and internal buffers that determine whether the broker is keeping up or falling behind.
 
+**File:** `kafka-perf-global-dashboard.json` (UID `kafka-perf-global`), **Broker Internals** row; request/response queue sizes also appear on `kafka-all-metrics-dashboard.json`.
+
 | Panel | What It Reveals |
 |-------|----------------|
-| Request Queue Size | How many requests are waiting to be processed |
-| Response Queue Size | How many responses are waiting to be sent |
-| Network Handler Idle | Percentage of time network threads are idle |
-| Purgatory Size | Requests waiting for ACKs (producer purgatory) |
-| ISR Shrink/Expand Rate | How often ISRs change — instability indicator |
+| Request / Response Queue Size | How many requests are waiting to be processed, and responses waiting to be sent |
+| Request Handler Idle % | Percentage of time request handler threads are idle |
+| Network Processor Idle % | Percentage of time network threads are idle |
+| ISR Shrinks / Expands (Replication row) | How often ISRs change — instability indicator |
 
-**Request Queue Size** tells you whether the broker is keeping up. A growing queue means requests are arriving faster than the broker can process them. On a healthy cluster, this stays near zero. **Network Handler Idle** below 50% is a warning — the broker's network threads are saturated, and adding more load will cause requests to queue. **ISR Shrink/Expand Rate** should be zero during normal operations. Any non-zero value means followers are falling behind and catching up — a sign of instability that directly impacts write latency with `acks=all`.
+**Request Queue Size** tells you whether the broker is keeping up. A growing queue means requests are arriving faster than the broker can process them. On a healthy cluster, this stays near zero. **Network Processor Idle %** below 50% is a warning — the broker's network threads are saturated, and adding more load will cause requests to queue. **ISR Shrinks / Expands** should be zero during normal operations. Any non-zero value means followers are falling behind and catching up — a sign of instability that directly impacts write latency with `acks=all`.
 
 ### Kafka JVM Metrics
 
 The JVM is the runtime underneath every broker. GC pauses are the single most common source of tail latency in Kafka benchmarks, making this dashboard essential for capacity planning and GC tuning. If your P99 latency has unexplained spikes, check here first.
 
+**File:** `kafka-jvm-dashboard.json` | **UID:** `kafka-jvm`
+
 | Panel | Significance |
 |-------|-------------|
-| Heap Used vs. Max | Memory pressure indicator |
-| GC Pause Time | Directly impacts tail latency |
-| GC Count | High frequency = memory pressure |
+| JVM Heap Memory | Memory pressure indicator |
+| GC Collection Rate | High frequency = memory pressure; GC pauses impact tail latency |
 | Thread Count | Leak detection over time |
-| Non-Heap Memory | Metaspace growth indicator |
+| JVM Non-Heap Memory | Metaspace growth indicator |
 
-**GC Pause Time** correlates directly with latency spikes. If you see GC pauses of 50ms+ coinciding with your P99 spikes, switching to ZGC will likely eliminate them — see [Chapter 12: Deployment](12-deployment.md#jvm-tuning). **Heap Used vs. Max** trending upward over time without leveling off suggests a memory leak or insufficient heap size.
+GC pauses correlate directly with latency spikes. The dashboard plots the **GC Collection Rate** — if collection spikes coincide with your P99 spikes, switching to ZGC will likely eliminate them — see [Chapter 12: Deployment](12-deployment.md#jvm-tuning). **JVM Heap Memory** trending upward over time without leveling off suggests a memory leak or insufficient heap size.
 
 ### Kafka Replication
 
 This dashboard becomes critical during chaos tests, where you intentionally take brokers offline and need to verify that replication recovers correctly. During normal tests, everything here should be flat and boring — which is exactly what you want.
 
+**File:** `kafka-perf-global-dashboard.json` (UID `kafka-perf-global`), **Replication** row.
+
 | Panel | During Normal | During Chaos |
 |-------|:---:|:---:|
-| ISR Count per Partition | = RF (3) | Drops to 2 or 1 |
-| Under-replicated Partitions | 0 | Spikes |
-| Replica Lag (bytes) | Near 0 | Spikes then recovers |
+| ISR Shrinks / Expands | 0 | Shrinks spike, then expands on recovery |
+| Under-Replicated Partitions | 0 | Spikes |
+| Leader Count (per Broker) | Balanced | Redistributes to surviving brokers |
 
-The story this dashboard tells during a chaos test is: the ISR shrinks when a broker goes down, under-replicated partitions spike, replica lag grows while the remaining brokers absorb the load, and then everything recovers when the broker returns. The *shape* of the recovery curve matters — a sharp V means fast recovery, a gradual slope means the cluster is struggling to catch up.
+The story this dashboard tells during a chaos test is: the ISR shrinks when a broker goes down, under-replicated partitions spike, leadership redistributes while the remaining brokers absorb the load, and then everything recovers when the broker returns. The *shape* of the recovery curve matters — a sharp V means fast recovery, a gradual slope means the cluster is struggling to catch up.
 
 ### Strimzi Operator & Kafka Connect
 
-The **Strimzi Operator & Kafka Connect** dashboard (`charts/monitoring/dashboards/strimzi-operator-dashboard.json`) provides visibility into the operator that manages your Kafka cluster and any Connect workloads. You'll check this dashboard when deployments seem stuck, when topic or user changes aren't applying, or when Connect tasks are failing silently.
+The **Strimzi Operator & Kafka Connect** dashboard (`strimzi-operator-dashboard.json`, UID `strimzi-operator-connect`) provides visibility into the operator that manages your Kafka cluster and any Connect workloads. You'll check this dashboard when deployments seem stuck, when topic or user changes aren't applying, or when Connect tasks are failing silently.
 
 | Panel | Metric | Alert Level |
 |-------|--------|:---:|
@@ -351,7 +358,7 @@ For the theory behind why heatmaps matter and why percentiles alone are insuffic
 graph TD
     subgraph Collection["During Test Execution"]
         direction LR
-        H1["Every 1 second:<br/>LatencyHistogram.snapshotAndReset()"]
+        H1["On each status poll:<br/>LatencyHistogram.exportBuckets()"]
         H2["25 logarithmic buckets<br/>0ms → 10,000ms"]
         H3["Counts per bucket<br/>stored as HeatmapRow"]
     end
@@ -367,30 +374,31 @@ graph TD
 
 ### Bucket Boundaries
 
-The 25 heatmap buckets use logarithmic spacing, concentrating resolution where it matters most — in the low-latency range where small differences are significant:
+The 25 heatmap buckets (defined by `HEATMAP_BOUNDARIES` in `LatencyHistogram.java`) use roughly logarithmic spacing, concentrating resolution where it matters most — in the low-latency range where small differences are significant:
 
 | Bucket | Range | Focus |
 |:-:|---|---|
-| 1 | 0 – 0.1ms | Sub-millisecond operations |
-| 2–5 | 0.1 – 1ms | Fast local writes |
-| 6–10 | 1 – 10ms | Typical Kafka latency |
-| 11–15 | 10 – 100ms | Moderate latency |
-| 16–20 | 100 – 1,000ms | High latency / timeouts |
-| 21–25 | 1,000 – 10,000ms | Extreme tail / failures |
+| 1 | 0 – 0.5ms | Sub-millisecond operations |
+| 2 | 0.5 – 1ms | Fast local writes |
+| 3–7 | 1 – 10ms | Typical Kafka latency |
+| 8–13 | 10 – 100ms | Moderate latency |
+| 14–19 | 100 – 1,000ms | High latency / timeouts |
+| 20–25 | 1,000 – 10,000ms | Extreme tail / failures |
 
 ### Exporting Heatmaps
 
 ```bash
-# JSON (for Grafana)
+# JSON (for Grafana) — run in a terminal, this writes kates-heatmap-<id>.json
 kates report export <id> --format heatmap
 
-# CSV (for spreadsheets)
+# CSV (for spreadsheets) — writes kates-heatmap-<id>.csv
 kates report export <id> --format heatmap-csv
 
-# Save to file
-kates report export <id> --format heatmap -o heatmap.json
-kates report export <id> --format heatmap-csv -o heatmap.csv
+# Pipe or redirect to send the export to stdout instead
+kates report export <id> --format heatmap > heatmap.json
 ```
+
+There is no output-file flag: when stdout is a terminal, the export is written to an auto-named file; when piped or redirected, it goes to stdout.
 
 ### REST API
 
@@ -401,17 +409,17 @@ GET /api/tests/{id}/report/heatmap?format=csv
 
 ### Reading Heatmap Data
 
-Each row in the heatmap data represents one second of the test:
+The JSON payload carries the run ID, test type, bucket labels and boundaries, and a list of rows. Each row is a snapshot of the latency distribution, captured while the engine polls the running test:
 
 ```json
 {
   "timestampMs": 1708012345000,
-  "phaseName": "steady-state",
-  "buckets": [0, 0, 12, 145, 832, 456, 89, 23, 5, 1, ...]
+  "phase": "steady-state",
+  "counts": [0, 0, 12, 145, 832, 456, 89, 23, 5, 1, ...]
 }
 ```
 
-Interpretation: during this second, 832 messages had latency between 1–5ms, 456 had 5–10ms, etc. The `phaseName` field tells you which test phase was active — compare the latency distribution during `ramp-up` vs. `steady-state` to see the effect of JVM warm-up.
+Interpretation: at this snapshot, 832 messages fell in the 3–5ms bucket, 456 in the 5–7ms bucket, etc. The `phase` field tells you which test phase was active — compare the latency distribution during `ramp-up` vs. `steady-state` to see the effect of JVM warm-up.
 
 ### What Heatmaps Reveal
 
@@ -498,15 +506,18 @@ This is particularly valuable after chaos tests — you can see exactly how the 
 
 ## Export Formats Summary
 
-Kates supports five export formats, each designed for a different downstream consumer:
+The `kates report export` command supports six export formats, each designed for a different downstream consumer:
 
 | Format | Command | Use Case |
 |--------|---------|----------|
-| JSON | `kates report export <id> --format json` | Programmatic consumption |
 | CSV | `kates report export <id> --format csv` | Spreadsheet analysis |
 | JUnit XML | `kates report export <id> --format junit` | CI/CD pipelines |
+| Markdown | `kates report export <id> --format md` | Docs, PRs, and chat |
+| HTML | `kates report export <id> --format html` | Shareable standalone report |
 | Heatmap JSON | `kates report export <id> --format heatmap` | Grafana visualization |
 | Heatmap CSV | `kates report export <id> --format heatmap-csv` | Spreadsheet analysis |
+
+When stdout is a terminal, each export is written to an auto-named file (`kates-report-<id>.csv`, `kates-heatmap-<id>.json`, …); when piped or redirected, it goes to stdout — except HTML, which always writes a file. There is no `--format json`: for programmatic JSON, use `kates report show <id> -o json` or the REST API directly.
 
 ---
 
@@ -520,11 +531,11 @@ Tracing is configured in `application.properties`:
 
 | Property | Value | Purpose |
 |----------|-------|---------| 
-| `quarkus.otel.traces.exporter` | `otlp` | Export spans via OTLP (gRPC) |
-| `quarkus.otel.exporter.otlp.endpoint` | `jaeger-collector:4317` | Jaeger collector address |
+| `quarkus.otel.enabled` | `true` | Master switch for OpenTelemetry |
+| `quarkus.otel.exporter.otlp.endpoint` | `http://jaeger-collector.monitoring.svc:4317` | Jaeger collector address (`http://localhost:4317` in dev) |
+| `quarkus.otel.exporter.otlp.protocol` | `grpc` | Export spans via OTLP over gRPC |
 | `quarkus.otel.traces.sampler` | `parentbased_traceidratio` | Sample based on parent trace |
 | `quarkus.otel.traces.sampler.arg` | `0.1` (prod) / `1.0` (dev) | 10% sampling in prod, 100% in dev |
-| `quarkus.otel.instrument.kafka` | `true` | Auto-instrument Kafka client operations |
 
 ::: {.callout-note}
 The `0.1` sampling rate in production means only 10% of requests generate traces. This is a deliberate trade-off — tracing adds overhead, and at high throughput you don't need every request traced to spot patterns. In development, 100% sampling is used so you can trace any request.
@@ -542,7 +553,7 @@ The `0.1` sampling rate in production means only 10% of requests generate traces
 
 ### Viewing Traces
 
-Access the Jaeger UI at http://localhost:30086:
+Deploy Jaeger with `make jaeger`, then access the UI at http://localhost:30086 (NodePort set in `config/monitoring/jaeger-values.yaml`):
 
 1. Select service **kates** in the dropdown
 2. Click **Find Traces** to see recent requests
@@ -554,63 +565,47 @@ Each trace shows the complete request lifecycle as a waterfall diagram. Look for
 
 ## Alerting
 
-Kates deploys 20+ PrometheusRule alerts across 6 alert groups. These alerts fire automatically when cluster health degrades, giving you early warning before problems become outages.
+Kates ships PrometheusRule alerts alongside its charts. These alerts fire automatically when cluster health degrades, giving you early warning before problems become outages.
 
-| Group | File | Alerts |
-|-------|------|--------|
-| `kafka.cluster` | `kafka-alerts.yaml` | Offline partitions, under-replicated, no active controller, disk usage |
-| `kafka.consumer` | `kafka-alerts.yaml` | Consumer group lag warning + critical |
-| `kafka.kraft` | `kafka-alerts.yaml` | Leader election rate, uncommitted records |
-| `kafka.network` | `kafka-alerts.yaml` | Request latency p99 > 1s |
-| `strimzi.operator.health` | `kafka-connect-alerts.yaml` | Reconciliation failing/slow/stalled, resource count drift |
-| `kafka.connect.health` | `kafka-connect-alerts.yaml` | Worker down, task failed, error rate, sink lag, stuck rebalancing |
+| File | Groups | What They Cover |
+|------|--------|-----------------|
+| `charts/kafka-cluster/templates/prometheusrule.yaml` | `kafka.cluster`, `kafka.consumer`, `kafka.kraft`, `kafka.network`, `strimzi.operator`, `kafka.replication`, `kafka.performance`, `kafka.cruisecontrol`, `kafka.certificates` | Offline/under-replicated partitions, controller health, disk usage, consumer lag, KRaft election rate, request latency, operator liveness, ISR shrink, log-flush latency, handler saturation, Cruise Control anomalies, certificate expiry |
+| `charts/connect-cluster/templates/alerts-connect.yaml` | `kafka-connect` | Worker down, failed tasks, task-count mismatch, rebalance storms, error rate, source lag, worker heap |
+| `charts/monitoring/templates/prometheus-chaos-rules.yaml` | `kafka-chaos-expected`, `kafka-chaos-unexpected`, `kafka-chaos-results`, `kafka-gameday`, `kafka-chaos-rto-rpo` | Chaos experiment status, unexpected broker restarts during chaos, gameday workflows, RTO/RPO SLA breaches and data loss |
 
 ### Alert Configuration
 
-Alert thresholds are defined in `charts/monitoring/values.yaml` and can be customized per environment. The alert rules are deployed as Kubernetes `PrometheusRule` resources, which the Prometheus operator discovers automatically.
+The alert rules are deployed as Kubernetes `PrometheusRule` resources, which the Prometheus operator discovers automatically. Each chart has its own toggle: `alerts.enabled` in `charts/kafka-cluster/values.yaml` and `charts/connect-cluster/values.yaml` (with extra labels via `alerts.labels`), and `chaosAlerts.enabled` in `charts/monitoring/values.yaml` (off by default).
 
-To customize thresholds, override the relevant values in your environment-specific values file (`values-kind.yaml` or `values-generic.yaml`). Here are three common alert configurations:
+Thresholds and `for:` durations live in the rule templates themselves — to change one, edit the template or deploy your own `PrometheusRule` alongside. Here are three of the kafka-cluster rules as the chart renders them:
 
 #### Consumer Group Lag
 
 This alert fires when a consumer group falls behind, meaning messages are being produced faster than they're being consumed. A small lag during load tests is expected — sustained lag in production means your consumers are undersized.
 
 ```yaml
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
-metadata:
-  name: kafka-consumer-lag
-  labels:
-    release: monitoring
-spec:
-  groups:
-    - name: kafka.consumer
-      rules:
-        - alert: KafkaConsumerGroupLagWarning
-          expr: |
-            sum by (consumergroup, topic) (
-              kafka_consumergroup_lag
-            ) > 1000
-          for: 5m
-          labels:
-            severity: warning
-          annotations:
-            summary: "Consumer group {{ $labels.consumergroup }} lag > 1000 on {{ $labels.topic }}"
-            description: "Consumer lag has exceeded 1000 for 5 minutes. Check consumer health and scaling."
-        - alert: KafkaConsumerGroupLagCritical
-          expr: |
-            sum by (consumergroup, topic) (
-              kafka_consumergroup_lag
-            ) > 10000
-          for: 5m
-          labels:
-            severity: critical
-          annotations:
-            summary: "Consumer group {{ $labels.consumergroup }} lag > 10000 on {{ $labels.topic }}"
-            description: "Consumer lag is critically high. Consumers may be down or severely undersized."
+- name: kafka.consumer
+  rules:
+    - alert: KafkaConsumerGroupLag
+      expr: kafka_consumergroup_lag_sum > 1000000
+      for: 15m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Consumer group lag exceeds threshold"
+        description: "Consumer group {{ $labels.consumergroup }} has {{ $value }} messages lag."
+
+    - alert: KafkaConsumerGroupLagCritical
+      expr: kafka_consumergroup_lag_sum > 10000000
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: "Consumer group lag critical"
+        description: "Consumer group {{ $labels.consumergroup }} has {{ $value }} messages lag."
 ```
 
-**When it fires:** Consumer lag exceeds 1,000 messages (warning) or 10,000 messages (critical) for 5 continuous minutes.  
+**When it fires:** Consumer lag exceeds 1 million messages for 15 continuous minutes (warning) or 10 million for 5 minutes (critical).  
 **What to do:** Check that consumer pods are running (`kubectl get pods`). If they're healthy, consider scaling the consumer group or investigating whether the consumer is blocked on downstream dependencies.
 
 #### Offline Partitions
@@ -618,54 +613,36 @@ spec:
 This is the most critical Kafka alert. Offline partitions mean messages can't be produced or consumed for those partitions — this is data unavailability.
 
 ```yaml
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
-metadata:
-  name: kafka-offline-partitions
-  labels:
-    release: monitoring
-spec:
-  groups:
-    - name: kafka.cluster
-      rules:
-        - alert: KafkaOfflinePartitions
-          expr: |
-            sum(kafka_controller_kafkacontroller_offlinepartitionscount) > 0
-          for: 1m
-          labels:
-            severity: critical
-          annotations:
-            summary: "Kafka has {{ $value }} offline partitions"
-            description: "One or more partitions have no active leader. Producers and consumers for these partitions are blocked."
+- name: kafka.cluster
+  rules:
+    - alert: KafkaOfflinePartitions
+      expr: kafka_controller_kafkacontroller_offlinepartitionscount > 0
+      for: 2m
+      labels:
+        severity: critical
+      annotations:
+        summary: "Kafka has offline partitions"
+        description: "{{ $value }} partitions are offline on cluster krafter."
 ```
 
-**When it fires:** Any partition has no leader for more than 1 minute.  
-**What to do:** Check which brokers are down (`kates cluster watch`). If a broker crashed, Kafka should elect new leaders automatically — if it doesn't within a minute, check the KRaft controller logs for election failures.
+**When it fires:** Any partition has no leader for more than 2 minutes.  
+**What to do:** Check which brokers are down (`kates cluster watch`). If a broker crashed, Kafka should elect new leaders automatically — if it doesn't within a couple of minutes, check the KRaft controller logs for election failures.
 
 #### Under-Replicated Partitions (Sustained)
 
 Transient under-replication is normal during broker restarts. Sustained under-replication means data durability is at risk — if the remaining replica also fails, you lose data.
 
 ```yaml
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
-metadata:
-  name: kafka-under-replicated
-  labels:
-    release: monitoring
-spec:
-  groups:
-    - name: kafka.cluster
-      rules:
-        - alert: KafkaUnderReplicatedPartitions
-          expr: |
-            sum(kafka_server_replicamanager_underreplicatedpartitions) > 0
-          for: 5m
-          labels:
-            severity: warning
-          annotations:
-            summary: "{{ $value }} under-replicated partitions for > 5 minutes"
-            description: "Partitions have fewer in-sync replicas than the replication factor. Check broker health and disk I/O."
+- name: kafka.cluster
+  rules:
+    - alert: KafkaUnderReplicatedPartitions
+      expr: kafka_server_replicamanager_underreplicatedpartitions > 0
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Under-replicated partitions detected"
+        description: "{{ $value }} partitions are under-replicated on {{ $labels.kubernetes_pod_name }}."
 ```
 
 **When it fires:** Any partition has ISR < replication factor for more than 5 minutes.  
@@ -680,8 +657,8 @@ The monitoring stack is installed via a **local wrapper chart** in `charts/monit
 | Component | Version | Source |
 |---|---|---|
 | Monitoring Chart | 1.0.0 | Local wrapper (`charts/monitoring`) |
-| Prometheus | Managed by kube-prometheus-stack | `prometheus-community/kube-prometheus-stack` |
-| Grafana | 12.3.1 | Bundled with kube-prometheus-stack |
+| Prometheus | v3.9.1 | Pinned in `charts/monitoring/values.yaml` |
+| Grafana | 12.3.1 | Pinned in `charts/monitoring/values.yaml` |
 | kube-prometheus-stack | `82.4.3` | Upstream dependency in `Chart.yaml` |
 
 ### Deploying
@@ -698,7 +675,7 @@ These commands will:
 
 1. Build chart dependencies (`helm dependency build charts/monitoring`)
 2. Install the local wrapper chart
-3. Automatically deploy all 13 Kates and Kafka Grafana dashboards (templated as ConfigMaps)
+3. Automatically deploy every dashboard in `charts/monitoring/dashboards/` (templated as ConfigMaps)
 
 ### Access
 

--- a/docs/book/10-cli-reference.md
+++ b/docs/book/10-cli-reference.md
@@ -1,6 +1,6 @@
 # Chapter 10: CLI Reference
 
-Complete reference for the Kates CLI — every command, flag, and output format.
+Reference for the Kates CLI — the commands, flags, and output formats you'll use day to day.
 
 ## Installation
 
@@ -29,7 +29,7 @@ Before diving into individual commands, here are the workflows you'll use most o
 
 ### Workflow 1: Performance Regression Check
 
-Before upgrading Kafka from 3.8 to 3.9, you want to know if the new version regresses performance. The idea is simple: capture a baseline on the current version, perform the upgrade, run the same test again, and diff the results. If P99 latency or throughput moves outside your tolerance, you have a data-backed reason to investigate before the upgrade reaches production.
+Before upgrading Kafka to a new version, you want to know if the new version regresses performance. The idea is simple: capture a baseline on the current version, perform the upgrade, run the same test again, and diff the results. If P99 latency or throughput moves outside your tolerance, you have a data-backed reason to investigate before the upgrade reaches production.
 
 ```bash
 # 1. Verify the cluster is healthy before starting
@@ -82,7 +82,7 @@ kates top
 kates disruption status <id>
 
 # 4. Export the latency heatmap for detailed post-mortem analysis
-kates report export <test-id> --format heatmap -o heatmap.json
+kates report export <test-id> --format heatmap > heatmap.json
 ```
 
 ### Workflow 4: Pre-Production Cluster Validation
@@ -108,17 +108,17 @@ kates trend --type ENDURANCE --metric p99LatencyMs --days 30
 
 ### Workflow 5: CI/CD Quality Gate
 
-You want every pull request to prove it doesn't regress Kafka performance. This workflow integrates into your CI pipeline — it runs a scenario file, exports JUnit results, and exits non-zero if the grade drops below your threshold.
+You want every pull request to prove it doesn't regress Kafka performance. This workflow integrates into your CI pipeline — it runs a scenario file, exports JUnit results, and runs a quality-gate test that exits non-zero if the grade drops below your threshold.
 
 ```bash
 # 1. Run the scenario defined in your repo
 kates test apply -f ci/load-test.yaml --wait
 
 # 2. Export results as JUnit XML for your CI system
-kates report export <id> --format junit -o results.xml
+kates report export <id> --format junit > results.xml
 
-# 3. Gate: fail the build if the grade is below B
-kates gate -f ci/load-test.yaml --min-grade B
+# 3. Gate: run a gate test and fail the build if the grade is below B
+kates gate --min-grade B --type LOAD --records 100000
 ```
 
 ::: {.callout-tip}
@@ -207,18 +207,22 @@ kates health
 Expected output:
 
 ```
- Kates Health Check
+ Kates Health Dashboard — System Status: UP
 
-  Component          Status    Details
-  ─────────────────────────────────────────────────────
-  API Server         ● UP      v1.17.0 (uptime 4d 12h)
-  Kafka Cluster      ● UP      3 brokers, 0 under-replicated
-  Schema Registry    ● UP      Apicurio 2.2.5.Final
-  Test Engine        ● IDLE    No tests running
-  Database           ● UP      PostgreSQL 16.3
-  Monitoring         ● UP      Prometheus + Grafana
+  Engine
+  Active Backend:   native
+  Available:        [native trogdor]
 
-  Overall: ● HEALTHY
+  Kafka Cluster
+  Status:           ● UP
+  Bootstrap:        krafter-kafka-bootstrap.kafka.svc:9092
+
+  Performance Tests
+  Test        Records   Partitions   Producers   Acks   Compress
+  ─────────────────────────────────────────────────────────────
+  load        100000    3            2           all    lz4
+  stress      5000000   6            16          1      lz4
+  ...
 ```
 
 #### status
@@ -232,12 +236,14 @@ kates status
 Expected output:
 
 ```
-● HEALTHY | 3 brokers | 42 topics | 0 running tests | v1.17.0
+  ✓ local │ UP │ Kafka ✓ │ 12 configs │ 0 running │ 8 done │ 0 failed
 ```
+
+If the API is unreachable, the line shows the context name, its URL, and `unreachable` instead.
 
 #### version
 
-Show CLI, API, and runtime version information.
+Show CLI and runtime version information (CLI version, commit, build date, Go runtime), plus API reachability and the active backend when the server is up.
 
 ```bash
 kates version
@@ -247,7 +253,7 @@ kates version
 
 Aliases: `preflight`, `check`
 
-Pre-flight cluster readiness checklist. The doctor command performs a deep diagnostic of your environment: Kubernetes connectivity, Strimzi operator status, Kafka AdminClient reachability, storage provisioner health, and namespace configuration. It's the first command to run when something "feels wrong" but `kates health` reports healthy — doctor checks the infrastructure layers that health doesn't.
+Pre-flight cluster readiness checklist. The doctor command verifies that the Kates API is reachable, Kafka is connected, the broker count meets the 3-broker minimum, ISR health is clean, topics are listable, and benchmark backends are available. It also checks whether Kyverno is installed with active policies and no workload violations (Kyverno checks warn rather than fail — it's optional but recommended). Failing checks come with remediation hints. It's the first command to run when something "feels wrong" but `kates health` reports healthy.
 
 ```bash
 kates doctor
@@ -258,25 +264,22 @@ kates check
 Expected output:
 
 ```
- Kates Doctor — Environment Diagnostics
+ Kates Doctor — Pre-flight cluster readiness
 
-  Check                          Result
-  ──────────────────────────────────────────────────────
-  Kubernetes API                 ✔ Reachable (v1.32.4)
-  kubectl context                ✔ kind-panda
-  Strimzi Operator               ✔ Running (0.45.0)
-  Kafka Cluster CR               ✔ Ready (3 brokers)
-  KRaft Controller               ✔ Active (broker-0)
-  AdminClient connectivity       ✔ Connected
-  Schema Registry                ✔ Healthy
-  Prometheus                     ✔ Scraping 12 targets
-  Grafana                        ✔ 10 dashboards loaded
-  Namespace: kafka               ✔ Exists
-  Namespace: kates               ✔ Exists
-  StorageClass: standard         ✔ Available
-  PVC health                     ✔ 3/3 Bound
+  Check                Status   Detail
+  ─────────────────────────────────────────────────────────────
+  API Reachable        PASS     Connected
+  Kafka Connected      PASS     krafter-kafka-bootstrap.kafka.svc:9092
+  Broker Count ≥ 3     PASS     3 brokers detected
+  ISR Health           PASS     All replicas in sync
+  Topics Available     PASS     42 topics found
+  Benchmark Backends   PASS     [native trogdor]
+  Kyverno Installed    PASS     CRD present
+  Kyverno Ready        PASS     Admission controller running
+  Kyverno Policies     PASS     6 policies active
+  Kyverno Violations   PASS     No workload violations
 
-  Result: 13/13 checks passed ✔
+  ✓ 10/10 checks passed — cluster is ready for testing!
 ```
 
 **See also:** [Chapter 12: Deployment](12-deployment.md) for environment setup, [Appendix B: Troubleshooting](appendix-b-troubleshooting.md) for common diagnostic failures.
@@ -293,24 +296,24 @@ Kafka cluster metadata and inspection.
 
 ```bash
 # Cluster overview
-kates cluster
+kates cluster info
 
 # List topics
 kates cluster topics
 
 # Topic detail with partition layout
-kates cluster topic <topic-name>
+kates cluster topics describe <topic-name>
 
 # Consumer groups
 kates cluster groups
 
 # Consumer group detail with lag
-kates cluster group <group-name>
+kates cluster groups describe <group-id>
 
-# Broker configuration
-kates cluster brokers
+# Non-default configuration for a broker
+kates cluster broker configs <broker-id>
 
-# Full cluster topology (26 sections)
+# Full cluster topology
 kates cluster topology
 
 # Critical Kafka health alerts
@@ -319,7 +322,7 @@ kates cluster alerts
 
 #### cluster info
 
-Display cluster metadata including broker list, controller identity, cluster ID, and Kafka version.
+Display cluster metadata including broker count, controller identity, cluster ID, and the broker list with rack/AZ placement. The controller broker is marked with ★ in the Role column.
 
 ```bash
 kates cluster info
@@ -328,21 +331,23 @@ kates cluster info
 Expected output:
 
 ```
- Kafka Cluster Info
+ Kafka Cluster — Cluster ID: dQw4w9WgXcQ
 
-  Cluster ID:    dQw4w9WgXcQ
-  Kafka Version: 4.2.0
-  Mode:          KRaft (no ZooKeeper)
-  Controller:    broker-0 (id: 0)
+  Overview
+  Broker Count:   3
 
-  Brokers (3):
-  ID   Host                           Port   Rack    Role
-  ──   ────                           ────   ────    ────
-  0    panda-broker-0.kafka.svc       9092   alpha   broker,controller
-  1    panda-broker-1.kafka.svc       9092   sigma   broker
-  2    panda-broker-2.kafka.svc       9092   gamma   broker
+  Controller
+  Node ID:    0
+  Host:       krafter-broker-0.kafka.svc
+  Port:       9092
+  Rack / AZ:  alpha
 
-  Topics: 42 | Partitions: 186 | Consumer Groups: 7
+  Brokers (3)
+  ID   Host                         Port   Rack / AZ   Role
+  ──   ────                         ────   ─────────   ────
+  0    krafter-broker-0.kafka.svc   9092   alpha       ★
+  1    krafter-broker-1.kafka.svc   9092   sigma
+  2    krafter-broker-2.kafka.svc   9092   gamma
 ```
 
 #### cluster check
@@ -358,80 +363,75 @@ Output statuses: `● HEALTHY`, `▲ WARNING`, `✖ CRITICAL`.
 
 #### cluster topology
 
-Display the full Strimzi/Kafka cluster topology with 26 data sections. Requires the Kates backend to be deployed on Kubernetes with access to Strimzi CRDs and Kafka AdminClient APIs. This is the most comprehensive view of your cluster — use it to verify broker/controller layout after deployment or to audit infrastructure before a load test.
+Display the full Strimzi/Kafka cluster topology, section by section — from the Kubernetes platform down to individual PVCs and endpoints. Requires the Kates backend to be deployed on Kubernetes with access to Strimzi CRDs and Kafka AdminClient APIs. This is the most comprehensive view of your cluster — use it to verify broker/controller layout after deployment or to audit infrastructure before a load test.
 
 ```bash
 kates cluster topology
 kates cluster topology -o json
 ```
 
-Expected output (abbreviated — full output includes 26 sections):
+Expected output (abbreviated — full output includes all sections listed below):
 
 ```
- Kates Cluster Topology — 26 Sections
+ Kafka Cluster Topology — Cluster: krafter  │  Kafka 4.2.0  │  KRaft Mode
 
- ── 1. Kubernetes Platform ─────────────────────────
-  Version:     v1.32.4
-  Provider:    kind
-  Nodes:       3 (panda-worker, panda-worker2, panda-worker3)
+  Kubernetes Platform
+  Version:   v1.31.4
+  Platform:  linux/arm64
+  Nodes:     3
 
- ── 2. Strimzi Operator ────────────────────────────
-  Version:     0.45.0
-  Replicas:    1/1 Ready
-  Watching:    All namespaces
+  Strimzi Operator
+  Version:     1.0.0
+  Components:  ✓ Operator  ✓ Entity Operator  ✓ Cruise Control
 
- ── 3. Kafka Cluster ───────────────────────────────
-  Name:        panda
+  Kafka Cluster
+  Cluster ID:  dQw4w9WgXcQ
   Namespace:   kafka
-  Replicas:    3
-  Status:      Ready
-  Listeners:   PLAIN (9092), TLS (9093)
+  Brokers:     3
+  Status:      ✓ Ready
 
- ── 6. Controllers ─────────────────────────────────
-  Active:      broker-0 (id: 0, zone: alpha)
-  Mode:        KRaft
+  Controllers (3)
+  ...
 
- ── 7. Brokers ─────────────────────────────────────
-  ID  Pod                  Zone    CPU    Memory   Disk
-  0   panda-broker-0       alpha   120m   1.2Gi    4.8Gi
-  1   panda-broker-1       sigma   95m    1.1Gi    4.6Gi
-  2   panda-broker-2       gamma   110m   1.2Gi    4.7Gi
+  Brokers (3)
+  ...
 
-  ... (19 more sections)
+  (more sections: node pools, certificates, ACLs, PVCs, services, ...)
 ```
 
-| # | Section | Source |
-|---|---------|--------|
-| 1 | Kubernetes Platform | K8s API |
-| 2 | Strimzi Operator | Deployment |
-| 3 | Kafka Cluster | CR + AdminClient |
-| 4 | Kafka Config | CR |
-| 5 | Node Pools | CRD |
-| 6 | Controllers | AdminClient + Pods |
-| 7 | Brokers | AdminClient + Pods |
-| 8 | Entity Operator | CR |
-| 9 | Cruise Control | CR |
-| 10 | Kafka Exporter | CR |
-| 11 | TLS Certificates | CR |
-| 12 | Metrics & Monitoring | CR + PodMonitors |
-| 13 | Managed Topics | CRD |
-| 14 | Kafka Users | CRD |
-| 15 | Consumer Groups | AdminClient |
-| 16 | ACLs | AdminClient |
-| 17 | Log Directories | AdminClient |
-| 18 | Feature Flags | AdminClient |
-| 19 | Kafka Rebalances | CRD |
-| 20 | Strimzi Drain Cleaner | Deployment |
-| 21 | Strimzi Pod Sets | CRD |
-| 22 | Network Policies | K8s API |
-| 23 | PVCs | K8s API |
-| 24 | Services | K8s API |
-| 25 | Endpoints | K8s API |
-| 26 | Connect / MirrorMaker2 | CRD |
+| Section | Source |
+|---------|--------|
+| Kubernetes Platform | K8s API |
+| Strimzi Operator | Deployment |
+| Kafka Cluster | CR + AdminClient |
+| Kafka Broker Configuration | CR |
+| Node Pools | CRD |
+| Controllers | AdminClient + Pods |
+| Brokers | AdminClient + Pods |
+| Entity Operator | CR |
+| Cruise Control | CR |
+| Kafka Exporter | CR |
+| TLS Certificates | CR |
+| Metrics & Monitoring | CR + PodMonitors |
+| Managed Topics | CRD |
+| Kafka Users | CRD |
+| Consumer Groups | AdminClient |
+| Access Control Lists | AdminClient |
+| Log Directories | AdminClient |
+| Feature Flags | AdminClient |
+| Kafka Rebalances | CRD |
+| Strimzi Drain Cleaner | Deployment |
+| Strimzi Pod Sets | CRD |
+| Network Policies | K8s API |
+| Persistent Volume Claims | K8s API |
+| Services | K8s API |
+| Endpoints | K8s API |
+| Kafka Connect | CRD |
+| MirrorMaker2 | CRD |
 
 #### cluster alerts
 
-Show critical Kafka health alerts from PrometheusRule CRDs. Displays 16 alert rules across 8 groups that can affect cluster health. Alerts are sorted by severity (critical first) with styled indicators.
+Show critical Kafka health alerts from PrometheusRule CRDs — the alert rules the `kafka-cluster` chart installs, organized into the groups listed below. Alerts are sorted by severity (critical first) with styled indicators.
 
 Returns **exit code 2** when critical alerts are configured — useful for CI/CD health gates.
 
@@ -568,25 +568,27 @@ Apply a YAML scenario file. Supports multi-phase tests with SLA definitions.
 
 #### test scaffold
 
+Browse and export the built-in library of ready-to-use YAML scenario templates.
+
 ```bash
-kates test scaffold --type LOAD
-kates test scaffold --type STRESS -o stress-test.yaml
-kates test scaffold --type INTEGRITY_CHAOS -o chaos-integrity.yaml
+kates test scaffold                        # list all templates
+kates test scaffold --type LOAD           # filter by test type
+kates test scaffold show production-load  # preview a template
+kates test scaffold export ci-gate        # write ci-gate.yaml to current dir
+kates test scaffold export ci-gate -o my-gate.yaml
+kates test scaffold export --all           # export every template
 ```
 
-Generate a YAML scaffold template for any test type.
-
-| Type | Description |
-|------|-------------|
-| `LOAD` | Standard load test scenario |
-| `STRESS` | Multi-phase ramp-up stress test |
-| `SPIKE` | Three-phase spike simulation |
-| `ENDURANCE` | Long-running soak test |
-| `VOLUME` | Large message volume test |
-| `CAPACITY` | Progressive capacity discovery |
-| `ROUND_TRIP` | End-to-end latency measurement |
-| `INTEGRITY` | Data integrity verification |
-| `INTEGRITY_CHAOS` | Integrity + chaos injection |
+| Template | Type | Description |
+|----------|------|-------------|
+| `quick-load` | LOAD | Quick smoke test — 50k records, 2 producers, p99 < 100ms gate |
+| `production-load` | LOAD | Production-grade — 1M records, 8 producers, acks=all, lz4, strict SLA |
+| `stress-test` | STRESS | High-throughput stress — 5M records, 16 producers, find breaking points |
+| `endurance-soak` | ENDURANCE | 1-hour soak at 5k msg/s — detect GC pauses and log compaction issues |
+| `exactly-once` | ROUND_TRIP | E2E integrity — idempotent + transactional, zero-loss, CRC verification |
+| `integrity-tx` | INTEGRITY | Transactional integrity — 4 producers, zstd, CRC, zero-loss verification |
+| `spike-test` | SPIKE | Burst traffic — 32 producers for 60s, test backpressure handling |
+| `ci-gate` | LOAD | CI pipeline gate — fast 10k-record validation with strict zero-error SLA |
 
 **See also:** [Chapter 5: Test Types](05-test-types.md) for the theory behind each test type, [Chapter 13: Scenario Files](13-scenario-files.md) for YAML scenario syntax.
 
@@ -607,34 +609,31 @@ Display the full report for a test run.
 Expected output:
 
 ```
- Test Report — t-a1b2c3
+ Performance Report — Test: a1b2c3
 
-  Type:       LOAD
-  Status:     DONE
-  Duration:   32.4s
-  Backend:    native-loom
-  Topic:      kates-perf-test-a1b2c3 (6 partitions, RF=3)
+  Throughput
+  Total Records:     100,000
+  Avg Throughput:    3,086 rec/s
+  Peak Throughput:   3,412 rec/s
+  Avg MB/s:          3.02
 
-  ── Producer Metrics ──────────────────────────────
-  Records Sent:          100,000
-  Throughput:            3,086 rec/s (3.02 MB/s)
-  Avg Latency:           4.12 ms
-  P50 Latency:           3.00 ms
-  P95 Latency:           8.00 ms
-  P99 Latency:           22.00 ms
-  Max Latency:           186.00 ms
+  Latency Distribution
+  Average  ▓▓░░░░░░░░░░░░░░░░░░    4.12 ms
+  P50      ▓▓░░░░░░░░░░░░░░░░░░    3.00 ms
+  P95      ▓▓▓░░░░░░░░░░░░░░░░░    8.00 ms
+  P99      ▓▓▓▓▓░░░░░░░░░░░░░░░   22.00 ms
+  Max      ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  186.00 ms
 
-  ── Consumer Metrics ──────────────────────────────
-  Records Consumed:      100,000
-  Consumer Throughput:   3,102 rec/s (3.04 MB/s)
-  Integrity:             ✔ 100.00% (0 lost, 0 duplicates)
+  Reliability
+  Error Rate:   0.0000%
 
-  ── SLA Verdict ───────────────────────────────────
-  Grade: A
-  P99 ≤ 50ms:           ✔ PASS (22.00ms)
-  Throughput ≥ 1000:     ✔ PASS (3,086 rec/s)
-  Data Loss = 0:         ✔ PASS
+  SLA Verdict
+  ✓ All SLA thresholds met
+
+  Export: kates report export a1b2c3 --format csv
 ```
+
+If SLA thresholds are violated, the verdict section instead lists each violation in a Metric / Threshold / Actual / Status table.
 
 #### report summary
 
@@ -647,20 +646,23 @@ Condensed summary of key metrics.
 #### report export
 
 ```bash
-kates report export <id> --format json
 kates report export <id> --format csv
-kates report export <id> --format junit -o results.xml
-kates report export <id> --format heatmap -o heatmap.json
-kates report export <id> --format heatmap-csv -o heatmap.csv
+kates report export <id> --format junit
+kates report export <id> --format md
+kates report export <id> --format heatmap > heatmap.json
+kates report export <id> --format heatmap-csv > heatmap.csv
 ```
 
 | Format | Description |
 |--------|-------------|
-| `json` | Full report as JSON |
 | `csv` | Metrics as CSV spreadsheet |
 | `junit` | JUnit XML for CI/CD |
+| `md` | Markdown report |
+| `html` | HTML report |
 | `heatmap` | Latency heatmap as JSON |
 | `heatmap-csv` | Latency heatmap as CSV |
+
+When run in a terminal, the export is written to an auto-named file (e.g. `kates-report-<id>.csv`); when piped or redirected, it goes to stdout. For the full report as JSON, use the global output flag instead: `kates report show <id> -o json`.
 
 #### report diff
 
@@ -700,31 +702,47 @@ Historical performance trend analysis.
 
 ```bash
 kates trend --type LOAD --metric p99LatencyMs --days 30
-kates trend --type LOAD --metric throughputRecordsPerSec --days 7
+kates trend --type LOAD --metric avgThroughputRecPerSec --days 7
+kates trend --type SPIKE --phase spike --metric avgThroughputRecPerSec
+kates trend --type ENDURANCE --all-phases --metric p99LatencyMs
+kates trend phases --type SPIKE --days 30
 ```
 
 Expected output:
 
 ```
- Performance Trend — LOAD / p99LatencyMs / 30 days
+ Trend Analysis — LOAD · p99LatencyMs · 30d window
 
-  Date         P99 (ms)   Trend
-  ──────────────────────────────────────────
-  2026-06-09   18.0       ▁▁▁▂▂
-  2026-06-16   19.5       ▁▁▂▂▃
-  2026-06-23   21.0       ▁▂▂▃▃
-  2026-06-30   20.0       ▁▂▂▂▃
-  2026-07-07   22.0       ▂▂▃▃▃
+  Baseline:   20.10
 
-  30-day avg: 20.1ms | Min: 17.5ms | Max: 24.0ms
-  Trend: → stable (±8.2% variance)
+  Trend Chart
+  ▁▂▂▃▃  → stable  (5 data points)
+
+  Min:       18.00
+  Max:       22.00
+  Average:   20.10
+
+  Data Points
+  Run ID     Timestamp             Value
+  ─────────────────────────────────────────
+  a1b2c3     2026-06-09T02:00:00Z  18.00
+  d4e5f6     2026-06-16T02:00:00Z  19.50
+  ...
 ```
 
-| Flag | Description |
-|------|-------------|
-| `--type` | Test type to analyze |
-| `--metric` | Metric name: `p99LatencyMs`, `avgLatencyMs`, `throughputRecordsPerSec` |
-| `--days` | Lookback period in days |
+Runs that deviate significantly from the baseline are listed in a separate "Regressions Detected" table with the deviation percentage.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--type` | | Test type to analyze (required) |
+| `--metric` | `avgThroughputRecPerSec` | Metric name: `avgThroughputRecPerSec`, `peakThroughputRecPerSec`, `avgThroughputMBPerSec`, `avgLatencyMs`, `p50LatencyMs`, `p95LatencyMs`, `p99LatencyMs`, `p999LatencyMs`, `maxLatencyMs`, `errorRate` |
+| `--days` | 30 | Lookback period in days |
+| `--baseline` | 5 | Number of recent runs used to compute the baseline |
+| `--phase` | | Phase name to analyze (omit for overall) |
+| `--all-phases` | false | Show trends for all phases side-by-side |
+| `--broker` | | Broker ID to scope trend analysis |
+
+Use `kates trend phases --type <TYPE>` to list the phase names available for a test type.
 
 **See also:** [Chapter 4: Performance Theory](04-performance-theory.md) for statistical significance and why single runs are insufficient.
 
@@ -801,12 +819,63 @@ Real-time SSE progress stream for disruption tests.
 
 ---
 
+### Chaos Experiment History
+
+Chaos commands browse the history of past chaos experiment reports and their probe results — the record left behind by disruption and resilience runs.
+
+Aliases: `cx`
+
+#### chaos list
+
+List recent chaos experiment reports with ID, plan name, status, SLA grade, and date.
+
+```bash
+kates chaos list
+kates chaos list --limit 50
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--limit` | 20 | Maximum reports to display |
+
+#### chaos show
+
+Show a detailed chaos experiment report with per-probe breakdown.
+
+```bash
+kates chaos show <id>
+```
+
+---
+
 ### Resilience
 
 Combined performance + chaos testing. Resilience tests run a load workload and inject disruptions simultaneously, then grade the cluster's ability to maintain SLA under fault conditions. This is the highest-level chaos primitive — it combines what you'd otherwise do manually with `test create` + `disruption run`.
 
 ```bash
-kates resilience run --config resilience-test.json
+kates resilience run -f resilience-test.yaml
+kates resilience run -f resilience-test.json    # JSON also supported
+kates resilience run -f resilience-test.yaml --dry-run
+```
+
+The config file has three parts: a `testRequest` (the same shape as a test creation request), a `chaosSpec` (experiment name, target namespace/label, duration, disruption type), and an optional `steadyStateSec` baseline period:
+
+```yaml
+testRequest:
+  type: LOAD
+  spec:
+    numRecords: 100000
+    numProducers: 2
+    recordSize: 512
+
+chaosSpec:
+  experimentName: kafka-broker-pod-kill
+  targetNamespace: kafka
+  targetLabel: "strimzi.io/component-type=kafka"
+  chaosDurationSec: 30
+  disruptionType: POD_KILL
+
+steadyStateSec: 30
 ```
 
 **See also:** [Chapter 7: Chaos Practice](07-chaos-practice.md) for resilience test configuration.
@@ -927,20 +996,22 @@ kates deploy status
 Expected output:
 
 ```
- Kates Deployment Status
+  Operators & CRDs
+    Strimzi Operator      [Healthy]
+    Cert-Manager          [Healthy]
+    Kyverno               [Healthy]
 
-  Component             Namespace    Status     Version
-  ─────────────────────────────────────────────────────
-  Strimzi Operator      kafka        ● Running  0.45.0
-  Kafka Cluster         kafka        ● Ready    4.2.0
-  Kates Backend         kates        ● Running  1.17.0
-  PostgreSQL            kates        ● Running  16.3
-  Prometheus            monitoring   ● Running  2.54.0
-  Grafana               monitoring   ● Running  11.6.0
-  Jaeger                monitoring   ● Running  1.62.0
-  LitmusChaos           litmus       ● Running  3.14.0
+  Core Infrastructure
+    Kafka (krafter)       [Healthy]
+    PostgreSQL (CDC)      [Healthy]
+    Kafka Connect         [Healthy]
+    Monitoring Stack      [Healthy]
 
-  Overall: 8/8 components healthy
+  Applications
+    Apicurio Registry     [Healthy]
+    Kates Backend         [Healthy]
+    Kafka UI              [Healthy]
+    Litmus Chaos          [Healthy]
 ```
 
 #### clean
@@ -1293,20 +1364,19 @@ kates kafka topics
 Expected output:
 
 ```
- Kafka Topics (42 total)
+ Kafka Topics (42)
 
-  Topic                          Partitions   RF   ISR    Status
-  ─────────────────────────────────────────────────────────────────
-  orders.events                  6            3    6/6    ● Healthy
-  user.signups                   3            3    3/3    ● Healthy
-  payments.processed             6            3    6/6    ● Healthy
-  inventory.updates              3            3    3/3    ● Healthy
-  kates-perf-test-a1b2c3         6            3    6/6    ● Healthy
-  __consumer_offsets              50           3    50/50  ● Healthy
+  Topic                    Type       Partitions   Rep. Factor   ISR Health
+  ──────────────────────────────────────────────────────────────────────────
+  orders.events                       6            3             ✓ HEALTHY
+  user.signups                        3            3             ✓ HEALTHY
+  payments.processed                  6            3             ✓ HEALTHY
+  kates-events             system     3            3             ✓ HEALTHY
+  __consumer_offsets       internal   50           3             ✓ HEALTHY
   ...
-
-  Summary: 42 topics, 186 partitions, 0 under-replicated
 ```
+
+Topics with under-replicated partitions show `⚠ N under-replicated` in the ISR Health column. Use `--filter <substring>` to narrow the list.
 
 #### kafka topic
 
@@ -1398,7 +1468,32 @@ Launch interactive Kafka explorer (full-screen TUI).
 kates kafka tui
 ```
 
-**See also:** [Chapter 3: Cluster Setup](03-cluster.md) for Kafka cluster architecture, [Chapter 15: Kafka Deployment](15-kafka-deployment.md) for production Kafka configuration.
+#### kafka connect
+
+Manage Kafka Connect (via Strimzi CRDs) — inspect the Connect cluster, list and describe connectors, and perform lifecycle operations. All subcommands accept `-n`/`--namespace` to select the namespace where Connect is deployed (auto-detected by default: `KATES_CONNECT_NS` env var, then live cluster detection, then `KATES_KAFKA_NS`, then `kafka`).
+
+```bash
+kates kafka connect status                  # Connect cluster status
+kates kafka connect connectors              # List all KafkaConnector CRs
+kates kafka connect connector <name>        # Describe a connector
+kates kafka connect tasks <name>            # Task-level status for a connector
+kates kafka connect config <name>           # Show connector configuration
+kates kafka connect plugins                 # List installed connector plugins
+kates kafka connect logs --follow           # Tail Connect worker logs
+kates kafka connect restart <name>          # Restart a connector
+kates kafka connect restart-task <name> <taskId>
+kates kafka connect pause <name>
+kates kafka connect resume <name>
+kates kafka connect delete <name>
+kates kafka connect scale <replicas>        # Scale Connect workers
+```
+
+| Flag | Description |
+|------|-------------|
+| `-n`, `--namespace` | Namespace where Kafka Connect is deployed |
+| `-f`, `--follow` | (`logs` only) Stream logs continuously |
+
+**See also:** [Chapter 21: Kafka Connect](21-kafka-connect.md) for Connect cluster deployment and connector configuration, [Chapter 3: Cluster Setup](03-cluster.md) for Kafka cluster architecture, [Chapter 15: Kafka Deployment](15-kafka-deployment.md) for production Kafka configuration.
 
 ---
 
@@ -1457,8 +1552,18 @@ CI quality gate — run a test and exit non-zero if grade is below threshold.
 kates gate
 kates ci
 kates quality-gate
-kates gate -f scenario.yaml --min-grade B
+kates gate --min-grade B
+kates gate --min-grade C --type STRESS --records 100000
+kates gate --min-grade A --timeout 300
 ```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--min-grade` | `C` | Minimum passing grade (A, B, C, D, F) |
+| `--type` | `LOAD` | Test type to run |
+| `--records` | 50000 | Number of records |
+| `--backend` | | Benchmark backend |
+| `--timeout` | 180 | Timeout in seconds |
 
 #### baseline
 
@@ -1671,20 +1776,25 @@ kates flow run -f pipeline.yaml
 
 ### Badge Generation
 
-The badge command generates shields.io-compatible SVG badges that display your cluster's latest performance grade, security score, or build status. Embed them in your repository's README, wiki pages, or internal dashboards. Badges are generated from the most recent test or audit results — they update automatically when you run new tests. Supported badge types include `build`, `performance`, `security`, and `health`.
+The badge command generates shields.io-compatible badge URLs from your most recent completed test — ready to paste into a repository README, GitHub PR, or dashboard. It prints the raw URL plus ready-made Markdown and HTML snippets. The badge value comes from the latest `DONE` test (optionally filtered by test type), so it reflects your most recent results each time you regenerate it.
 
 ```bash
-kates badge
-kates badge --type build --output badge.svg
-kates badge --type performance --output perf-badge.svg
-kates badge --type security --output sec-badge.svg
+kates badge                                # grade badge from the latest test
+kates badge --type LOAD --metric grade
+kates badge --type STRESS --metric p99
+kates badge --metric throughput
 ```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--type` | | Test type filter (LOAD, STRESS, etc.) |
+| `--metric` | `grade` | Badge metric: `grade`, `p99`, or `throughput` |
 
 ---
 
 ### Webhook Notifications
 
-Webhooks send HTTP POST notifications to external endpoints when specific events occur in Kates. Supported events include `test.completed`, `test.failed`, `disruption.completed`, `schedule.triggered`, and `security.audit.completed`. Use webhooks to integrate Kates with Slack, PagerDuty, Microsoft Teams, or any system that accepts incoming webhooks. Each webhook registration binds a name, a URL, and an optional event filter — if no event filter is specified, the webhook fires for all events.
+Webhooks send HTTP POST notifications to external endpoints when a test finishes. The backend fires a `test.completed` event whenever a test reaches `DONE` or `FAILED` status; the payload carries the event name, test ID, test type, final status, and timestamp (the event name is also sent in the `X-Kates-Event` header). Use webhooks to integrate Kates with Slack, PagerDuty, Microsoft Teams, or any system that accepts incoming webhooks. Each webhook registration binds a name to a URL. Deliveries are retried, and events that still fail are parked in a dead-letter queue.
 
 #### webhook
 

--- a/docs/book/10b-lab.md
+++ b/docs/book/10b-lab.md
@@ -42,7 +42,7 @@ Lab splits the terminal into two panes:
 │                          │  10-50 █                4%   │
 │                          │  50+ms ▏                1%   │
 ├──────────────────────────┴──────────────────────────────┤
-│  ✓ #3 — 48.7K rec/s, p99=11.00ms  (23s)                 │
+│  ✓ #3 — 48.7K rec/s, p99=11.00ms                        │
 │  ↑↓ navigate  ←→ change  Enter run  p preset  d diff    │
 └─────────────────────────────────────────────────────────┘
 ```
@@ -59,7 +59,7 @@ The left pane shows configurable parameters. The right pane shows iteration hist
 | `p` | Config | Cycle through presets (Low Latency → Max Throughput → Durability) |
 | `s` | Config | Start auto-sweep on the currently selected parameter |
 | `m` | Config | Run 3 identical tests and record the median (stabilized result) |
-| `W` | Config | Cycle warmup count (0→1→2→3→4→5→off) — warmup runs are discarded |
+| `W` | Config | Cycle warmup count (1→2→3→4→5→off) — warmup runs are discarded |
 | `d` | Config | Show diff between last two iterations (or pinned pair) |
 | `c` | Config | Open pin-select view to pick arbitrary iterations to compare |
 | `e` | Config | Export all iterations to CSV (`~/kates-lab-{timestamp}.csv`) |
@@ -76,11 +76,11 @@ Presets apply a curated set of parameters for common test scenarios. Press `p` t
 
 | Preset | Goal | Key Settings |
 |--------|------|-------------|
-| **Low Latency** | Minimize P99 | `acks=1`, `compression=none`, `batchSize=16384`, `lingerMs=0`, `producers=1` |
-| **Max Throughput** | Maximize rec/s | `acks=all`, `compression=lz4`, `batchSize=262144`, `lingerMs=50`, `producers=8` |
-| **Durability** | Zero data loss | `acks=all`, `replication=3`, `compression=lz4`, `batchSize=65536`, `lingerMs=5` |
+| **Low Latency** | Minimize P99 | `type=SPIKE`, `acks=1`, `compression=none`, `batchSize=16384`, `lingerMs=0`, `producers=1` |
+| **Max Throughput** | Maximize rec/s | `type=STRESS`, `acks=all`, `compression=lz4`, `batchSize=262144`, `lingerMs=50`, `producers=8` |
+| **Durability** | Zero data loss | `type=LOAD`, `acks=all`, `replication=3`, `compression=lz4`, `batchSize=65536`, `lingerMs=5` |
 
-Presets are starting points — after applying one, fine-tune individual parameters before running.
+Note that each preset also switches the **Test Type** (`SPIKE`, `STRESS`, or `LOAD`), so the top field changes when you cycle `p`. Presets are starting points — after applying one, fine-tune individual parameters before running.
 
 ## Iteration Workflow
 
@@ -102,13 +102,13 @@ Each completed test creates an **iteration** — a snapshot of parameters and re
 
 ### Live Progress
 
-While a test runs, the status bar displays live metrics:
+While a test runs, the status bar shows the iteration number and elapsed time, updating every second:
 
 ```
-⏳ Running iteration #4…  (12s)  23.4K rec  45.2K rec/s  p99=8.50ms
+⏳ Running iteration #4…  (12s)
 ```
 
-The elapsed time, records sent, throughput, and latency update every second.
+Throughput and latency metrics appear once the test completes.
 
 ## Comparing Iterations
 
@@ -167,7 +167,7 @@ After the sweep completes, the iteration history shows results for all values si
 
 The JVM needs time to JIT-compile hot code paths. The first 1–3 runs in a fresh session are typically slower and noisier than subsequent runs. Warmup mode discards a configurable number of iterations before recording the measured one.
 
-Press `W` to cycle the warmup count (0 → 1 → 2 → 3 → 4 → 5 → off):
+Press `W` to cycle the warmup count (1 → 2 → 3 → 4 → 5 → off):
 
 ```
 🔥 Warmup: 2 iteration(s) before measuring
@@ -193,7 +193,7 @@ Press `m` to start:
 After all 3 runs complete, a single iteration is added to the history with the middle throughput/P99 value. This gives you a **stable, reproducible** metric for parameter comparisons.
 
 ::: {.callout-note}
-Median mode and warmup combine: if warmup is set to 2 and you press `m`, Lab runs 2+3+2+3+2+3 = 15 iterations internally but records only 1 aggregated result. For faster sessions, set warmup to 0 when using median mode — the first of 3 runs provides the warmup naturally.
+Median mode ignores the warmup setting: pressing `m` always runs exactly 3 back-to-back tests, with no warmup iterations inserted. Warmup applies only to tests started with `Enter`. In practice the first of the 3 median runs absorbs most of the warmup effect anyway.
 :::
 
 
@@ -235,18 +235,21 @@ Press `r` to retry with the exact same parameters — the previous `CreateTestRe
 
 ## Duration Calculation
 
-Lab calculates `durationMs` proportionally to the record count:
+Lab budgets roughly one millisecond per record when computing `durationMs`:
 
-```
-durationMs = (records / 1000) × 1000
+```go
+durationMs := records / 1000 * 1000 // integer division: ~1 ms per record
+if durationMs < 60000 {
+    durationMs = 60000 // 60-second floor
+}
 ```
 
-With a floor of 60 seconds. This prevents the backend from using its default (15 minutes for STRESS tests) when the workload would finish much faster.
+This prevents the backend from falling back to its configured default duration (for STRESS tests, `kates.tests.stress.duration-ms` — 15 minutes out of the box) when the workload would finish much faster.
 
 | Records | Duration |
 |:-------:|:--------:|
 | 10,000 | 60s (floor) |
-| 50,000 | 60s |
+| 50,000 | 60s (floor) |
 | 100,000 | 100s |
 | 500,000 | 500s |
 | 1,000,000 | 1000s |

--- a/docs/book/11-api-reference.md
+++ b/docs/book/11-api-reference.md
@@ -12,13 +12,16 @@ If you need strongly typed clients, streaming results, or high-throughput progra
 
 ## Authentication
 
-Kates does **not** enforce authentication by default when running inside a Kubernetes cluster with port-forwarding. However, when exposed externally (e.g., via an Ingress or LoadBalancer), you should secure access.
+Kates enforces API-key authentication **by default**: `kates.api.security-enabled=true` in `application.properties` (the `%dev` and `%test` profiles disable it). The expected key comes from the `kates.api.key` property, which reads the `KATES_API_KEY` environment variable; the Helm chart provisions it as a Kubernetes Secret via the `apiKey` values (see [Chapter 17: Security & Compliance](17-security.md)).
 
-If token-based authentication is enabled (via the `kates.auth.enabled=true` configuration), include the token in every request:
+Include the key in every request, using either header form:
 
 ```bash
-curl -H "Authorization: Bearer <your-token>" http://localhost:30083/api/health
+curl -H "Authorization: Bearer $KATES_API_KEY" http://localhost:30083/api/tests
+curl -H "X-API-Key: $KATES_API_KEY" http://localhost:30083/api/tests
 ```
+
+Requests without a key receive `401 Unauthorized`; requests with a wrong key receive `403 Forbidden`. The paths `/api/health`, `/openapi`, and everything under `/q/` (metrics, OpenAPI spec) are public and never require a key.
 
 ### Common Request Headers
 
@@ -26,10 +29,10 @@ curl -H "Authorization: Bearer <your-token>" http://localhost:30083/api/health
 |--------|-------|:---:|-------------|
 | `Content-Type` | `application/json` | ✅ (POST/PUT) | Request body format |
 | `Accept` | `application/json` | | Response format (default) |
-| `Authorization` | `Bearer <token>` | When auth enabled | Authentication token |
-| `X-Request-Id` | UUID string | | Correlation ID for tracing |
+| `Authorization` | `Bearer <api-key>` | When security enabled | API key (alternative: `X-API-Key`) |
+| `X-API-Key` | `<api-key>` | When security enabled | API key (alternative to `Authorization`) |
 
-> **Tip:** When running locally via `kubectl port-forward`, no authentication headers are needed. Kubernetes RBAC controlling access to the port-forward command is sufficient.
+> **Tip:** In Quarkus dev mode and in tests, security is switched off (`%dev.kates.api.security-enabled=false`), so no authentication headers are needed there.
 
 ---
 
@@ -39,34 +42,35 @@ curl -H "Authorization: Bearer <your-token>" http://localhost:30083/api/health
 http://localhost:30083
 ```
 
-When running in-cluster, use the Kubernetes service DNS name: `http://kates.kates.svc.cluster.local:8080`
+Port `30083` is the NodePort defined by the kind overlay (`charts/kates/values-kind.yaml`) — it is not a universal default. On other clusters, port-forward the service (`kubectl port-forward svc/kates 8080:8080`) and target `http://localhost:8080`. When running in-cluster, use the Kubernetes service DNS name: `http://kates.kates.svc.cluster.local:8080`
 
 ---
 
 ## Endpoints
 
+This chapter documents the most commonly used endpoints in the core resource families: health, tests, reports, cluster inspection, disruptions, resilience, trends, and schedules. The backend exposes more than is listed here — bulk operations, test cancellation, baselines, report comparison and markdown export, disruption templates/schedules/playbooks, resilience scenarios, plus entire resource families (webhooks, events, cost, advisor, audit, profiles, security, Kafka client tooling, DLQ, share groups). The complete, always-current machine-readable specification is generated from the code by MicroProfile OpenAPI and served at `/q/openapi` (Swagger UI is available at `/q/swagger-ui` in dev mode).
+
 ### Health & System
 
 #### GET /api/health
 
-System health check including Kafka connectivity and engine status.
+System health check including Kafka connectivity and engine status. This endpoint is public — no API key required.
 
 **Response:** `200 OK`
 
 ```json
 {
   "status": "UP",
+  "engine": { "activeBackend": "native", "availableBackends": ["native", "trogdor"] },
   "kafka": {
-    "connected": true,
+    "status": "UP",
     "bootstrapServers": "krafter-kafka-bootstrap.kafka.svc:9092",
-    "clusterId": "abc123",
-    "brokerCount": 3
-  },
-  "engine": { "activeTests": 2, "totalCompleted": 45 }
+    "message": "Kafka cluster is reachable"
+  }
 }
 ```
 
-When Kafka is unreachable, the response status code is `503 Service Unavailable` with `"status": "DOWN"` and `"kafka.connected": false`.
+The response also contains a `tests` object with the resolved default configuration for every test type. When Kafka is unreachable, the endpoint still returns `200 OK`, but with `"status": "DEGRADED"` and `"kafka.status": "DOWN"`.
 
 ---
 
@@ -74,25 +78,25 @@ When Kafka is unreachable, the response status code is `503 Service Unavailable`
 
 #### POST /api/tests
 
-Create and start a new test run.
+Create and start a new test run. Execution is asynchronous — poll `GET /api/tests/{id}` for progress.
 
 **Request Body:**
 
 ```json
 {
-  "testType": "LOAD",
+  "type": "LOAD",
   "backend": "native",
   "spec": {
-    "records": 100000,
-    "recordSizeBytes": 1024,
-    "producers": 4,
-    "consumers": 2,
+    "numRecords": 100000,
+    "recordSize": 1024,
+    "numProducers": 4,
+    "numConsumers": 2,
     "acks": "all",
     "topic": "perf-test",
     "partitions": 3,
     "replicationFactor": 3,
     "minInsyncReplicas": 2,
-    "durationSeconds": 120,
+    "durationMs": 120000,
     "throughput": -1,
     "consumerGroup": "perf-cg",
     "fetchMinBytes": 1,
@@ -103,27 +107,28 @@ Create and start a new test run.
 
 | Field | Type | Required | Description |
 |-------|------|:---:|-------------|
-| `testType` | String | ✅ | One of: LOAD, STRESS, SPIKE, ENDURANCE, VOLUME, CAPACITY, ROUND_TRIP, INTEGRITY |
+| `type` | String | ✅ | Test type — any value returned by `GET /api/tests/types` (LOAD, STRESS, SPIKE, ENDURANCE, VOLUME, CAPACITY, ROUND_TRIP, INTEGRITY, the TUNE_* family, INTEGRATION_CDC) |
 | `backend` | String | | Backend engine (default: "native") |
 | `spec` | Object | | Test specification overrides |
 
-**Response:** `201 Created`
+**Response:** `202 Accepted`
 
 ```json
 {
-  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "id": "a1b2c3d4",
   "testType": "LOAD",
   "status": "PENDING",
   "backend": "native",
   "spec": {
-    "records": 100000, "recordSizeBytes": 1024, "producers": 4, "consumers": 2,
+    "numRecords": 100000, "recordSize": 1024, "numProducers": 4, "numConsumers": 2,
     "acks": "all", "topic": "perf-test", "partitions": 3, "replicationFactor": 3,
-    "minInsyncReplicas": 2, "durationSeconds": 120, "throughput": -1
+    "minInsyncReplicas": 2, "durationMs": 120000, "throughput": -1
   },
-  "createdAt": "2026-02-15T20:00:00Z",
-  "updatedAt": "2026-02-15T20:00:00Z"
+  "createdAt": "2026-02-15T20:00:00Z"
 }
 ```
+
+Run IDs are 8-character UUID prefixes. `status` moves through `PENDING`, `RUNNING`, `STOPPING`, and ends at `DONE` or `FAILED`.
 
 #### GET /api/tests
 
@@ -134,9 +139,9 @@ List test runs with pagination and filtering.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `page` | int | 0 | Page number (0-indexed) |
-| `size` | int | 20 | Page size |
+| `size` | int | 50 | Page size (max 200) |
 | `type` | String | | Filter by test type |
-| `status` | String | | Filter by status |
+| `status` | String | | Filter by status (PENDING, RUNNING, STOPPING, DONE, FAILED) |
 
 **Response:** `200 OK`
 
@@ -144,64 +149,52 @@ List test runs with pagination and filtering.
 {
   "items": [
     {
-      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "id": "a1b2c3d4",
       "testType": "LOAD",
-      "status": "COMPLETED",
-      "createdAt": "2026-02-15T20:00:00Z",
-      "completedAt": "2026-02-15T20:02:05Z",
-      "summary": {
-        "recordsSent": 100000,
-        "throughputRecordsPerSec": 8412.7,
-        "avgLatencyMs": 2.4,
-        "p99LatencyMs": 12.3
-      }
+      "status": "DONE",
+      "backend": "native",
+      "createdAt": "2026-02-15T20:00:00Z"
     },
     {
-      "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+      "id": "b2c3d4e5",
       "testType": "STRESS",
       "status": "RUNNING",
-      "createdAt": "2026-02-15T20:05:00Z",
-      "completedAt": null,
-      "summary": null
+      "backend": "native",
+      "createdAt": "2026-02-15T20:05:00Z"
     }
   ],
-  "page": 0, "size": 20, "totalItems": 45, "totalPages": 3
+  "page": 0, "size": 50, "total": 2, "count": 2
 }
 ```
 
 #### GET /api/tests/{id}
 
-Get full details of a test run including results, integrity data, and timeline events.
+Get full details of a test run, refreshing its status. The run carries one result entry per task/phase; for INTEGRITY tests each result also includes an `integrity` object (lost/duplicate records, RTO/RPO).
 
 **Response:** `200 OK`
 
 ```json
 {
-  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "id": "a1b2c3d4",
   "testType": "LOAD",
-  "status": "COMPLETED",
+  "status": "DONE",
   "backend": "native",
-  "spec": { "records": 100000, "recordSizeBytes": 1024, "producers": 4, "consumers": 2, "acks": "all", "topic": "perf-test" },
+  "spec": { "numRecords": 100000, "recordSize": 1024, "numProducers": 4, "numConsumers": 2, "acks": "all", "topic": "perf-test" },
   "results": [
     {
-      "phaseName": "ramp-up", "recordsSent": 10000,
-      "throughputRecordsPerSec": 5234.1, "throughputMbPerSec": 5.1,
-      "avgLatencyMs": 4.8, "p50LatencyMs": 3.2, "p95LatencyMs": 9.6, "p99LatencyMs": 18.4, "maxLatencyMs": 45.2
+      "taskId": "producer-1", "phaseName": "ramp-up", "status": "DONE", "recordsSent": 10000,
+      "throughputRecordsPerSec": 5234.1, "throughputMBPerSec": 5.1,
+      "avgLatencyMs": 4.8, "p50LatencyMs": 3.2, "p95LatencyMs": 9.6, "p99LatencyMs": 18.4, "maxLatencyMs": 45.2,
+      "startTime": "2026-02-15T20:00:01Z", "endTime": "2026-02-15T20:00:16Z"
     },
     {
-      "phaseName": "steady-state", "recordsSent": 90000,
-      "throughputRecordsPerSec": 8412.7, "throughputMbPerSec": 8.2,
-      "avgLatencyMs": 2.4, "p50LatencyMs": 1.8, "p95LatencyMs": 5.6, "p99LatencyMs": 12.3, "maxLatencyMs": 34.1
+      "taskId": "producer-2", "phaseName": "steady-state", "status": "DONE", "recordsSent": 90000,
+      "throughputRecordsPerSec": 8412.7, "throughputMBPerSec": 8.2,
+      "avgLatencyMs": 2.4, "p50LatencyMs": 1.8, "p95LatencyMs": 5.6, "p99LatencyMs": 12.3, "maxLatencyMs": 34.1,
+      "startTime": "2026-02-15T20:00:16Z", "endTime": "2026-02-15T20:02:05Z"
     }
   ],
-  "integrity": { "totalProduced": 100000, "totalConsumed": 100000, "duplicates": 0, "lost": 0, "outOfOrder": 0, "verified": true },
-  "timeline": [
-    { "timestamp": "2026-02-15T20:00:00Z", "event": "TEST_STARTED", "detail": "Initializing producers" },
-    { "timestamp": "2026-02-15T20:00:01Z", "event": "PHASE_STARTED", "detail": "ramp-up" },
-    { "timestamp": "2026-02-15T20:02:05Z", "event": "TEST_COMPLETED", "detail": "All phases finished" }
-  ],
-  "createdAt": "2026-02-15T20:00:00Z",
-  "completedAt": "2026-02-15T20:02:05Z"
+  "createdAt": "2026-02-15T20:00:00Z"
 }
 ```
 
@@ -221,59 +214,64 @@ Get the full test report with cluster snapshot, broker metrics, and SLA verdict.
 
 ```json
 {
-  "testRun": { "id": "a1b2c3d4-...", "testType": "LOAD", "status": "COMPLETED" },
-  "clusterId": "abc123",
-  "clusterSnapshot": { "brokerCount": 3, "topicCount": 12, "totalPartitions": 36 },
+  "run": { "id": "a1b2c3d4", "testType": "LOAD", "status": "DONE" },
+  "summary": {
+    "totalRecords": 100000,
+    "avgThroughputRecPerSec": 8412.7, "peakThroughputRecPerSec": 9120.4, "avgThroughputMBPerSec": 8.2,
+    "avgLatencyMs": 2.4, "p50LatencyMs": 1.8, "p95LatencyMs": 5.6, "p99LatencyMs": 12.3,
+    "p999LatencyMs": 21.7, "maxLatencyMs": 34.1,
+    "totalErrors": 0, "errorRate": 0.0, "durationMs": 125000
+  },
+  "phases": [
+    { "phaseName": "steady-state", "metrics": { "avgThroughputRecPerSec": 8412.7, "p99LatencyMs": 12.3 } }
+  ],
+  "clusterSnapshot": {
+    "clusterId": "abc123",
+    "brokerCount": 3,
+    "controllerId": 0,
+    "brokers": [ { "id": 0, "host": "krafter-kafka-0.kafka.svc", "port": 9092, "rack": "zone-a" } ]
+  },
   "brokerMetrics": [
     {
-      "brokerId": 0, "host": "krafter-kafka-0.kafka.svc",
-      "bytesInPerSec": 8523412.5, "messagesInPerSec": 8412.7,
-      "activeControllerCount": 1, "underReplicatedPartitions": 0
+      "brokerId": 0, "host": "krafter-kafka-0.kafka.svc", "isController": true,
+      "leaderPartitions": 12, "replicaPartitions": 36, "underReplicatedPartitions": 0,
+      "leaderSharePercent": 33.3, "skewed": false
     }
   ],
-  "slaVerdict": {
-    "passed": true,
-    "checks": [
-      { "metric": "p99LatencyMs", "threshold": 500, "actual": 12.3, "result": "PASS" },
-      { "metric": "throughputRecordsPerSec", "threshold": 5000, "actual": 8412.7, "result": "PASS" },
-      { "metric": "errorRate", "threshold": 0.01, "actual": 0.0, "result": "PASS" }
-    ]
-  },
-  "summary": {
-    "totalRecordsSent": 100000, "totalRecordsConsumed": 100000,
-    "avgThroughputRecordsPerSec": 8412.7, "avgLatencyMs": 2.4, "p99LatencyMs": 12.3,
-    "totalDurationMs": 125000, "dataIntegrityVerified": true
-  },
+  "overallSlaVerdict": { "passed": true, "violations": [] },
   "generatedAt": "2026-02-15T20:05:00Z"
 }
 ```
+
+When an SLA is violated, `overallSlaVerdict.violations` contains entries of the form `{ "metric": "p99LatencyMs", "threshold": 500.0, "actual": 612.4, "severity": "CRITICAL" }`.
 
 #### GET /api/tests/{id}/report/csv
 
 Export report as CSV. **Response:** `200 OK` with `Content-Type: text/csv`
 
 ```
-phase,records_sent,throughput_rps,throughput_mbps,avg_latency_ms,p50_ms,p95_ms,p99_ms,max_ms
-ramp-up,10000,5234.1,5.1,4.8,3.2,9.6,18.4,45.2
-steady-state,90000,8412.7,8.2,2.4,1.8,5.6,12.3,34.1
+runId,testType,backend,phase,recordsSent,throughputRecPerSec,throughputMBPerSec,avgLatencyMs,p50LatencyMs,p95LatencyMs,p99LatencyMs,maxLatencyMs,error
+a1b2c3d4,LOAD,native,ramp-up,10000,5234.1,5.1,4.8,3.2,9.6,18.4,45.2,
+a1b2c3d4,LOAD,native,steady-state,90000,8412.7,8.2,2.4,1.8,5.6,12.3,34.1,
 ```
+
+A `# Summary` block with aggregate metrics is appended after the per-result rows.
 
 #### GET /api/tests/{id}/report/junit
 
-Export report as JUnit XML for CI/CD integration. **Response:** `200 OK` with `Content-Type: application/xml`
+Export report as JUnit XML for CI/CD integration. Each test result maps to a `<testcase>`; SLA violations are appended as extra `<testcase>` entries with `<failure>` elements. **Response:** `200 OK` with `Content-Type: application/xml`
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="kates-load-test" tests="3" failures="0" time="125.0">
-  <testcase name="p99LatencyMs <= 500ms" time="0.001"/>
-  <testcase name="throughputRecordsPerSec >= 5000" time="0.001"/>
-  <testcase name="errorRate <= 0.01" time="0.001"/>
+<testsuite name="LOAD" tests="2" failures="0" errors="0">
+  <testcase name="ramp-up" classname="kates.LOAD" time="15.000"/>
+  <testcase name="steady-state" classname="kates.LOAD" time="110.000"/>
 </testsuite>
 ```
 
 #### GET /api/tests/{id}/report/heatmap
 
-Export latency heatmap data.
+Export latency heatmap data. Returns `404` with a plain-text message when no heatmap data was recorded for the run.
 
 **Query Parameters:**
 
@@ -285,102 +283,109 @@ Export latency heatmap data.
 
 ```json
 {
-  "runId": "a1b2c3d4-...",
+  "runId": "a1b2c3d4",
   "testType": "LOAD",
-  "bucketLabels": ["0–0.1ms", "0.1–0.5ms", "0.5–1ms", "1–2ms", "2–5ms", "5–10ms", "10–50ms", "50–100ms", "100–500ms", "500–1000ms"],
+  "bucketLabels": ["0ms-0.5ms", "0.5ms-1ms", "1ms-2ms", "2ms-3ms", "3ms-5ms"],
+  "bucketBoundaries": [[0.0, 0.5], [0.5, 1.0], [1.0, 2.0], [2.0, 3.0], [3.0, 5.0]],
   "rows": [
-    { "timestampMs": 1708012345000, "phaseName": "ramp-up", "buckets": [0, 12, 145, 832, 1456, 389, 23, 5, 1, 0] },
-    { "timestampMs": 1708012350000, "phaseName": "steady-state", "buckets": [0, 0, 12, 145, 832, 456, 89, 23, 5, 1] }
+    { "timestampMs": 1771185645000, "phase": "ramp-up", "counts": [0, 12, 145, 832, 1456] },
+    { "timestampMs": 1771185650000, "phase": "steady-state", "counts": [0, 0, 12, 145, 832] }
   ]
 }
 ```
+
+*(Arrays truncated for readability — the real heatmap uses 25 latency buckets spanning 0 ms to 10 s. Each row is a 1-second sampling window.)*
 
 ---
 
 ### Cluster Inspection
 
-#### GET /api/cluster
+#### GET /api/cluster/info
 
-Kafka cluster metadata: brokers, topics, partitions.
+Kafka cluster metadata: cluster ID, controller, and brokers.
 
 ```json
 {
   "clusterId": "abc123",
   "controller": { "id": 0, "host": "krafter-kafka-0.kafka.svc", "port": 9092 },
+  "brokerCount": 3,
   "brokers": [
     { "id": 0, "host": "krafter-kafka-0.kafka.svc", "port": 9092, "rack": "zone-a" },
     { "id": 1, "host": "krafter-kafka-1.kafka.svc", "port": 9092, "rack": "zone-b" },
     { "id": 2, "host": "krafter-kafka-2.kafka.svc", "port": 9092, "rack": "zone-c" }
-  ],
-  "topicCount": 12, "totalPartitions": 36
+  ]
 }
 ```
 
 #### GET /api/cluster/topics
 
-List all topics with partition counts.
+List topic names, paginated (`page`, `size` query parameters; `size` defaults to 50, max 200).
 
 ```json
-{
-  "topics": [
-    { "name": "kates-results", "partitions": 6, "replicationFactor": 3, "internal": false },
-    { "name": "perf-test", "partitions": 3, "replicationFactor": 3, "internal": false }
-  ]
-}
+{ "page": 0, "size": 50, "total": 2, "count": 2, "items": ["kates-results", "perf-test"] }
 ```
 
 #### GET /api/cluster/topics/{name}
 
-Topic detail with partition assignments and ISR.
+Topic detail with partition assignments, ISR, and key configuration entries.
 
 ```json
 {
   "name": "perf-test",
-  "partitions": [
-    { "id": 0, "leader": 0, "replicas": [0, 1, 2], "isr": [0, 1, 2] },
-    { "id": 1, "leader": 1, "replicas": [1, 2, 0], "isr": [1, 2, 0] }
+  "internal": false,
+  "partitions": 3,
+  "replicationFactor": 3,
+  "partitionInfo": [
+    { "partition": 0, "leader": 0, "replicas": [0, 1, 2], "isr": [0, 1, 2], "underReplicated": false },
+    { "partition": 1, "leader": 1, "replicas": [1, 2, 0], "isr": [1, 2, 0], "underReplicated": false }
   ],
-  "config": { "retention.ms": "604800000", "min.insync.replicas": "2", "cleanup.policy": "delete" }
+  "configs": { "retention.ms": "604800000", "min.insync.replicas": "2", "cleanup.policy": "delete" }
 }
 ```
 
 #### GET /api/cluster/groups
 
-List consumer groups with status.
+List consumer groups with state, paginated (`page`, `size` query parameters).
 
 ```json
-{ "groups": [{ "name": "perf-cg", "state": "STABLE", "members": 2, "assignedPartitions": 3 }] }
+{ "page": 0, "size": 50, "total": 1, "count": 1, "items": [{ "groupId": "perf-cg", "state": "Stable" }] }
 ```
 
-#### GET /api/cluster/groups/{name}
+#### GET /api/cluster/groups/{id}
 
-Consumer group detail with per-partition lag.
+Consumer group detail with per-partition offsets and lag.
 
 ```json
 {
-  "name": "perf-cg", "state": "STABLE",
-  "coordinator": { "id": 1, "host": "krafter-kafka-1.kafka.svc" },
-  "members": [{
-    "memberId": "consumer-perf-cg-1-abc123", "clientId": "consumer-perf-cg-1", "host": "/10.244.0.15",
-    "assignments": [
-      { "topic": "perf-test", "partition": 0, "currentOffset": 50000, "logEndOffset": 50000, "lag": 0 }
-    ]
-  }],
+  "groupId": "perf-cg",
+  "state": "Stable",
+  "members": 2,
+  "offsets": [
+    { "topic": "perf-test", "partition": 0, "currentOffset": 50000, "endOffset": 50000, "lag": 0 },
+    { "topic": "perf-test", "partition": 1, "currentOffset": 49998, "endOffset": 50000, "lag": 2 }
+  ],
   "totalLag": 2
 }
 ```
 
-#### GET /api/cluster/brokers
+#### GET /api/cluster/brokers/{id}/configs
 
-Broker configuration listing. Returns broker IDs, hosts, rack assignments, and server-level configuration key/value pairs.
+Non-default configuration entries for a specific broker.
+
+```json
+[
+  { "name": "min.insync.replicas", "value": "2", "source": "STATIC_BROKER_CONFIG", "readOnly": false },
+  { "name": "log.retention.hours", "value": "168", "source": "STATIC_BROKER_CONFIG", "readOnly": false }
+]
+```
 
 ---
 
 ### Disruption Testing
 
-#### POST /api/disruptions/run
+#### POST /api/disruptions
 
-Execute a disruption plan.
+Execute a disruption plan. Execution is **synchronous** — the call blocks until every step has run (including observation windows) and returns the finished report. Add the `dryRun=true` query parameter to validate the plan without injecting any faults.
 
 **Request Body:**
 
@@ -401,94 +406,132 @@ Execute a disruption plan.
 }
 ```
 
-**Response:** `201 Created`
+**Response:** `200 OK`
 
 ```json
 {
-  "id": "disrupt-7f8e9d0c-1a2b-3c4d-5e6f-789012345678",
-  "name": "broker-kill-test",
-  "status": "RUNNING",
-  "steps": [{ "name": "kill-broker-0", "status": "PENDING" }],
-  "createdAt": "2026-02-15T21:00:00Z"
+  "id": "7f8e9d0c",
+  "report": {
+    "planName": "broker-kill-test",
+    "status": "COMPLETED",
+    "stepReports": [{
+      "stepName": "kill-broker-0",
+      "disruptionType": "POD_KILL",
+      "timeToFirstReady": "PT27S",
+      "timeToAllReady": "PT41S",
+      "impactDeltas": { "throughputRecPerSec": -15.6, "p99LatencyMs": 596.7 },
+      "rolledBack": false
+    }],
+    "summary": {
+      "totalSteps": 1, "passedSteps": 1, "worstRecovery": "PT41S",
+      "avgThroughputDegradation": 15.6, "maxP99LatencySpike": 596.7, "slaViolated": false
+    }
+  }
 }
 ```
 
-#### POST /api/disruptions/dry-run
+Disruption IDs are 8-character UUID prefixes. `report.status` is one of `COMPLETED`, `PARTIAL` (some steps failed), or `FAILED`. Plans that violate the safety guard are not executed and return `422 Unprocessable Entity` with status `REJECTED` (see [Error Responses](#error-responses)).
 
-Validate a disruption plan without executing. Accepts the same request body as `POST /api/disruptions/run`.
+**Dry run** — `POST /api/disruptions?dryRun=true` with the same request body returns `200 OK`:
 
 ```json
 {
-  "valid": true,
-  "steps": [{ "name": "kill-broker-0", "targetPods": ["krafter-kafka-0"], "safetyCheck": "PASSED", "warnings": [] }],
-  "estimatedDurationSec": 105
+  "wouldSucceed": true,
+  "totalBrokers": 3,
+  "steps": [{
+    "name": "kill-broker-0",
+    "disruptionType": "POD_KILL",
+    "targetPod": "krafter-kafka-0",
+    "resolvedLeaderId": null,
+    "affectedPods": ["krafter-kafka-0"],
+    "warnings": []
+  }],
+  "warnings": [],
+  "errors": []
 }
 ```
 
 #### GET /api/disruptions
 
-List recent disruption reports.
+List recent disruption reports. Supports `planName`, `page`, and `size` (default 50) query parameters.
 
 ```json
 {
+  "page": 0,
+  "size": 50,
+  "count": 1,
   "items": [{
-    "id": "disrupt-7f8e9d0c-...", "name": "broker-kill-test",
-    "status": "COMPLETED", "verdict": "PASS",
-    "createdAt": "2026-02-15T21:00:00Z", "completedAt": "2026-02-15T21:02:45Z"
-  }],
-  "page": 0, "size": 20, "totalItems": 8, "totalPages": 1
+    "id": "7f8e9d0c",
+    "planName": "broker-kill-test",
+    "status": "COMPLETED",
+    "slaGrade": "A",
+    "createdAt": "2026-02-15T21:02:45Z"
+  }]
 }
 ```
 
 #### GET /api/disruptions/{id}
 
-Get detailed disruption report with step-level verdicts, fault timing, recovery metrics, and observations (under-replicated partitions, leader elections).
+Get the full disruption report: per-step recovery timings, pod event timeline, pre/post metrics with impact deltas, ISR and consumer-lag tracking, and the SLA verdict (letter grade A/B/C/F).
 
 ```json
 {
-  "id": "disrupt-7f8e9d0c-...", "name": "broker-kill-test", "status": "COMPLETED", "verdict": "PASS",
-  "steps": [{
-    "name": "kill-broker-0", "status": "COMPLETED", "verdict": "PASS",
-    "faultAppliedAt": "2026-02-15T21:00:15Z", "recoveryDetectedAt": "2026-02-15T21:01:12Z",
-    "recoveryTimeSec": 27, "affectedPods": ["krafter-kafka-0"],
-    "observations": { "underReplicatedPartitions": 3, "leaderElections": 3, "partitionsFullyReplicated": true }
+  "planName": "broker-kill-test",
+  "status": "COMPLETED",
+  "stepReports": [{
+    "stepName": "kill-broker-0",
+    "disruptionType": "POD_KILL",
+    "podTimeline": [
+      { "timestamp": "2026-02-15T21:00:15Z", "podName": "krafter-kafka-0", "eventType": "DELETED", "phase": "Running", "reason": "Killing", "message": "Pod deleted" }
+    ],
+    "timeToFirstReady": "PT27S",
+    "timeToAllReady": "PT41S",
+    "impactDeltas": { "throughputRecPerSec": -15.6, "p99LatencyMs": 596.7 },
+    "rolledBack": false
   }],
-  "createdAt": "2026-02-15T21:00:00Z", "completedAt": "2026-02-15T21:02:45Z"
+  "summary": {
+    "totalSteps": 1, "passedSteps": 1, "worstRecovery": "PT41S",
+    "avgThroughputDegradation": 15.6, "maxP99LatencySpike": 596.7, "slaViolated": false
+  },
+  "slaVerdict": { "grade": "A", "violated": false, "violations": [], "totalChecks": 3, "passedChecks": 3 }
 }
 ```
 
 #### GET /api/disruptions/{id}/timeline
 
-Get pod event timeline — fault injection, leader elections, recovery events.
+Get pod-level events and recovery times per step.
 
 ```json
-{
-  "disruptionId": "disrupt-7f8e9d0c-...",
-  "events": [
-    { "timestamp": "2026-02-15T21:00:15Z", "type": "FAULT_INJECTED", "detail": "Pod krafter-kafka-0 killed" },
-    { "timestamp": "2026-02-15T21:00:18Z", "type": "LEADER_ELECTION", "detail": "Partition perf-test-0: new leader broker-1" },
-    { "timestamp": "2026-02-15T21:01:12Z", "type": "RECOVERY_DETECTED", "detail": "ISR fully restored" }
-  ]
-}
+[
+  {
+    "step": "kill-broker-0",
+    "type": "POD_KILL",
+    "events": [
+      { "timestamp": "2026-02-15T21:00:15Z", "podName": "krafter-kafka-0", "eventType": "DELETED", "phase": "Running", "reason": "Killing", "message": "Pod deleted" }
+    ],
+    "timeToFirstReady": "27000ms",
+    "timeToAllReady": "41000ms"
+  }
+]
 ```
 
 #### GET /api/disruptions/types
 
-List available disruption types: `POD_KILL`, `POD_FAILURE`, `NETWORK_PARTITION`, `NETWORK_LATENCY`, `DISK_FILL`, `CPU_STRESS`.
+List available disruption types with descriptions. Returns an array of `{ "name": ..., "description": ... }` objects covering: `POD_KILL`, `POD_DELETE`, `NETWORK_PARTITION`, `NETWORK_LATENCY`, `CPU_STRESS`, `MEMORY_STRESS`, `IO_STRESS`, `DNS_ERROR`, `DISK_FILL`, `ROLLING_RESTART`, `LEADER_ELECTION`, `SCALE_DOWN`, `NODE_DRAIN`.
 
 #### GET /api/disruptions/{id}/kafka-metrics
 
-Get Kafka intelligence data — pre-fault, during-fault, and post-recovery metrics with impact deltas.
+Get Kafka intelligence data captured during the disruption — ISR recovery and consumer-lag metrics per step.
 
 ```json
-{
-  "metrics": {
-    "preFault": { "throughputRecordsPerSec": 8412.7, "p99LatencyMs": 12.3, "underReplicatedPartitions": 0 },
-    "duringFault": { "throughputRecordsPerSec": 6201.3, "p99LatencyMs": 156.8, "underReplicatedPartitions": 3 },
-    "postRecovery": { "throughputRecordsPerSec": 8389.1, "p99LatencyMs": 13.1, "underReplicatedPartitions": 0 }
-  },
-  "impact": { "throughputDropPercent": 26.3, "latencyIncreasePercent": 1174.8, "recoveryTimeSec": 27 }
-}
+[
+  {
+    "step": "kill-broker-0",
+    "disruptionType": "POD_KILL",
+    "isr": { "timeToFullIsr": "41000ms", "minIsrDepth": 2, "underReplicatedPeakCount": 3, "totalPartitions": 36 },
+    "lag": { "baselineLag": 0, "peakLag": 12500, "lagSpike": 12500, "timeToLagRecovery": "35000ms" }
+  }
+]
 ```
 
 ---
@@ -497,29 +540,34 @@ Get Kafka intelligence data — pre-fault, during-fault, and post-recovery metri
 
 #### POST /api/resilience
 
-Run a combined performance + chaos test.
+Run a combined performance + chaos test. The call is long-running: whitespace is streamed as a keep-alive while the test executes, and the JSON report is written when it completes.
 
 **Request Body:**
 
 ```json
 {
-  "testRequest": { "testType": "LOAD", "spec": { "records": 100000, "producers": 4 } },
+  "testRequest": { "type": "LOAD", "spec": { "numRecords": 100000, "numProducers": 4 } },
   "chaosSpec": { "experimentName": "kafka-pod-kill", "targetNamespace": "kafka" },
   "steadyStateSec": 30
 }
 ```
+
+Optional fields: `probes` (steady-state probe definitions) and `maxRecoveryWaitSec` (default 120).
 
 **Response:**
 
 ```json
 {
   "status": "COMPLETED",
-  "chaosOutcome": { "experimentName": "kafka-pod-kill", "verdict": "PASS", "chaosDuration": "30s" },
-  "impactDeltas": { "throughputRecordsPerSec": -15.6, "p99LatencyMs": 596.7, "errorRate": 0.3 },
-  "preChaosSummary": { "throughputRecordsPerSec": 8412.7, "p99LatencyMs": 12.3, "errorRate": 0.0 },
-  "postChaosSummary": { "throughputRecordsPerSec": 7097.1, "p99LatencyMs": 609.0, "errorRate": 0.3 }
+  "chaosOutcome": { "experimentName": "kafka-pod-kill", "verdict": "Pass", "chaosDuration": "PT30S" },
+  "impactDeltas": { "throughputRecPerSec": -15.6, "avgLatencyMs": 42.1, "p99LatencyMs": 596.7, "maxLatencyMs": 310.4, "errorRate": 0.3 },
+  "preChaosSummary": { "avgThroughputRecPerSec": 8412.7, "p99LatencyMs": 12.3, "errorRate": 0.0 },
+  "postChaosSummary": { "avgThroughputRecPerSec": 7097.1, "p99LatencyMs": 609.0, "errorRate": 0.3 },
+  "recoveryTime": "PT41S"
 }
 ```
+
+`status` is one of `COMPLETED`, `CHAOS_FAILED`, `INTERRUPTED`, or `ERROR`. Impact deltas are percentage changes between the pre- and post-chaos summaries.
 
 ---
 
@@ -527,23 +575,26 @@ Run a combined performance + chaos test.
 
 #### GET /api/trends
 
-Historical test trends.
+Historical test trends with baseline comparison and regression detection.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `type` | String | Test type |
-| `metric` | String | Metric name |
-| `days` | int | Lookback period |
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `type` | String | (required) | Test type |
+| `metric` | String | `avgThroughputRecPerSec` | Summary metric name (e.g. `p99LatencyMs`) |
+| `days` | int | 30 | Lookback period |
+| `baselineWindow` | int | 5 | Number of runs used for the baseline average |
+| `phase` | String | | Restrict analysis to a named test phase |
 
 ```json
 {
-  "testType": "LOAD", "metric": "p99LatencyMs", "days": 7,
+  "testType": "LOAD", "metric": "p99LatencyMs",
   "dataPoints": [
-    { "date": "2026-02-09", "value": 14.2, "runId": "run-001" },
-    { "date": "2026-02-12", "value": 15.1, "runId": "run-004" },
-    { "date": "2026-02-15", "value": 12.3, "runId": "run-007" }
+    { "timestamp": "2026-02-09T02:00:14Z", "runId": "aa11bb22", "value": 14.2 },
+    { "timestamp": "2026-02-12T02:00:09Z", "runId": "cc33dd44", "value": 15.1 },
+    { "timestamp": "2026-02-15T02:00:11Z", "runId": "ee55ff66", "value": 12.3 }
   ],
-  "trendDirection": "STABLE", "avgValue": 13.2
+  "baseline": 13.9,
+  "regressions": []
 }
 ```
 
@@ -553,7 +604,7 @@ Historical test trends.
 
 #### POST /api/schedules
 
-Create a recurring test schedule.
+Create a recurring test schedule. Cron expressions use the 5-field Unix format (`minute hour day-of-month month day-of-week`, evaluated in UTC).
 
 **Request Body:**
 
@@ -562,7 +613,7 @@ Create a recurring test schedule.
   "name": "Nightly Load Regression",
   "cronExpression": "0 2 * * *",
   "enabled": true,
-  "testRequest": { "testType": "LOAD", "spec": { "records": 100000, "parallelProducers": 4, "acks": "all" } }
+  "testRequest": { "type": "LOAD", "spec": { "numRecords": 100000, "numProducers": 4, "acks": "all" } }
 }
 ```
 
@@ -570,13 +621,16 @@ Create a recurring test schedule.
 
 ```json
 {
-  "id": "sched-a1b2c3d4-...",
+  "id": "e5f6a7b8",
   "name": "Nightly Load Regression",
   "cronExpression": "0 2 * * *",
   "enabled": true,
-  "createdAt": "2026-02-15T20:00:00Z"
+  "lastRunId": null,
+  "lastRunAt": null
 }
 ```
+
+Schedule IDs, like run IDs, are 8-character UUID prefixes.
 
 #### GET /api/schedules
 
@@ -584,19 +638,22 @@ List all schedules.
 
 ```json
 [{
-  "id": "sched-a1b2c3d4-...",
+  "id": "e5f6a7b8",
   "name": "Nightly Load Regression",
   "cronExpression": "0 2 * * *",
   "enabled": true,
-  "lastRunId": "run-d4e5f6...",
-  "lastRunAt": "2026-02-15T02:00:00Z",
-  "createdAt": "2026-02-14T10:00:00Z"
+  "lastRunId": "d4e5f6a7",
+  "lastRunAt": "2026-02-15T02:00:00Z"
 }]
 ```
 
 #### GET /api/schedules/{id}
 
-Get detailed schedule info including last run data, next run time, and total run count.
+Get a single schedule, including the ID and time of its last triggered run.
+
+#### PUT /api/schedules/{id}
+
+Update a schedule. Accepts the same body as `POST /api/schedules` (fields you omit keep their current values, except `enabled`, which is always applied). Returns the updated schedule.
 
 #### DELETE /api/schedules/{id}
 
@@ -606,45 +663,53 @@ Delete a schedule. Returns `204 No Content`.
 
 ## Error Responses
 
-All errors follow a consistent JSON format:
+Errors follow a consistent JSON format:
 
 ```json
-{ "error": "Not Found", "message": "Test run not found: abc123", "status": 404 }
+{ "status": 404, "error": "Not Found", "message": "Test run not found: abc123" }
 ```
+
+The one exception is the disruption safety-guard rejection (`422`), which returns the shape shown in the examples below.
 
 ### HTTP Error Codes
 
 | Status | Error | Description | Common Causes |
 |:---:|-------|-------------|---------------|
-| 400 | Bad Request | Malformed or invalid request | Invalid `testType`, missing required fields, malformed JSON |
+| 400 | Bad Request | Malformed or invalid request | Invalid `type`, missing required fields, malformed JSON |
+| 401 | Unauthorized | Missing API key | Security enabled and no `Authorization`/`X-API-Key` header sent |
+| 403 | Forbidden | Invalid API key | Key does not match `kates.api.key` |
 | 404 | Not Found | Resource does not exist | Unknown test ID, deleted report, non-existent schedule |
-| 409 | Conflict | Conflicts with current state | Test already running on same topic, schedule name collision |
-| 422 | Unprocessable Entity | Rejected by safety guards | `maxAffectedBrokers` exceeded, unsafe partition count |
-| 500 | Internal Server Error | Unexpected server failure | Thread pool exhaustion, out-of-memory |
-| 503 | Service Unavailable | Backend unreachable | Kafka connection lost, broker cluster restarting |
+| 409 | Conflict | Conflicts with current state | Cancelling a test that is not running |
+| 422 | Unprocessable Entity | Rejected by safety guards | `maxAffectedBrokers` exceeded, plan would affect all brokers |
+| 500 | Internal Server Error | Unexpected server failure | Kafka admin call failed, cluster unreachable |
+| 503 | Service Unavailable | Dependent system unavailable | Kubernetes API not reachable |
 
 ### Error Examples
 
 **400 — Invalid test type:**
 ```json
-{ "error": "Bad Request", "message": "Invalid test type: 'BENCHMARK'. Valid types: LOAD, STRESS, SPIKE, ENDURANCE, VOLUME, CAPACITY, ROUND_TRIP, INTEGRITY", "status": 400 }
+{ "status": 400, "error": "Bad Request", "message": "Invalid test type: BENCHMARK" }
 ```
 
-**409 — Test already running:**
+**409 — Cancelling a test that is not running:**
 ```json
-{ "error": "Conflict", "message": "A test is already running on topic 'perf-test'. Cancel or wait for completion.", "status": 409 }
+{ "status": 409, "error": "Conflict", "message": "Test is not running (status: DONE)" }
 ```
 
-**503 — Kafka unreachable:**
+**422 — Disruption plan rejected by the safety guard:**
 ```json
-{ "error": "Service Unavailable", "message": "Cannot reach Kafka cluster at krafter-kafka-bootstrap.kafka.svc:9092. Connection timed out.", "status": 503 }
+{
+  "id": "7f8e9d0c",
+  "status": "REJECTED",
+  "validationWarnings": ["ERROR: Plan would affect ALL 3 brokers — cluster would lose availability"]
+}
 ```
 
 ---
 
 ## API Workflows
 
-The following `curl`-based workflows demonstrate common multi-step operations. All examples assume the API is available at `localhost:30083`.
+The following `curl`-based workflows demonstrate common multi-step operations. All examples assume the API is available at `localhost:30083` (the kind NodePort). When API security is enabled — the production default — add `-H "X-API-Key: $KATES_API_KEY"` to every `curl` call.
 
 ### Workflow 1: Create a Test, Poll for Completion, Get the Report
 
@@ -656,7 +721,7 @@ BASE="http://localhost:30083"
 # Create a load test
 TEST_ID=$(curl -s -X POST "$BASE/api/tests" \
   -H "Content-Type: application/json" \
-  -d '{"testType":"LOAD","spec":{"records":100000,"producers":4,"consumers":2,"acks":"all","topic":"perf-test","partitions":3,"replicationFactor":3}}' \
+  -d '{"type":"LOAD","spec":{"numRecords":100000,"numProducers":4,"numConsumers":2,"acks":"all","topic":"perf-test","partitions":3,"replicationFactor":3}}' \
   | jq -r '.id')
 echo "Created test: $TEST_ID"
 
@@ -664,7 +729,7 @@ echo "Created test: $TEST_ID"
 while true; do
   STATUS=$(curl -s "$BASE/api/tests/$TEST_ID" | jq -r '.status')
   echo "Status: $STATUS"
-  [[ "$STATUS" == "COMPLETED" || "$STATUS" == "FAILED" ]] && break
+  [[ "$STATUS" == "DONE" || "$STATUS" == "FAILED" ]] && break
   sleep 5
 done
 
@@ -673,7 +738,9 @@ curl -s "$BASE/api/tests/$TEST_ID/report" | jq .
 curl -s "$BASE/api/tests/$TEST_ID/report/junit" -o report.xml
 ```
 
-### Workflow 2: Create a Disruption and Monitor Status
+### Workflow 2: Validate and Execute a Disruption
+
+Disruption execution is synchronous — there is nothing to poll. The `POST` returns only when every step (including observation windows) has finished, so set generous client timeouts for long plans.
 
 ```bash
 #!/usr/bin/env bash
@@ -681,24 +748,17 @@ set -euo pipefail
 BASE="http://localhost:30083"
 PLAN='{"name":"broker-kill-test","maxAffectedBrokers":1,"autoRollback":true,"steps":[{"name":"kill-broker-0","faultSpec":{"experimentName":"broker-kill","disruptionType":"POD_KILL","targetNamespace":"kafka","targetLabel":"strimzi.io/cluster=krafter","chaosDurationSec":30},"steadyStateSec":15,"observationWindowSec":60,"requireRecovery":true}]}'
 
-# Dry-run to validate
-curl -s -X POST "$BASE/api/disruptions/dry-run" -H "Content-Type: application/json" -d "$PLAN" | jq .
+# Dry-run to validate (no faults injected)
+curl -s -X POST "$BASE/api/disruptions?dryRun=true" -H "Content-Type: application/json" -d "$PLAN" | jq .
 
-# Execute
-DISRUPT_ID=$(curl -s -X POST "$BASE/api/disruptions/run" -H "Content-Type: application/json" -d "$PLAN" | jq -r '.id')
-echo "Disruption started: $DISRUPT_ID"
+# Execute — blocks until the plan completes, then returns the report
+RESULT=$(curl -s --max-time 600 -X POST "$BASE/api/disruptions" -H "Content-Type: application/json" -d "$PLAN")
+DISRUPT_ID=$(jq -r '.id' <<<"$RESULT")
+echo "Disruption finished: $DISRUPT_ID (status: $(jq -r '.report.status' <<<"$RESULT"))"
 
-# Poll status
-while true; do
-  STATUS=$(curl -s "$BASE/api/disruptions/$DISRUPT_ID" | jq -r '.status')
-  echo "Status: $STATUS"
-  [[ "$STATUS" == "COMPLETED" || "$STATUS" == "FAILED" ]] && break
-  sleep 10
-done
-
-# Inspect timeline and impact
-curl -s "$BASE/api/disruptions/$DISRUPT_ID/timeline" | jq '.events[]'
-curl -s "$BASE/api/disruptions/$DISRUPT_ID/kafka-metrics" | jq '.impact'
+# Inspect recovery timings and Kafka impact
+curl -s "$BASE/api/disruptions/$DISRUPT_ID/timeline" | jq '.[] | {step, timeToFirstReady, timeToAllReady}'
+curl -s "$BASE/api/disruptions/$DISRUPT_ID/kafka-metrics" | jq '.[] | {step, isr, lag}'
 ```
 
 ### Workflow 3: Export Results in Different Formats
@@ -707,7 +767,7 @@ curl -s "$BASE/api/disruptions/$DISRUPT_ID/kafka-metrics" | jq '.impact'
 #!/usr/bin/env bash
 set -euo pipefail
 BASE="http://localhost:30083"
-TEST_ID="a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+TEST_ID="a1b2c3d4"
 
 curl -s "$BASE/api/tests/$TEST_ID/report"                   -o report.json
 curl -s "$BASE/api/tests/$TEST_ID/report/csv"                -o report.csv
@@ -716,7 +776,7 @@ curl -s "$BASE/api/tests/$TEST_ID/report/heatmap?format=json" -o heatmap.json
 curl -s "$BASE/api/tests/$TEST_ID/report/heatmap?format=csv"  -o heatmap.csv
 
 echo "Exported: report.json, report.csv, report.xml, heatmap.json, heatmap.csv"
-jq '{type:.testRun.testType, throughput:.summary.avgThroughputRecordsPerSec, p99:.summary.p99LatencyMs, sla:.slaVerdict.passed}' report.json
+jq '{type:.run.testType, throughput:.summary.avgThroughputRecPerSec, p99:.summary.p99LatencyMs, sla:.overallSlaVerdict.passed}' report.json
 ```
 
 ---

--- a/docs/book/12-deployment.md
+++ b/docs/book/12-deployment.md
@@ -15,7 +15,7 @@ This chapter walks you through those decisions. You'll start with the architectu
 | kubectl | 1.28+ | Kubernetes CLI |
 | Helm | 3.12+ | Kubernetes package manager |
 | jq | 1.6+ | JSON processing (optional) |
-| Go | 1.22+ | CLI compilation (if building from source) |
+| Go | 1.25+ | CLI compilation (if building from source) |
 | Java | 21+ | Backend compilation (if building from source) |
 | Maven | 3.9+ | Backend build (bundled as `mvnw`) |
 
@@ -44,7 +44,7 @@ The Kates stack uses four namespaces by default:
 | `litmus` | LitmusChaos operator, experiment runners | Chaos tools need elevated privileges; isolation limits the blast radius of those permissions |
 
 ::: {.callout-tip}
-For local Kind deployments, the multi-namespace layout still works and is what `make all` creates by default. The only time single-namespace makes sense is throwaway CI environments where fast teardown (`kubectl delete namespace`) matters more than isolation.
+For local Kind deployments, the multi-namespace layout still works — `make all` prompts you to choose between a single-namespace topology (everything in `kates-stack`) and the isolated multi-namespace topology, and the underlying `kates deploy` command defaults to `--topology isolated`. The only time single-namespace makes sense is throwaway CI environments where fast teardown (`kubectl delete namespace`) matters more than isolation.
 :::
 
 
@@ -136,7 +136,7 @@ The following table shows resource requirements per component. Use this to right
 | Kafka Exporter | 1 | 100m / 200m | 128Mi / 256Mi | — | Consumer lag metrics |
 | Kates Backend | 1 | 500m / 1000m | 512Mi / 2560Mi | — | JVM: `-Xms512m -Xmx2560m` with ZGC |
 | PostgreSQL | 1 | 250m / 500m | 256Mi / 512Mi | 10Gi | Test results and metadata |
-| Prometheus | 1 | 500m / 1000m | 1Gi / 2Gi | 50Gi | 15s scrape interval, 15d retention |
+| Prometheus | 1 | 500m / 1000m | 1Gi / 2Gi | 50Gi | 30d retention in the generic overlay |
 | Grafana | 1 | 100m / 200m | 128Mi / 256Mi | — | 13 pre-provisioned dashboards |
 | LitmusChaos | 1 | 200m / 500m | 256Mi / 512Mi | — | Operator + experiment runners |
 
@@ -306,19 +306,16 @@ These YAML overlays are passed via `helm upgrade --install -f values-eks.yaml` (
 make all
 ```
 
-This executes a 10-step pipeline:
+`make all` drives the deployment through the Kates CLI itself — the Makefile checks prerequisites, ensures a cluster exists, then hands the heavy lifting to `kates deploy`:
 
 ```mermaid
 graph TD
-    S1["Step 1<br/>Create Kind cluster 'panda'<br/>+ local Docker registry"] --> S2["Step 2<br/>Pull all images<br/>to local registry"]
-    S2 --> S3["Step 3<br/>Load images<br/>into Kind nodes"]
-    S3 --> S4["Step 4<br/>Deploy Prometheus<br/>& Grafana"]
-    S4 --> S5["Step 5<br/>Wait for monitoring<br/>readiness"]
-    S5 --> S6["Step 6<br/>Deploy Strimzi Kafka<br/>(KRaft mode)"]
-    S6 --> S7["Step 7<br/>Wait for Kafka<br/>readiness"]
-    S7 --> S8["Step 8<br/>Deploy Kafka UI"]
-    S8 --> S9["Step 9<br/>Deploy Apicurio<br/>Registry"]
-    S9 --> S10["Step 10<br/>Deploy LitmusChaos"]
+    S1["Check prerequisites<br/>(kubectl, helm)"] --> S2["Ensure cluster connectivity<br/>(creates Kind cluster 'panda'<br/>if none is reachable)"]
+    S2 --> S3["Build the kates CLI<br/>if the binary is missing"]
+    S3 --> S4["Prompt: deployment topology<br/>1) single namespace (kates-stack)<br/>2) isolated namespaces"]
+    S4 --> S5["kates deploy --topology &lt;choice&gt;<br/>--with-schema-registry apicurio"]
+    S5 --> S6["Expose service ports<br/>(scripts/port-forward.sh)"]
+    S6 --> S7["Print access points<br/>(Apicurio 30082, Kates 30083,<br/>Litmus UI 9091)"]
 ```
 
 ## Component-by-Component Deployment
@@ -341,14 +338,14 @@ Creates a Kind cluster named `panda` with:
 ### Image Management
 
 ```bash
-# Pull all images to local registry
-make images
+# Pull all images directly into Kind nodes (via ctr pull inside containerd)
+./scripts/load-images-to-kind.sh
 
-# Check registry status
-make registry-status
+# Check local registry status
+./scripts/registry-status.sh
 ```
 
-All images are defined in `images.env`. The pull script detects your platform (arm64/amd64) and pulls the correct architecture.
+All images are defined in `images.env`. The load script defaults to `linux/arm64`; override with `--platform linux/amd64` (or the `CTR_PLATFORM` environment variable) on Intel/AMD hosts.
 
 ### Monitoring Stack
 
@@ -387,8 +384,14 @@ make litmus
 make chaos-ui
 # → http://localhost:9091 (admin/litmus)
 
-# Deploy chaos experiments
-make chaos-experiments
+# Run the chaos chart's Helm tests
+make litmus-test
+
+# Trigger the GameDay validation via the chaos chart
+make litmus-gameday
+
+# Check chaos status
+make chaos-status
 ```
 
 ### Kates Application
@@ -418,13 +421,13 @@ Pattern: `<fully.qualified.class>/<method>/Timeout/value=<millis>`
 com.bmscomp.kates.service.TopicService/describeTopicDetail/Timeout/value=60000
 ```
 
-In `k8s/configmap.yaml` the equivalent env var is:
+In `kates/k8s/configmap.yaml` (relative to the repo root) the equivalent env var is:
 
 ```yaml
 COM_BMSCOMP_KATES_SERVICE_TOPICSERVICE_DESCRIBETOPICDETAIL_TIMEOUT_VALUE: "60000"
 ```
 
-All 13 annotated methods across `TopicService`, `ClusterHealthService`, and `ConsumerGroupService` have corresponding entries in both files.
+The 13 annotated methods across `TopicService`, `ClusterHealthService`, and `ConsumerGroupService` have corresponding entries in both files. The codebase carries 26 `@Timeout` annotations across seven classes in total — the remaining ones (in `SecurityService`, `KafkaAdminService`, `DisruptionSafetyGuard`, and `KubernetesChaosProvider`) rely on their annotation defaults but can be overridden with the same property pattern.
 
 #### JVM Tuning
 
@@ -433,7 +436,7 @@ Kates is a latency-sensitive application — it's measuring Kafka's performance,
 ZGC achieves sub-millisecond pause times by performing garbage collection concurrently with the application. The trade-off is roughly 10–15% lower peak throughput compared to G1GC — but for a benchmarking tool, consistent latency matters far more than raw throughput.
 
 ```yaml
-# k8s/deployment.yaml
+# kates/k8s/deployment.yaml
 - name: JAVA_TOOL_OPTIONS
   value: "-Xms512m -Xmx2560m -XX:+UseZGC -XX:+ZGenerational"
 ```
@@ -497,12 +500,13 @@ graph TB
     subgraph Infrastructure
         ALL[make all<br/>Complete setup]
         CLUSTER[make cluster]
-        IMAGES[make images]
         MONITOR[make monitoring]
         KAFKA[make kafka]
         UI[make ui]
         APICURIO[make apicurio]
         LITMUS[make litmus]
+        JAEGER[make jaeger]
+        KYVERNO[make kyverno]
     end
     
     subgraph Kates
@@ -513,6 +517,7 @@ graph TB
         KR[make kates-redeploy]
         KL[make kates-logs]
         KU[make kates-undeploy]
+        KH[make kates-helm]
     end
     
     subgraph CLI
@@ -532,12 +537,11 @@ graph TB
     end
     
     subgraph Chaos
-        CK[make chaos-kafka]
-        CKP[make chaos-kafka-pod-delete]
-        CKN[make chaos-kafka-network-partition]
-        CKC[make chaos-kafka-cpu-stress]
-        CKA[make chaos-kafka-all]
-        CKS[make chaos-kafka-status]
+        LT[make litmus-test]
+        LG[make litmus-gameday]
+        CS[make chaos-status]
+        CU[make chaos-ui]
+        GD[make gameday]
     end
     
     subgraph Operations
@@ -551,20 +555,24 @@ graph TB
 
 | Target | Description |
 |--------|-------------|
-| `make all` | Complete setup (cluster → images → all services) |
+| `make all` | Complete setup (cluster check → topology prompt → `kates deploy`) |
 | `make cluster` | Start Kind cluster only |
-| `make images` | Pull and load all images |
-| `make monitoring` | Deploy Prometheus & Grafana (Kind overlay) |
+| `make monitoring` | Deploy Prometheus & Grafana (auto-detects provider) |
 | `make monitoring-generic` | Deploy Prometheus & Grafana (Generic cloud overlay) |
 | `make monitoring-undeploy` | Remove Prometheus & Grafana |
 | `make kafka` | Deploy Strimzi Kafka |
 | `make ui` | Deploy Kafka UI |
 | `make apicurio` | Deploy Apicurio Registry |
 | `make litmus` | Deploy LitmusChaos |
+| `make jaeger` | Deploy Jaeger (distributed tracing) |
+| `make kyverno` | Deploy Kyverno policy engine |
+| `make cert-manager` | Deploy cert-manager |
+| `make connect-deploy` | Deploy Kafka Connect cluster |
 | `make kates` | Build + deploy Kates application |
 | `make kates-build` | Build Kates JVM image |
 | `make kates-native` | Build Kates native image (see below) |
 | `make kates-deploy` | Apply Kates K8s manifests |
+| `make kates-helm` | Deploy Kates via its Helm chart |
 | `make kates-redeploy` | Restart Kates deployment |
 | `make kates-logs` | Stream Kates logs |
 | `make kates-undeploy` | Remove Kates |
@@ -609,12 +617,10 @@ kubectl logs deployment/kates -n kates | head -1
 | `make test-endurance` | Run endurance test |
 | `make test-volume` | Run volume test |
 | `make test-capacity` | Run capacity test |
-| `make chaos-kafka` | Set up Kafka chaos |
-| `make chaos-kafka-pod-delete` | Run pod-delete chaos |
-| `make chaos-kafka-network-partition` | Run network partition |
-| `make chaos-kafka-cpu-stress` | Run CPU stress |
-| `make chaos-kafka-all` | Run all chaos experiments |
-| `make chaos-kafka-status` | Check chaos status |
+| `make litmus-test` | Run the chaos chart's Helm tests |
+| `make litmus-gameday` | Trigger GameDay validation via the chaos chart |
+| `make chaos-status` | Check chaos status |
+| `make chaos-ui` | Port-forward the Litmus UI (localhost:9091) |
 | `make gameday` | Run automated GameDay validation pipeline |
 | `make velero` | Deploy Velero backup |
 | `make chart-lint` | Lint Kates Helm chart |
@@ -659,7 +665,7 @@ Kates uses PostgreSQL as its persistent data store for everything that outlives 
 
 - **Test run metadata** — timestamps, configuration snapshots, which topics and partitions were tested
 - **Performance results** — throughput measurements, latency percentiles (p50/p95/p99), error counts per run
-- **Historical baselines** — aggregated metrics used by the `kates compare` command to detect regressions
+- **Historical baselines** — aggregated metrics used by the `kates report compare` and `kates test compare` commands to detect regressions
 - **Audit records** — who ran what test, when, and with which parameters
 
 Why PostgreSQL and not Kafka itself? Kafka is optimized for sequential append and time-windowed retention — it's not designed for the random-access queries that trend analysis and historical comparison require. PostgreSQL gives you indexed queries like "show me p99 latency for topic X across the last 30 runs" that would be impractical with Kafka's log-based storage.
@@ -704,7 +710,7 @@ Run an automated 7-phase validation pipeline:
 make gameday
 ```
 
-Phases: pre-flight → baseline → chaos-inject → observe → recover → post-flight → report
+Phases: pre-flight → baseline → chaos-inject → chaos-observe → chaos-recover → post-flight → report
 
 ## Troubleshooting
 
@@ -712,10 +718,9 @@ Phases: pre-flight → baseline → chaos-inject → observe → recover → pos
 
 ```bash
 # Check registry health
-make registry-status
+./scripts/registry-status.sh
 
-# Manually pull and load
-./scripts/pull-images.sh
+# Manually pull images into Kind nodes
 ./scripts/load-images-to-kind.sh
 ```
 
@@ -743,7 +748,7 @@ Direct proxy flags are supported too:
 kubectl logs -f deployment/strimzi-cluster-operator -n kafka
 
 # Check Kafka pod events
-kubectl describe pod pool-alpha-0 -n kafka
+kubectl describe pods -l strimzi.io/cluster=krafter -n kafka
 ```
 
 ### CLI Binary Killed on macOS
@@ -780,7 +785,7 @@ kubectl get configmap kates-config -n kates -o yaml
 kubectl get pods -n litmus
 
 # Check experiment status
-make chaos-kafka-status
+make chaos-status
 
 # View experiment logs
 kubectl logs -f -l app=chaos-operator -n litmus

--- a/docs/book/12-deployment.md
+++ b/docs/book/12-deployment.md
@@ -345,7 +345,7 @@ Creates a Kind cluster named `panda` with:
 ./scripts/registry-status.sh
 ```
 
-All images are defined in `images.env`. The load script defaults to `linux/arm64`; override with `--platform linux/amd64` (or the `CTR_PLATFORM` environment variable) on Intel/AMD hosts.
+All images are defined in `images.env`. The load script defaults to `linux/arm64`; override with the `CTR_PLATFORM` environment variable (`CTR_PLATFORM=linux/amd64 ./scripts/load-images-to-kind.sh`) on Intel/AMD hosts.
 
 ### Monitoring Stack
 

--- a/docs/book/13-scenario-files.md
+++ b/docs/book/13-scenario-files.md
@@ -60,26 +60,26 @@ scenarios:
 | Field | Type | Required | Description |
 |-------|------|:---:|-------------|
 | `name` | String | | Human-readable scenario name (displayed in output) |
-| `type` | String | ✅ | Test type: `LOAD`, `STRESS`, `SPIKE`, `ENDURANCE`, `VOLUME`, `CAPACITY`, `ROUND_TRIP`, `INTEGRITY` |
+| `type` | String | ✅ | Test type: `LOAD`, `STRESS`, `SPIKE`, `ENDURANCE`, `VOLUME`, `CAPACITY`, `ROUND_TRIP`, `INTEGRITY`, `TUNE_REPLICATION`, `TUNE_ACKS`, `TUNE_BATCHING`, `TUNE_COMPRESSION`, `TUNE_PARTITIONS`, or `INTEGRATION_CDC`. Case-insensitive — the CLI upper-cases the value before submitting |
 | `backend` | String | | Backend engine (default: `native`) |
 | `spec` | Object | | Test specification — see Spec Reference below |
 | `validate` | Object | | SLA validation gates — see Validation Reference below |
 
 ## Spec Reference
 
-The `spec` object controls all test parameters. Every field is optional; Kates applies sensible defaults per test type when a field is omitted.
+The `spec` object controls all test parameters. Every field is optional; the backend fills in defaults per test type (configurable via its `kates.tests.<type>.*` properties), so a STRESS test defaults to larger batches and more producers than a ROUND_TRIP test. The defaults shown below are the stock values for a LOAD test — other types differ.
 
 ### Producer Configuration
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `records` | Integer | varies by type | Number of records to produce |
+| `records` | Integer | 1,000,000 | Number of records to produce |
 | `parallelProducers` | Integer | 1 | Number of concurrent producer threads |
 | `recordSizeBytes` | Integer | 1024 | Payload size per record in bytes |
 | `acks` | String | `all` | Producer acknowledgment mode: `0`, `1`, or `all` |
-| `batchSize` | Integer | 16384 | Producer batch size in bytes |
-| `lingerMs` | Integer | 0 | Milliseconds to wait before sending a batch |
-| `compressionType` | String | `none` | Compression: `none`, `gzip`, `snappy`, `lz4`, `zstd` |
+| `batchSize` | Integer | 65536 | Producer batch size in bytes |
+| `lingerMs` | Integer | 5 | Milliseconds to wait before sending a batch |
+| `compressionType` | String | `lz4` | Compression: `none`, `gzip`, `snappy`, `lz4`, `zstd` |
 | `targetThroughput` | Integer | -1 | Target records/sec (-1 = unlimited) |
 | `enableIdempotence` | Boolean | false | Enable Kafka producer idempotency |
 | `enableTransactions` | Boolean | false | Enable Kafka transactions |
@@ -88,7 +88,7 @@ The `spec` object controls all test parameters. Every field is optional; Kates a
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `numConsumers` | Integer | 0 | Number of consumer threads (0 = no consumption) |
+| `numConsumers` | Integer | 1 | Number of consumer threads |
 | `consumerGroup` | String | auto | Consumer group name |
 | `fetchMinBytes` | Integer | 1 | Minimum bytes per fetch request |
 | `fetchMaxWaitMs` | Integer | 500 | Maximum wait time for fetch in milliseconds |
@@ -97,7 +97,7 @@ The `spec` object controls all test parameters. Every field is optional; Kates a
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `topic` | String | auto-generated | Target topic name |
+| `topic` | String | auto (`<type>-test`) | Target topic name |
 | `partitions` | Integer | 3 | Number of topic partitions |
 | `replicationFactor` | Integer | 3 | Topic replication factor |
 | `minInsyncReplicas` | Integer | 2 | Minimum in-sync replicas |
@@ -106,17 +106,21 @@ The `spec` object controls all test parameters. Every field is optional; Kates a
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `durationSeconds` | Integer | 0 | Time-based test duration (0 = use record count) |
+| `durationSeconds` | Integer | per type | Time-based duration cap — the run stops at `records` or the deadline, whichever comes first |
 
 ### Integrity Options
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `enableCrc` | Boolean | false | Enable CRC32 checksum verification on messages |
+| `enableCrc` | Boolean | true | Enable CRC32 checksum verification on messages |
 
 ## Validation Reference (SLA Gates)
 
-The `validate` section defines pass/fail criteria that Kates checks after the test completes. If any threshold is breached, the scenario is marked as failed, and the CLI exits with a non-zero status code — making it ideal for CI/CD gate enforcement.
+The `validate` section defines pass/fail criteria that the CLI checks after each test completes. If any threshold is breached, the violation is listed in the summary table and the CLI exits with a non-zero status code — making it ideal for CI/CD gate enforcement.
+
+::: {.callout-warning}
+SLA gates are only evaluated when you run `kates test apply` with `--wait`. Without it, scenarios are fire-and-forget: each one is submitted (status `SUBMITTED`), no gate is ever checked, and the CLI exits 0 regardless of how the tests turn out.
+:::
 
 ```mermaid
 graph TD
@@ -128,7 +132,6 @@ graph TD
         R --> G1{"P99 ≤ threshold?"}
         R --> G2{"Avg ≤ threshold?"}
         R --> G3{"Throughput ≥ min?"}
-        R --> G4{"Error rate ≤ max?"}
         R --> G5{"Data loss ≤ max?"}
         R --> G6{"RTO ≤ max?"}
         R --> G7{"RPO ≤ max?"}
@@ -149,7 +152,7 @@ graph TD
 | `maxP99LatencyMs` | Float | Maximum acceptable P99 latency in milliseconds |
 | `maxAvgLatencyMs` | Float | Maximum acceptable average latency in milliseconds |
 | `minThroughputRecPerSec` | Float | Minimum acceptable throughput in records per second |
-| `maxErrorRate` | Float | Maximum acceptable error rate (0.0 = zero errors) |
+| `maxErrorRate` | Float | Maximum acceptable error rate. Accepted in the file, but not currently evaluated by the CLI's gate check |
 
 ### Resilience Gates
 
@@ -206,7 +209,7 @@ scenarios:
       parallelProducers: 8
     validate:
       maxP99LatencyMs: 200
-      maxErrorRate: 0.01
+      minThroughputRecPerSec: 5000
 
   - name: "Data Integrity Check"
     type: INTEGRITY
@@ -256,9 +259,9 @@ scenarios:
     spec:
       records: 100000
       parallelProducers: 4
-      batchSize: 65536
+      batchSize: 262144
       lingerMs: 50
-      compressionType: lz4
+      compressionType: zstd
     validate:
       maxP99LatencyMs: 100
       minThroughputRecPerSec: 20000
@@ -269,43 +272,44 @@ scenarios:
 ### Basic Execution
 
 ```bash
-# Run all scenarios in the file
+# Submit all scenarios in the file (fire-and-forget — no SLA evaluation)
 kates test apply -f scenarios.yaml
 
-# Run and wait for all to complete (blocking)
+# Run and wait for each to complete; SLA gates are evaluated at the end
 kates test apply -f scenarios.yaml --wait
 ```
 
 ### How Execution Works
 
-1. Kates parses the file and validates the schema
+1. Kates parses the file (YAML or JSON) — a malformed file aborts the run with the raw parse error; there is no further schema validation on the client side
 2. Each scenario is submitted to the backend sequentially
 3. If `--wait` is specified, Kates polls until each test completes before submitting the next
-4. After all scenarios complete, SLA gates are evaluated
+4. SLA gates are evaluated for each completed scenario — this only happens with `--wait`; without it, every scenario is left as `SUBMITTED` and never validated
 5. A summary table is printed showing each scenario's result
 
 ### Output
 
+Running with `--wait`:
+
 ```
   ▸ Baseline Load Test (LOAD)...
-    → ID: a1b2c3d4  Status: DONE
-
+  ✓   Created: 3f8a2c1e-9b4…
+  ✓ Baseline Load Test → DONE
   ▸ Stress Ramp-Up (STRESS)...
-    → ID: e5f6a7b8  Status: DONE
-
+  ✓   Created: 7c5e0d2a-1f6…
+  ✓ Stress Ramp-Up → DONE
   ▸ Data Integrity Check (INTEGRITY)...
-    → ID: c9d0e1f2  Status: DONE
+  ✓   Created: b2d94e7f-8a3…
+  ✓ Data Integrity Check → DONE
 
-  Summary
-  ┌──────────────────────┬──────────┬────────┬──────────────────────────┐
-  │ Scenario             │ ID       │ Status │ Note                     │
-  ├──────────────────────┼──────────┼────────┼──────────────────────────┤
-  │ Baseline Load Test   │ a1b2c3d4 │ DONE   │                          │
-  │ Stress Ramp-Up       │ e5f6a7b8 │ DONE   │ p99=210ms > 200ms        │
-  │ Data Integrity Check │ c9d0e1f2 │ DONE   │                          │
-  └──────────────────────┴──────────┴────────┴──────────────────────────┘
+▸ Summary
+  Scenario              ID             Status  Note
+  ────────────────────  ─────────────  ──────  ─────────────────
+  Baseline Load Test    3f8a2c1e-9b4…  DONE    ✓ SLA Pass
+  Stress Ramp-Up        7c5e0d2a-1f6…  DONE    p99=210ms > 200ms
+  Data Integrity Check  b2d94e7f-8a3…  DONE    ✓ SLA Pass
 
-  ✗ One or more SLA gates violated
+  ✖ One or more SLA gates violated
 ```
 
 In this example, the stress test's P99 latency (210ms) exceeded the 200ms threshold. The CLI exits with code 1, which would fail a CI/CD pipeline.
@@ -319,9 +323,11 @@ Scenario files are designed for CI/CD pipelines. Combine with `--wait` to block 
 kates test apply -f regression-suite.yaml --wait
 
 # The exit code tells you the result:
-# 0 = all SLA gates passed
+# 0 = no SLA gate violations detected
 # 1 = one or more SLA gates violated
 ```
+
+Note that only SLA violations set the exit code: a scenario that fails to submit or errors out shows as `FAILED`/`ERROR` in the summary but does not change the exit code. Give every scenario you gate on a `validate` block so a regression actually fails the pipeline.
 
 For JUnit-compatible output, export each test report individually after the suite completes — see [Chapter 9: Observability](09-observability.md) for export formats.
 
@@ -350,33 +356,35 @@ Scenario files also work in JSON:
 
 ## Scaffolding Scenario Files
 
-Use `kates test scaffold` to generate a starter YAML for any test type:
+Rather than writing scenario YAML from scratch, start from the curated template library built into the CLI:
 
 ```bash
-# Generate a load test scenario
-kates test scaffold --type LOAD -o load-scenario.yaml
+# List the built-in templates (bare `kates test scaffold` does the same)
+kates test scaffold list
 
-# Generate an integrity + chaos scenario
-kates test scaffold --type INTEGRITY_CHAOS -o chaos-integrity.yaml
+# Filter the list by test type
+kates test scaffold list --type LOAD
+
+# Preview a template
+kates test scaffold show quick-load
+
+# Export a template as an editable file in the current directory
+kates test scaffold export quick-load
+
+# Export with a custom filename or directory, or export everything
+kates test scaffold export production-load -o load-scenario.yaml
+kates test scaffold export --all --dir ./scenarios/
 ```
 
-The scaffold output includes all available fields with comments explaining each one. Edit the generated file and run it with `kates test apply -f`.
+The library covers the common cases: `quick-load` (fast smoke test), `production-load` (1M records, strict SLA), `stress-test`, `endurance-soak`, `exactly-once`, `integrity-tx`, `spike-test`, and `ci-gate` (a fast 10k-record CI pipeline gate). Edit the exported file and run it with `kates test apply -f`.
 
 ## Common Mistakes
 
-These are the most frequently encountered errors when writing scenario files. Each entry shows the error message you'll see and how to fix it.
+The CLI does not validate scenario files against a schema — a file either parses or it doesn't, and everything else is checked by the backend when the scenario is submitted. These are the most frequent mistakes and what actually happens when you make them.
 
-### 1. Missing Required Field (`testType`)
+### 1. Missing Required Field (`type`)
 
-**Error:**
-
-```
-  ✗ Validation error in scenario #1:
-    Missing required field: 'type'
-    at: scenarios[0].type
-```
-
-**Cause:** The `type` field is the only required field in a scenario definition, but it's easy to forget when copying from examples.
+`type` is the only required field, but the CLI does not check for it. The scenario is submitted as-is and the backend rejects it with a 400 (its request validation requires a test type), so the scenario shows a `✖ Failed: ...` line and is marked `FAILED` in the summary table.
 
 **Fix:** Add the `type` field to every scenario:
 
@@ -390,39 +398,26 @@ scenarios:
 
 ### 2. Invalid Test Type Name
 
-**Error:**
+Case is not the problem — the CLI upper-cases the type before submitting, so `load` and `Load` work fine. What fails is a name that isn't a real test type: the backend rejects it at submission and the scenario is marked `FAILED`.
 
-```
-  ✗ Validation error in scenario "My Test":
-    Invalid test type: 'load'
-    Valid types: LOAD, STRESS, SPIKE, ENDURANCE, VOLUME, CAPACITY, ROUND_TRIP, INTEGRITY
-    at: scenarios[0].type
-```
-
-**Cause:** Test type names are case-sensitive and must be uppercase. Common mistakes include `load` (lowercase), `Load` (mixed case), or `LATENCY` (not a valid type — use `ROUND_TRIP`).
-
-**Fix:** Use the exact uppercase type name:
+**Fix:** Use one of the valid type names:
 
 ```yaml
 scenarios:
   - name: "My Test"
-    type: LOAD           # ✅ correct
-    # type: load         # ❌ wrong — lowercase
-    # type: LATENCY      # ❌ wrong — not a valid type
+    type: LOAD           # ✅ canonical
+    # type: load         # ✅ also works — the CLI upper-cases it
+    # type: LATENCY      # ❌ not a valid type — use ROUND_TRIP
 ```
 
 ### 3. SLA Threshold Format Error
 
-**Error:**
+SLA threshold values must be plain numbers, not strings with units — the field name already indicates the unit (e.g., `maxP99LatencyMs` implies milliseconds). A string value fails YAML decoding, so the whole run aborts with the raw parse error:
 
 ```
-  ✗ Validation error in scenario "Baseline Load Test":
-    Invalid value for 'maxP99LatencyMs': '50ms'
-    Expected: numeric value (integer or float), got: string
-    at: scenarios[0].validate.maxP99LatencyMs
+  ✖ Invalid scenario file: yaml: unmarshal errors:
+  line 8: cannot unmarshal !!str `50ms` into float64
 ```
-
-**Cause:** SLA threshold values must be plain numbers, not strings with units. The field name already indicates the unit (e.g., `maxP99LatencyMs` implies milliseconds).
 
 **Fix:** Remove the unit suffix and any quotes around the number:
 
@@ -436,16 +431,7 @@ validate:
 
 ### 4. Records Count Too Low for Meaningful Results
 
-**Error (warning):**
-
-```
-  ⚠ Warning in scenario "Quick Check":
-    Record count (100) is very low for test type LOAD.
-    Recommended minimum: 10,000 for LOAD, 50,000 for INTEGRITY.
-    Results may not be statistically meaningful.
-```
-
-**Cause:** Low record counts produce unreliable metrics. P99 latency with only 100 records means you're measuring the single slowest message — not a meaningful percentile.
+Kates will not warn you about this — a LOAD test with `records: 100` runs happily and reports a "P99" that is really just your single slowest message. Low record counts produce unreliable metrics.
 
 **Fix:** Use appropriate record counts per test type:
 
@@ -470,22 +456,12 @@ scenarios:
 | STRESS | 50,000 | Need sustained load to detect saturation |
 | INTEGRITY | 50,000 | Higher counts catch intermittent data loss |
 | ROUND_TRIP | 5,000 | Latency measurement is per-message, so fewer needed |
-| CAPACITY | N/A (auto) | Capacity tests auto-scale — don't override |
 
-### 5. Conflicting Spec Fields
+### 5. Setting Both `records` and `durationSeconds`
 
-**Error:**
+Kates does not treat this as a conflict — no error is raised, both values are forwarded to the backend, and the run stops at whichever bound is hit first. That silent "whichever comes first" behavior is easy to misread when you look at results later, so keep the intent explicit.
 
-```
-  ✗ Validation error in scenario "Endurance Run":
-    Conflicting fields: 'records' and 'durationSeconds' are both set.
-    Use 'records' for count-based tests or 'durationSeconds' for time-based tests, not both.
-    at: scenarios[0].spec
-```
-
-**Cause:** You set both `records: 100000` and `durationSeconds: 300` in the same scenario. Kates doesn't know whether to stop after 100K records or after 5 minutes.
-
-**Fix:** Choose one termination condition:
+**Fix:** Set only the termination condition you mean:
 
 ```yaml
 scenarios:

--- a/docs/book/14-recipes.md
+++ b/docs/book/14-recipes.md
@@ -50,7 +50,7 @@ Expected output:
 ```
 
 ::: {.callout-tip}
-If you see `No test found for ID` errors, make sure you noted the test IDs from Step 1 output before starting the upgrade. Test IDs are printed after each `kates test apply` or `kates test create` command.
+If you see `Test run not found` errors, make sure you noted the test IDs from Step 1 output before starting the upgrade. Test IDs are printed after each `kates test apply` or `kates test create` command.
 :::
 
 
@@ -100,11 +100,11 @@ scenarios:
 ```bash
 cat > nightly-load.json << 'EOF'
 {
-  "testType": "LOAD",
+  "type": "LOAD",
   "spec": {
-    "records": 100000,
-    "parallelProducers": 4,
-    "recordSizeBytes": 1024,
+    "numRecords": 100000,
+    "numProducers": 4,
+    "recordSize": 1024,
     "acks": "all"
   }
 }
@@ -124,7 +124,7 @@ kates schedule create \
 
 ```bash
 kates trend --type LOAD --metric p99LatencyMs --days 30
-kates trend --type LOAD --metric throughputRecordsPerSec --days 30
+kates trend --type LOAD --metric avgThroughputRecPerSec --days 30
 ```
 
 Expected output:
@@ -135,14 +135,14 @@ Expected output:
     ▁▁▂▁▁▁▂▁▃▁▁▁▂▁▁▁▁▂▁▁▁▁▁▁▁▇▁▁▁▁
                                  ↑ anomaly (run #26)
 
-  ▸ Trend: LOAD / throughputRecordsPerSec (30 days, 30 runs)
+  ▸ Trend: LOAD / avgThroughputRecPerSec (30 days, 30 runs)
     Min: 15,201  Max: 19,843  Avg: 18,102
     ▇▇▆▇▇▇▆▇▅▇▇▇▆▇▇▇▇▆▇▇▇▇▇▇▇▂▇▇▇▇
                                  ↑ anomaly (run #26)
 ```
 
 ::: {.callout-tip}
-If the schedule doesn't trigger, verify the Kates scheduler pod is running with `kubectl get pods -n kates -l app=kates-scheduler`. The cron expression uses UTC — adjust for your timezone.
+If the schedule doesn't trigger, verify the Kates backend pod is running with `kubectl get pods -n kates -l app.kubernetes.io/name=kates` — the scheduler runs inside the backend, not as a separate pod. The cron expression uses UTC — adjust for your timezone.
 :::
 
 
@@ -174,18 +174,19 @@ graph TD
 kates test create --type LOAD --records 200000 --producers 4 --acks all --wait
 ```
 
-**Step 2 — Data integrity under chaos:**
+**Step 2 — Data integrity:**
 
 ```bash
-kates test scaffold --type INTEGRITY_CHAOS -o integrity-chaos.yaml
-kates test apply -f integrity-chaos.yaml --wait
+kates test scaffold export integrity-tx
+kates test apply -f integrity-tx.yaml --wait
 ```
 
 **Step 3 — Disruption playbooks:**
 
 ```bash
-kates disruption run --config <(kates disruption playbook leader-cascade) --fail-on-sla-breach
-kates disruption run --config <(kates disruption playbook split-brain) --fail-on-sla-breach
+kates disruption playbook run leader-cascade
+kates disruption playbook run split-brain
+kates disruption playbook run az-failure
 ```
 
 **Step 4 — Resilience test (performance + chaos combined):**
@@ -194,33 +195,46 @@ kates disruption run --config <(kates disruption playbook split-brain) --fail-on
 cat > resilience.json << 'EOF'
 {
   "testRequest": {
-    "testType": "LOAD",
-    "spec": { "records": 100000, "producers": 4 }
+    "type": "LOAD",
+    "spec": { "numRecords": 100000, "numProducers": 4 }
   },
   "chaosSpec": {
-    "experimentName": "kafka-pod-kill",
-    "targetNamespace": "kafka"
+    "experimentName": "kafka-broker-pod-kill",
+    "targetNamespace": "kafka",
+    "targetLabel": "strimzi.io/component-type=kafka",
+    "chaosDurationSec": 30,
+    "disruptionType": "POD_KILL"
   },
   "steadyStateSec": 30
 }
 EOF
-kates resilience run --config resilience.json
+kates resilience run -f resilience.json
 ```
 
 Expected output:
 
 ```
-  ▸ Resilience Test: kafka-pod-kill
-    Steady-state baseline:    P99=11.2ms  Throughput=18,500 rec/s
-    During chaos:             P99=342.1ms Throughput=12,100 rec/s
-    Recovery time:            8.4s
-    Post-recovery:            P99=12.8ms  Throughput=18,200 rec/s
-    Data loss:                0 messages
-    Verdict:                  PASS ✅
+  Resilience Test Results
+  Status: COMPLETED
+
+  Chaos Outcome
+  Experiment: kafka-broker-pod-kill
+  Verdict:    Pass
+  Duration:   30s
+
+  Pre-Chaos Baseline
+  Throughput (rec/s): 18500.0
+  P99 Latency (ms):   11.20
+  Error Rate:         0.0000%
+
+  Post-Chaos Impact
+  Throughput (rec/s): 18200.0
+  P99 Latency (ms):   12.80
+  Error Rate:         0.0000%
 ```
 
 ::: {.callout-tip}
-If `--fail-on-sla-breach` causes immediate failure, your SLA thresholds may be too tight for disruption tests. Use `kates disruption playbook <name> --show-defaults` to see the recommended thresholds for each playbook.
+Each playbook run prints an SLA grade at the end. If you need a hard pass/fail gate for CI — exit code 1 on SLA violation — run a custom disruption plan instead: `kates disruption run --config plan.json --fail-on-sla-breach`. Use `kates disruption playbook list` to see the available playbooks and what each one does.
 :::
 
 
@@ -251,9 +265,11 @@ If one broker shows disproportionately high load (bytes in/s, request rate), it 
 **Step 3 — Export and compare heatmaps:**
 
 ```bash
-kates report export <good-id> --format heatmap -o good-heatmap.json
-kates report export <bad-id> --format heatmap -o bad-heatmap.json
+kates report export <good-id> --format heatmap > good-heatmap.json
+kates report export <bad-id> --format heatmap > bad-heatmap.json
 ```
+
+(When run interactively without a redirect, the heatmap is written to `kates-heatmap-<id>.json` in the current directory.)
 
 Heatmap patterns to look for:
 
@@ -273,15 +289,20 @@ Expected output:
 
 ```json
 {
-  "clusterHealthy": false,
-  "underReplicatedPartitions": 3,
-  "isrChanges": 12,
-  "offlinePartitions": 0,
-  "brokers": [
-    {"id": 0, "bytesInPerSec": 52428800, "requestRate": 1240},
-    {"id": 1, "bytesInPerSec": 15728640, "requestRate": 310},
-    {"id": 2, "bytesInPerSec": 16777216, "requestRate": 340}
-  ]
+  "clusterId": "lZ0T3AqiTtqzXWkGkDXG3g",
+  "brokers": 3,
+  "controllerId": 0,
+  "topics": 24,
+  "partitions": 96,
+  "consumerGroups": 5,
+  "partitionHealth": {
+    "underReplicated": 3,
+    "offline": 0,
+    "problems": [
+      {"topic": "kates-load-test", "partition": 4, "issue": "UNDER_REPLICATED", "isr": 2, "replicas": 3}
+    ]
+  },
+  "status": "WARNING"
 }
 ```
 
@@ -290,7 +311,7 @@ If the diff shows degraded throughput but the heatmap has no obvious pattern, ch
 :::
 
 
-If under-replicated partitions or ISR changes occurred during the test, the cluster was under stress.
+If under-replicated or offline partitions show up during the test, the cluster was under stress.
 
 ---
 
@@ -323,7 +344,7 @@ The results show per-phase metrics. The last phase before P99 latency exceeded y
 Combine with trend analysis to track capacity changes over time as your cluster configuration evolves:
 
 ```bash
-kates trend --type CAPACITY --metric throughputRecordsPerSec --days 90
+kates trend --type CAPACITY --metric avgThroughputRecPerSec --days 90
 ```
 
 Expected output:

--- a/docs/book/15-kafka-deployment.md
+++ b/docs/book/15-kafka-deployment.md
@@ -4,15 +4,15 @@ This chapter is the operations manual for the **krafter** Kafka cluster — the 
 
 ## Strimzi Operator
 
-Kafka on Kubernetes is managed by the **Strimzi Kafka Operator** (`1.0.0`), installed from the remote Helm chart:
+Kafka on Kubernetes is managed by the **Strimzi Kafka Operator** (`1.0.0`), installed from the OCI Helm chart on quay.io into a dedicated `strimzi-operator` namespace (this is exactly what `scripts/deploy-kafka.sh` runs when the Strimzi CRDs are not yet present):
 
 ```bash
-helm repo add strimzi https://strimzi.io/charts/
-helm upgrade --install strimzi-kafka-operator strimzi/strimzi-kafka-operator \
+helm upgrade --install strimzi-operator oci://quay.io/strimzi-helm/strimzi-kafka-operator \
   --version 1.0.0 \
-  --namespace kafka \
+  --namespace strimzi-operator \
   --set watchAnyNamespace=true \
-  --set image.imagePullPolicy=IfNotPresent
+  --set replicas=1 \
+  --timeout 5m --wait
 ```
 
 Strimzi watches for `Kafka`, `KafkaNodePool`, `KafkaTopic`, and `KafkaUser` custom resources and reconciles the desired state into StatefulSets, ConfigMaps, Secrets, and Services.
@@ -284,7 +284,7 @@ Simple ACL authorization with `kates-backend` as a superUser:
 authorization:
   type: simple
   superUsers:
-    - CN=kates-backend
+    - kates-backend
 ```
 
 ## KafkaUser Management
@@ -297,6 +297,7 @@ Users are declared as `KafkaUser` CRDs — Strimzi creates a Kubernetes Secret w
 | `kafka-ui` | Read-only monitor | 1MB/s produce, 50MB/s consume, 10% CPU | Describe+Read on all topics/groups |
 | `apicurio-registry` | Schema registry | 10MB/s produce, 20MB/s consume, 15% CPU | CRUD on `__apicurio*` topics only |
 | `litmus-chaos` | Chaos testing | None | Full CRUD on all topics |
+| `kates-connect` | Kafka Connect workers | 50MB/s produce, 50MB/s consume, 25% CPU | Read/Write/Create on `kates-*` and `cdc*` topics, `connect-*` groups, transactional IDs |
 
 **Secret flow:**
 
@@ -319,6 +320,9 @@ Topics are declared as `KafkaTopic` CRDs, managed by the Topic Operator:
 | `kates-metrics` | 6 | 3 | 24h | lz4 | Real-time broker metrics |
 | `kates-audit` | 3 | 3 | 30d | — | Audit trail |
 | `kates-dlq` | 3 | 3 | ∞ | — | Dead letter queue (compacted) |
+| `cdc-schema-history` | 1 | 3 | ∞ | — | Debezium schema history (compacted) |
+| `cdc-heartbeat` | 1 | 3 | 24h | — | Debezium heartbeat |
+| `test-sink-topic` | 3 | 3 | 24h | — | Connect sink-connector validation |
 
 **Partition rationale:** `kates-results` has 12 partitions (4× the broker count) for maximum consumer parallelism during high-throughput test runs. `kates-audit` has 3 (one per broker) since writes are infrequent.
 
@@ -362,7 +366,7 @@ graph LR
 
 ### Hardened Strimzi Operator NetworkPolicy (Isolated Topology)
 
-When deploying with `--topology isolated`, the Strimzi Operator runs in a dedicated `strimzi-operator` namespace, separate from the Kafka application namespace. This requires a precisely scoped NetworkPolicy to allow the operator to function while maintaining strict network isolation:
+When deploying with `kates deploy --topology isolated` (the kates CLI's default topology), the Strimzi Operator runs in a dedicated `strimzi-operator` namespace, separate from the Kafka application namespace. This requires a precisely scoped NetworkPolicy to allow the operator to function while maintaining strict network isolation:
 
 ```mermaid
 graph LR
@@ -474,7 +478,7 @@ The Entity Operator runs two sub-operators in a single pod:
 
 ## Prometheus Alerts
 
-The alerting rules in `kafka-alerts.yaml` cover five categories:
+The alerting rules in `kafka-alerts.yaml` cover six categories:
 
 ### Cluster Health
 
@@ -516,6 +520,13 @@ The alerting rules in `kafka-alerts.yaml` cover five categories:
 | `StrimziOperatorDown` | Operator unreachable for 5min | critical |
 | `CruiseControlAnomalyDetected` | Any anomaly in 10min window | warning |
 
+### Certificates
+
+| Alert | Condition | Severity |
+|-------|-----------|----------|
+| `KafkaCertificateExpiringSoon` | Certificate expires in < 30 days (for 1h) | warning |
+| `KafkaCertificateExpiryCritical` | Certificate expires in < 7 days (for 30min) | critical |
+
 ## Backup & Recovery
 
 Daily backups are managed by Velero:
@@ -539,24 +550,26 @@ kubectl apply -f config/kafka/kafka-backup.yaml
 
 ## Deploy Script Flow
 
-The `deploy-kafka.sh` script executes the following sequence:
+The `deploy-kafka.sh` script is Helm-chart-driven: it installs the `charts/kafka-cluster` chart (which templates the Kafka CR, node pools, users, topics, alerts, and network policies, and pulls in SeaweedFS as a subchart) with per-environment values files, installing the Strimzi operator first if its CRDs are missing:
 
 ```mermaid
 graph TD
-    A["Add Strimzi Helm repo"] --> B["Install Strimzi Operator"]
-    B --> C["Install Drain Cleaner"]
-    C --> D["Apply metrics config"]
-    D --> E["Create zone-specific StorageClasses"]
-    E --> F["Apply Kafka CR (brokers + controllers)"]
-    F --> G["Apply dashboards (7 Grafana panels)"]
-    G --> H["Wait for Kafka Ready"]
-    H --> I["Apply KafkaUsers (SCRAM secrets)"]
-    I --> J["Apply KafkaTopics"]
-    J --> K["Wait for user secrets"]
+    A["Ensure kafka namespace"] --> B{"Strimzi CRDs present?"}
+    B -->|"no"| C["Install Strimzi Operator<br/>(OCI chart → strimzi-operator namespace)"]
+    B -->|"yes"| D["helm dependency build<br/>(SeaweedFS subchart)"]
+    C --> D
+    D --> E{"ENV = kind?"}
+    E -->|"yes"| F["Apply zone-specific StorageClasses"]
+    E -->|"no"| G["Select values files<br/>(values-dev / values-kind /<br/>values-staging / values-prod)"]
+    F --> G
+    G --> H["Adopt pre-existing KafkaTopics + KafkaUsers<br/>into the Helm release"]
+    H --> I["helm upgrade --install kafka-cluster<br/>charts/kafka-cluster -n kafka"]
+    I --> J["Wait for kafka/krafter Ready<br/>(up to 10 min)"]
+    J --> K["Wait for KafkaUser secrets"]
     K --> L["Done ✅"]
 ```
 
-**Order matters:** Users must be applied after the cluster is Ready (the User Operator needs a running cluster), and before the Kafka UI deployment (which needs the `kafka-ui` secret).
+**Order matters:** The operator must exist before the cluster chart is installed — its CRDs are a hard dependency, which is why it lives in a separate Helm release. User secrets only appear after the cluster is Ready (the User Operator needs a running cluster), so downstream scripts like `deploy-kafka-ui.sh` wait for the `kafka-ui` secret before deploying.
 
 ## Troubleshooting
 
@@ -566,11 +579,11 @@ graph TD
 
 **Cause:** The Helm chart's Kafka image map includes versions not supported by the operator binary
 
-**Fix:** Use the remote Helm chart (always in sync with the operator):
+**Fix:** Use the OCI-distributed chart from quay.io (always in sync with the operator):
 
 ```bash
-helm upgrade --install strimzi-kafka-operator strimzi/strimzi-kafka-operator \
-  --version 1.0.0
+helm upgrade --install strimzi-operator oci://quay.io/strimzi-helm/strimzi-kafka-operator \
+  --version 1.0.0 --namespace strimzi-operator
 ```
 
 ### Brokers Crash with ConfigException
@@ -624,11 +637,11 @@ kubectl get pods -n kafka -l strimzi.io/name=krafter-entity-operator
 
 ```bash
 # Check for blocking NetworkPolicy
-kubectl describe networkpolicy strimzi-cluster-operator-network-policy -n kafka
+kubectl describe networkpolicy strimzi-cluster-operator-network-policy -n strimzi-operator
 # Look for: "Allowing egress traffic: <none>"
 
 # Check operator logs
-kubectl logs deployment/strimzi-cluster-operator -n kafka --tail=20
+kubectl logs deployment/strimzi-cluster-operator -n strimzi-operator --tail=20
 # Look for: "Error getting controller config: TimeoutException"
 ```
 
@@ -636,14 +649,14 @@ kubectl logs deployment/strimzi-cluster-operator -n kafka --tail=20
 
 ```bash
 # Set generateNetworkPolicy to false in Helm chart values
-helm upgrade strimzi-kafka-operator <chart-path> -n kafka \
-  --reuse-values --set generateNetworkPolicy=false
+helm upgrade strimzi-operator oci://quay.io/strimzi-helm/strimzi-kafka-operator \
+  -n strimzi-operator --reuse-values --set generateNetworkPolicy=false
 
 # Delete the blocking NetworkPolicy
-kubectl delete networkpolicy strimzi-cluster-operator-network-policy -n kafka
+kubectl delete networkpolicy strimzi-cluster-operator-network-policy -n strimzi-operator
 
 # Restart the operator to clear stale backoff state
-kubectl rollout restart deployment/strimzi-cluster-operator -n kafka
+kubectl rollout restart deployment/strimzi-cluster-operator -n strimzi-operator
 ```
 
 ### Cruise Control Goal Mismatch
@@ -676,9 +689,9 @@ goals: >-
 
 | Component | Version | Notes |
 |-----------|---------|-------|
-| Apache Kafka | 4.1.1 | Highest supported by Strimzi 1.0.0 |
-| Strimzi Operator | 1.0.0 | Remote Helm chart |
-| Strimzi Drain Cleaner | 1.5.0 | Installed without cert-manager |
-| Cruise Control | 2.5.146 | Bundled with Strimzi |
-| Kafka UI | 0.7.2 | Provectus |
+| Apache Kafka | 4.2.0 | Pinned in `versions.env` (`quay.io/strimzi/kafka:1.0.0-kafka-4.2.0`) |
+| Strimzi Operator | 1.0.0 | OCI Helm chart (`quay.io/strimzi-helm`) |
+| Strimzi Drain Cleaner | 1.0.0 | Installed without cert-manager |
+| Cruise Control | — | Bundled with the Strimzi Kafka image |
+| Kafka UI | v1.5.0 | kafbat/kafka-ui (successor to the Provectus UI) |
 | CRD API | `v1` | Migrated from deprecated `v1beta2` |

--- a/docs/book/16-grpc-api.md
+++ b/docs/book/16-grpc-api.md
@@ -81,14 +81,13 @@ The protobuf contract is defined in [`kates.proto`](https://github.com/bmscomp/k
 
 #### CreateTest
 
-`CreateTestRequest` exposes only a subset of `TestSpec` — `type`, `num_records`, `record_size`, `partitions`, `replication_factor`, `compression_type`, and `labels`; every other spec field (acks, batching, producer/consumer counts, ...) uses the server-side defaults listed under [TestSpec](#testspec).
+`CreateTestRequest` exposes only a subset of `TestSpec` — `type`, `num_records`, `record_size`, `partitions`, `replication_factor`, and `compression_type`; every other spec field (acks, batching, producer/consumer counts, ...) falls back to the per-test-type defaults described under [TestSpec](#testspec). The request message also declares a `labels` map, but the current server implementation ignores it — set labels through the REST API if you need them.
 
 ```bash
 grpcurl -plaintext -d '{
   "type": "LOAD", "num_records": 100000, "record_size": 1024,
   "partitions": 3, "replication_factor": 3,
-  "compression_type": "lz4",
-  "labels": {"env": "staging"}
+  "compression_type": "lz4"
 }' localhost:8080 kates.TestService/CreateTest
 ```
 
@@ -105,7 +104,6 @@ grpcurl -plaintext -d '{
     "durationMs": "600000", "replicationFactor": 3, "partitions": 3,
     "minInsyncReplicas": 2
   },
-  "labels": { "env": "staging" },
   "createdAt": "2026-02-15T20:00:00Z",
   "backend": "native"
 }
@@ -152,9 +150,11 @@ grpcurl -plaintext -d '{"type": "LOAD", "page": 0, "size": 10}' \
     { "id": "a1b2c3d4-...", "testType": "LOAD", "status": "COMPLETED", "createdAt": "2026-02-15T20:00:00Z" },
     { "id": "b2c3d4e5-...", "testType": "LOAD", "status": "RUNNING", "createdAt": "2026-02-15T20:05:00Z" }
   ],
-  "page": 0, "size": 10, "total": "45"
+  "size": 10, "total": "45"
 }
 ```
+
+(`page` is absent here for the same proto3 reason explained under [GetClusterInfo](#getclusterinfo): zero-valued fields are omitted from grpcurl's JSON output.)
 
 #### CancelTest / DeleteTest
 
@@ -259,9 +259,9 @@ enum TestType {
 
 ### TestSpec
 
-Proto3 fields carry no wire-level defaults — the values below are the server-side fallbacks the backend applies when a field is unset (see `kates/src/main/java/com/bmscomp/kates/domain/TestSpec.java`).
+Proto3 fields carry no wire-level defaults — when a field is unset, the backend applies **per-test-type defaults** (`TestOrchestrator` calls `applyTypeDefaults`, backed by `config/TestTypeDefaults.java` and overridable via `kates.tests.<type>.*` config properties). The values below are the LOAD-type defaults; other test types differ (STRESS uses more producers, ENDURANCE a longer duration, and so on).
 
-| Field | Type | Server default | Description |
+| Field | Type | LOAD default | Description |
 |-------|------|---------|-------------|
 | `num_records` | int64 | 1000000 | Total messages to produce |
 | `record_size` | int32 | 1024 | Message size in bytes |
@@ -302,7 +302,7 @@ All list RPCs use `page` (zero-based) and `size` (default 50, max 200) request f
 |-------------|:---:|------|---------|
 | `INVALID_ARGUMENT` | 400 | Missing/invalid fields | `Test type is required`, `Invalid test type: BENCHMARK` |
 | `NOT_FOUND` | 404 | Resource doesn't exist | `Test not found: abc-123` |
-| `INTERNAL` | 500 | Test execution failure (underlying exception message) | `Backend not found: 'trogdor'. Available: [native]` |
+| `INTERNAL` | 500 | Test execution failure | Surfaces the underlying exception message verbatim |
 
 Transport-level codes such as `UNAVAILABLE` come from the gRPC runtime itself (e.g. when the server cannot be reached), not from Kates.
 

--- a/docs/book/16-grpc-api.md
+++ b/docs/book/16-grpc-api.md
@@ -4,7 +4,7 @@
 
 Kates exposes a gRPC API alongside the REST API for high-throughput programmatic access from CI pipelines, other services, and language-native clients. Both APIs share the same backend service layer — identical behavior, different wire format.
 
-**When should you use gRPC over REST?** Choose gRPC when you need type-safe, high-performance integration from Go, Java, Python, or Rust services. The protobuf contract gives you compile-time type checking, automatic client code generation, and efficient binary serialization — ideal for CI/CD pipelines where reliability and speed matter more than human readability. gRPC's HTTP/2 foundation also provides connection multiplexing and server-side streaming for real-time test status updates without polling.
+**When should you use gRPC over REST?** Choose gRPC when you need type-safe, high-performance integration from Go, Java, Python, or Rust services. The protobuf contract gives you compile-time type checking, automatic client code generation, and efficient binary serialization — ideal for CI/CD pipelines where reliability and speed matter more than human readability. gRPC's HTTP/2 foundation also provides connection multiplexing.
 
 Use the REST API instead when you need quick automation with `curl`, are integrating with HTTP/1.1-only tools (webhooks, dashboards), or want human-readable responses during debugging. See [Chapter 11: REST API Reference](11-api-reference.md) for REST details.
 
@@ -19,14 +19,13 @@ Use the REST API instead when you need quick automation with `curl`, are integra
 | Service mesh | ✅ HTTP/2 multiplexing | ✅ Standard |
 | Code generation | ✅ Automatic from `.proto` | ❌ Manual |
 | Debugging | ⚠️ Binary format | ✅ Human-readable |
-| Streaming | ✅ Server-side streaming | ❌ Polling required |
 | Type safety | ✅ Compile-time via protobuf | ❌ Runtime JSON validation |
 | Payload size | ✅ ~30% smaller (binary) | Larger (JSON text) |
 | Tooling | `grpcurl`, generated stubs | `curl`, Postman, browsers |
 
 ---
 
-## Streaming Test Execution Flow
+## Test Execution Flow
 
 ```mermaid
 sequenceDiagram
@@ -38,29 +37,31 @@ sequenceDiagram
     Kates gRPC Server->>Kafka Cluster: Create topic, initialize producers
     Kates gRPC Server-->>Client: TestRun (status: PENDING)
 
-    Client->>Kates gRPC Server: StreamTestStatus(GetTestRequest)
-    Note over Client,Kates gRPC Server: Server-side streaming RPC
-
-    Kates gRPC Server-->>Client: StatusUpdate (RUNNING, phase: ramp-up)
-    Kates gRPC Server-->>Client: StatusUpdate (RUNNING, progress: 50%)
-    Kates gRPC Server-->>Client: StatusUpdate (COMPLETED, results attached)
-    Note over Client: Stream closes on completion
+    loop Poll until terminal status
+        Client->>Kates gRPC Server: GetTest(GetTestRequest)
+        Kates gRPC Server-->>Client: TestRun (status: RUNNING)
+    end
 
     Client->>Kates gRPC Server: GetTest(GetTestRequest)
-    Kates gRPC Server-->>Client: TestRun (full results)
+    Kates gRPC Server-->>Client: TestRun (status: COMPLETED, results attached)
 ```
 
 ---
 
 ## Connection
 
-The gRPC server runs on port **9000** (default Quarkus gRPC port):
+Kates serves gRPC through the unified Quarkus HTTP server: `quarkus.grpc.server.use-separate-server=false` in `application.properties` routes gRPC (HTTP/2) traffic over the same port as REST — **8080**. The separate-server port setting (`quarkus.grpc.server.port=9000`) is ignored in this mode.
 
 ```bash
-kubectl port-forward deployment/kates -n kates 9000:9000
-grpcurl -plaintext localhost:9000 list
-# Output: kates.ClusterService, kates.HealthService, kates.TestService
+kubectl port-forward deployment/kates -n kates 8080:8080
+grpcurl -plaintext localhost:8080 list
+# kates.ClusterService
+# kates.HealthService
+# kates.TestService
+# (plus the reflection and health services Quarkus registers)
 ```
+
+`grpcurl list` works because server reflection is enabled (`quarkus.grpc.server.enable-reflection-service=true`). Note that the Helm chart still declares a separate `grpc` service port 9000 (`charts/kates/values.yaml`); with the unified-server configuration nothing listens there — connect to the HTTP port instead.
 
 ---
 
@@ -75,19 +76,20 @@ The protobuf contract is defined in [`kates.proto`](https://github.com/bmscomp/k
 | `CreateTest` | `CreateTestRequest` | `TestRun` | Start a new test execution |
 | `GetTest` | `GetTestRequest` | `TestRun` | Retrieve a test by ID |
 | `ListTests` | `ListTestsRequest` | `ListTestsResponse` | Paginated test listing |
-| `StreamTestStatus` | `GetTestRequest` | `stream StatusUpdate` | Real-time status streaming |
 | `CancelTest` | `CancelTestRequest` | `TestRun` | Cancel a running test |
 | `DeleteTest` | `DeleteTestRequest` | `Empty` | Delete a test and its results |
 
 #### CreateTest
 
+`CreateTestRequest` exposes only a subset of `TestSpec` — `type`, `num_records`, `record_size`, `partitions`, `replication_factor`, `compression_type`, and `labels`; every other spec field (acks, batching, producer/consumer counts, ...) uses the server-side defaults listed under [TestSpec](#testspec).
+
 ```bash
 grpcurl -plaintext -d '{
   "type": "LOAD", "num_records": 100000, "record_size": 1024,
-  "num_producers": 4, "num_consumers": 2, "acks": "all",
   "partitions": 3, "replication_factor": 3,
+  "compression_type": "lz4",
   "labels": {"env": "staging"}
-}' localhost:9000 kates.TestService/CreateTest
+}' localhost:8080 kates.TestService/CreateTest
 ```
 
 **Response:**
@@ -95,10 +97,17 @@ grpcurl -plaintext -d '{
 ```json
 {
   "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-  "type": "LOAD", "status": "PENDING",
-  "spec": { "numRecords": "100000", "recordSize": 1024, "numProducers": 4, "numConsumers": 2, "acks": "all", "partitions": 3, "replicationFactor": 3 },
+  "testType": "LOAD", "status": "PENDING",
+  "spec": {
+    "numRecords": "100000", "recordSize": 1024, "throughput": "-1",
+    "acks": "all", "batchSize": 65536, "lingerMs": 5,
+    "compressionType": "lz4", "numProducers": 1, "numConsumers": 1,
+    "durationMs": "600000", "replicationFactor": 3, "partitions": 3,
+    "minInsyncReplicas": 2
+  },
   "labels": { "env": "staging" },
-  "createdAt": "2026-02-15T20:00:00Z"
+  "createdAt": "2026-02-15T20:00:00Z",
+  "backend": "native"
 }
 ```
 
@@ -106,7 +115,7 @@ grpcurl -plaintext -d '{
 
 ```bash
 grpcurl -plaintext -d '{"id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"}' \
-  localhost:9000 kates.TestService/GetTest
+  localhost:8080 kates.TestService/GetTest
 ```
 
 **Response:**
@@ -114,21 +123,25 @@ grpcurl -plaintext -d '{"id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"}' \
 ```json
 {
   "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-  "type": "LOAD", "status": "COMPLETED",
+  "testType": "LOAD", "status": "COMPLETED",
   "results": [
-    { "phaseName": "ramp-up", "recordsSent": "10000", "throughputRecordsPerSec": 5234.1, "avgLatencyMs": 4.8, "p99LatencyMs": 18.4 },
-    { "phaseName": "steady-state", "recordsSent": "90000", "throughputRecordsPerSec": 8412.7, "avgLatencyMs": 2.4, "p99LatencyMs": 12.3 }
+    { "taskId": "a1b2c3d4-...", "testType": "LOAD", "status": "COMPLETED",
+      "recordsSent": "100000", "throughputRecordsPerSec": 8412.7,
+      "avgLatencyMs": 2.4, "p99LatencyMs": 12.3,
+      "startTime": "2026-02-15T20:00:01Z", "endTime": "2026-02-15T20:02:05Z" }
   ],
   "createdAt": "2026-02-15T20:00:00Z",
-  "completedAt": "2026-02-15T20:02:05Z"
+  "backend": "native"
 }
 ```
+
+Timing lives on each `TestResult` (`start_time` / `end_time`) — `TestRun` itself carries only `created_at`.
 
 #### ListTests
 
 ```bash
 grpcurl -plaintext -d '{"type": "LOAD", "page": 0, "size": 10}' \
-  localhost:9000 kates.TestService/ListTests
+  localhost:8080 kates.TestService/ListTests
 ```
 
 **Response:**
@@ -136,39 +149,22 @@ grpcurl -plaintext -d '{"type": "LOAD", "page": 0, "size": 10}' \
 ```json
 {
   "items": [
-    { "id": "a1b2c3d4-...", "type": "LOAD", "status": "COMPLETED", "createdAt": "2026-02-15T20:00:00Z" },
-    { "id": "b2c3d4e5-...", "type": "LOAD", "status": "RUNNING", "createdAt": "2026-02-15T20:05:00Z" }
+    { "id": "a1b2c3d4-...", "testType": "LOAD", "status": "COMPLETED", "createdAt": "2026-02-15T20:00:00Z" },
+    { "id": "b2c3d4e5-...", "testType": "LOAD", "status": "RUNNING", "createdAt": "2026-02-15T20:05:00Z" }
   ],
-  "page": 0, "size": 10, "total": 45
+  "page": 0, "size": 10, "total": "45"
 }
 ```
-
-#### StreamTestStatus
-
-```bash
-grpcurl -plaintext -d '{"id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"}' \
-  localhost:9000 kates.TestService/StreamTestStatus
-```
-
-**Streaming output** (one JSON object per update):
-
-```json
-{ "testId": "a1b2c3d4-...", "status": "RUNNING", "phase": "ramp-up", "progressPercent": 0, "timestamp": "2026-02-15T20:00:01Z" }
-{ "testId": "a1b2c3d4-...", "status": "RUNNING", "phase": "steady-state", "progressPercent": 50, "currentThroughput": 8356.9, "timestamp": "2026-02-15T20:01:00Z" }
-{ "testId": "a1b2c3d4-...", "status": "COMPLETED", "progressPercent": 100, "finalResults": { "recordsSent": "100000", "throughputRecordsPerSec": 8412.7, "p99LatencyMs": 12.3 }, "timestamp": "2026-02-15T20:02:05Z" }
-```
-
-> **Note:** The stream closes automatically on completion/failure. If the test is already completed, a single final-status message is emitted.
 
 #### CancelTest / DeleteTest
 
 ```bash
 # Cancel
-grpcurl -plaintext -d '{"id": "a1b2c3d4-..."}' localhost:9000 kates.TestService/CancelTest
+grpcurl -plaintext -d '{"id": "a1b2c3d4-..."}' localhost:8080 kates.TestService/CancelTest
 # Response: TestRun with status "CANCELLED"
 
 # Delete
-grpcurl -plaintext -d '{"id": "a1b2c3d4-..."}' localhost:9000 kates.TestService/DeleteTest
+grpcurl -plaintext -d '{"id": "a1b2c3d4-..."}' localhost:8080 kates.TestService/DeleteTest
 # Response: {} (empty)
 ```
 
@@ -178,7 +174,8 @@ grpcurl -plaintext -d '{"id": "a1b2c3d4-..."}' localhost:9000 kates.TestService/
 
 | RPC | Request | Response | Description |
 |-----|---------|----------|-------------|
-| `GetClusterInfo` | `Empty` | `ClusterInfo` | Cluster ID, controller, broker list |
+| `GetClusterInfo` | `Empty` | `ClusterInfo` | Cluster ID, controller ID, broker list |
+| `GetClusterTopology` | `Empty` | `ClusterTopology` | KRaft topology: node pools, nodes, quorum leader |
 | `ListTopics` | `ListTopicsRequest` | `ListTopicsResponse` | Paginated topic listing |
 | `GetTopicDetail` | `GetTopicRequest` | `TopicDetail` | Topic config, partitions, RF |
 | `ListConsumerGroups` | `ListGroupsRequest` | `ListGroupsResponse` | Consumer groups with state |
@@ -186,39 +183,39 @@ grpcurl -plaintext -d '{"id": "a1b2c3d4-..."}' localhost:9000 kates.TestService/
 #### GetClusterInfo
 
 ```bash
-grpcurl -plaintext localhost:9000 kates.ClusterService/GetClusterInfo
+grpcurl -plaintext localhost:8080 kates.ClusterService/GetClusterInfo
 ```
 
 ```json
 {
   "clusterId": "abc123",
-  "controller": { "id": 0, "host": "krafter-kafka-0.kafka.svc", "port": 9092 },
+  "controllerId": 3,
   "brokers": [
-    { "id": 0, "host": "krafter-kafka-0.kafka.svc", "port": 9092, "rack": "zone-a" },
-    { "id": 1, "host": "krafter-kafka-1.kafka.svc", "port": 9092, "rack": "zone-b" },
-    { "id": 2, "host": "krafter-kafka-2.kafka.svc", "port": 9092, "rack": "zone-c" }
-  ],
-  "topicCount": 12, "totalPartitions": 36
+    { "host": "krafter-kafka-0.kafka.svc", "port": 9092 },
+    { "id": 1, "host": "krafter-kafka-1.kafka.svc", "port": 9092 },
+    { "id": 2, "host": "krafter-kafka-2.kafka.svc", "port": 9092 }
+  ]
 }
 ```
+
+`ClusterInfo` carries only the cluster ID, the controller's node ID (`controller_id`), and the broker list — the topic count comes from `ListTopics` (its `total` field) and per-topic partition counts from `GetTopicDetail`. Note that proto3 JSON output omits zero-valued fields, which is why broker 0's `id` is absent above. (Broker hostnames follow whatever your Kafka deployment advertises; the example shows the `krafter` cluster from this repo's `kafka-cluster` chart.)
 
 #### GetTopicDetail
 
 ```bash
-grpcurl -plaintext -d '{"name": "kates-results"}' localhost:9000 kates.ClusterService/GetTopicDetail
+grpcurl -plaintext -d '{"name": "kates-results"}' localhost:8080 kates.ClusterService/GetTopicDetail
 ```
 
 ```json
 {
   "name": "kates-results",
-  "partitions": [
-    { "id": 0, "leader": 0, "replicas": [0, 1, 2], "isr": [0, 1, 2] },
-    { "id": 1, "leader": 1, "replicas": [1, 2, 0], "isr": [1, 2, 0] }
-  ],
-  "config": { "retention.ms": "604800000", "min.insync.replicas": "2" },
-  "replicationFactor": 3
+  "partitions": 12,
+  "replicationFactor": 3,
+  "configs": { "retention.ms": "604800000", "min.insync.replicas": "2", "compression.type": "lz4" }
 }
 ```
+
+`partitions` is a count, not a per-partition breakdown — the proto `TopicDetail` message has no leader/replica/ISR detail.
 
 ---
 
@@ -229,16 +226,18 @@ grpcurl -plaintext -d '{"name": "kates-results"}' localhost:9000 kates.ClusterSe
 | `Check` | `Empty` | `HealthResponse` | Engine status + Kafka connectivity |
 
 ```bash
-grpcurl -plaintext localhost:9000 kates.HealthService/Check
+grpcurl -plaintext localhost:8080 kates.HealthService/Check
 ```
 
 ```json
 {
   "status": "UP",
-  "engine": { "activeBackend": "native", "availableBackends": ["native"], "activeTests": 2 },
-  "kafka": { "status": "UP", "bootstrapServers": "krafter-kafka-bootstrap.kafka:9092", "brokerCount": 3, "message": "Kafka cluster is reachable" }
+  "engine": { "activeBackend": "native", "availableBackends": ["native", "trogdor"] },
+  "kafka": { "status": "UP", "bootstrapServers": "krafter-kafka-bootstrap.kafka.svc:9092", "message": "Kafka cluster is reachable" }
 }
 ```
+
+When Kafka is unreachable, `status` becomes `DEGRADED`, `kafka.status` becomes `DOWN`, and the message reads `Cannot connect to Kafka cluster`.
 
 ---
 
@@ -254,26 +253,28 @@ enum TestType {
   ROUND_TRIP = 7; INTEGRITY = 8;
   TUNE_REPLICATION = 9;  TUNE_ACKS = 10;
   TUNE_BATCHING = 11;    TUNE_COMPRESSION = 12;
-  TUNE_PARTITIONS = 13;
+  TUNE_PARTITIONS = 13;  INTEGRATION_CDC = 14;
 }
 ```
 
 ### TestSpec
 
-| Field | Type | Default | Description |
+Proto3 fields carry no wire-level defaults — the values below are the server-side fallbacks the backend applies when a field is unset (see `kates/src/main/java/com/bmscomp/kates/domain/TestSpec.java`).
+
+| Field | Type | Server default | Description |
 |-------|------|---------|-------------|
-| `num_records` | int64 | — | Total messages to produce |
+| `num_records` | int64 | 1000000 | Total messages to produce |
 | `record_size` | int32 | 1024 | Message size in bytes |
 | `throughput` | int64 | -1 | Target records/s (-1 = unlimited) |
 | `acks` | string | "all" | Producer acknowledgment mode |
-| `batch_size` | int32 | 16384 | Producer batch size bytes |
+| `batch_size` | int32 | 65536 | Producer batch size bytes |
 | `linger_ms` | int32 | 5 | Producer linger delay |
-| `compression_type` | string | "none" | none, lz4, snappy, zstd, gzip |
+| `compression_type` | string | "lz4" | none, lz4, snappy, zstd, gzip |
 | `num_producers` | int32 | 1 | Parallel producer threads |
-| `num_consumers` | int32 | 0 | Parallel consumer threads |
-| `duration_ms` | int64 | 0 | Duration-based test (0 = record-based) |
+| `num_consumers` | int32 | 1 | Parallel consumer threads |
+| `duration_ms` | int64 | 600000 | Duration for duration-based tests |
 | `replication_factor` | int32 | 3 | Topic replication factor |
-| `partitions` | int32 | 6 | Topic partition count |
+| `partitions` | int32 | 3 | Topic partition count |
 | `min_insync_replicas` | int32 | 2 | Topic ISR constraint |
 
 ### TestResult
@@ -299,12 +300,11 @@ All list RPCs use `page` (zero-based) and `size` (default 50, max 200) request f
 
 | gRPC Status | HTTP Equiv. | When | Example |
 |-------------|:---:|------|---------|
-| `INVALID_ARGUMENT` | 400 | Missing/invalid fields | `Invalid test type: 'BENCHMARK'` |
+| `INVALID_ARGUMENT` | 400 | Missing/invalid fields | `Test type is required`, `Invalid test type: BENCHMARK` |
 | `NOT_FOUND` | 404 | Resource doesn't exist | `Test not found: abc-123` |
-| `ALREADY_EXISTS` | 409 | Name collision | `Schedule 'Nightly Load' already exists` |
-| `FAILED_PRECONDITION` | 409 | State conflict | `Test already running on topic 'perf-test'` |
-| `UNAVAILABLE` | 503 | Backend unreachable | `Kafka cluster unreachable` |
-| `INTERNAL` | 500 | Server failure | `Thread pool exhausted` |
+| `INTERNAL` | 500 | Test execution failure (underlying exception message) | `Backend not found: 'trogdor'. Available: [native]` |
+
+Transport-level codes such as `UNAVAILABLE` come from the gRPC runtime itself (e.g. when the server cannot be reached), not from Kates.
 
 **Error output format:**
 
@@ -323,10 +323,10 @@ ERROR:
 | `POST /api/tests` | `TestService/CreateTest` |
 | `GET /api/tests/{id}` | `TestService/GetTest` |
 | `GET /api/tests` | `TestService/ListTests` |
-| *(polling)* | `TestService/StreamTestStatus` |
 | `POST /api/tests/{id}/cancel` | `TestService/CancelTest` |
 | `DELETE /api/tests/{id}` | `TestService/DeleteTest` |
-| `GET /api/cluster` | `ClusterService/GetClusterInfo` |
+| `GET /api/cluster/info` | `ClusterService/GetClusterInfo` |
+| `GET /api/cluster/topology` | `ClusterService/GetClusterTopology` |
 | `GET /api/cluster/topics` | `ClusterService/ListTopics` |
 | `GET /api/cluster/topics/{name}` | `ClusterService/GetTopicDetail` |
 | `GET /api/cluster/groups` | `ClusterService/ListConsumerGroups` |
@@ -355,5 +355,5 @@ The proto file is bundled at `kates/src/main/proto/kates.proto`.
 
 ## See Also
 
-- [Chapter 10: CLI Reference](10-cli-reference.md) — Interactive CLI that wraps both REST and gRPC APIs
+- [Chapter 10: CLI Reference](10-cli-reference.md) — Interactive CLI that wraps the REST API
 - [Chapter 11: REST API Reference](11-api-reference.md) — JSON/HTTP alternative for curl-based scripting and browser access

--- a/docs/book/17-security.md
+++ b/docs/book/17-security.md
@@ -81,7 +81,7 @@ Each listener enforces a specific authentication mechanism. The choice of listen
 | Listener | Port | Auth | Protocol | Clients | When to Use |
 |----------|------|------|----------|---------|-------------|
 | `plain` | 9092 | SCRAM-SHA-512 | SASL_PLAINTEXT | Kates, Kafka UI, Apicurio | Performance testing baselines (no TLS overhead) |
-| `tls` | 9093 | mTLS (certificate) | SASL_SSL | Encrypted internal | When you need wire encryption between services |
+| `tls` | 9093 | mTLS (certificate) | SSL | Encrypted internal | When you need wire encryption between services |
 | `external` | 9094 | SCRAM-SHA-512 | SASL_SSL | External tools, CI | Access from outside the Kubernetes cluster |
 
 ### SCRAM-SHA-512
@@ -172,10 +172,12 @@ Kafka uses **simple ACL authorization** with principal-based access control:
 
 ```mermaid
 graph LR
-    User[KafkaUser] -->|"maps to"| Principal["Principal<br/>CN=user-name"]
+    User[KafkaUser] -->|"maps to"| Principal["Principal<br/>User:user-name"]
     Principal -->|"checked against"| ACL["ACL Rules<br/>(resource, operation, host)"]
     ACL -->|"allows/denies"| Resource["Topic / Group / Cluster"]
 ```
+
+A `KafkaUser` authenticating with SCRAM-SHA-512 maps to the principal `User:<username>`. Only users with `authentication.type: tls` get certificate-based principals, whose name is the certificate's Distinguished Name (e.g., `User:CN=my-service`).
 
 Every Kafka operation (produce, consume, describe, create, delete) is checked against the ACL list. If no matching rule is found, the operation is denied by default. This is a **deny-by-default** model — you must explicitly grant every permission.
 
@@ -183,10 +185,11 @@ Every Kafka operation (produce, consume, describe, create, delete) is checked ag
 
 | User | Principal | Access Level | Resources | Quotas |
 |------|-----------|-------------|-----------|--------|
-| `kates-backend` | CN=kates-backend | **superUser** | All (bypasses ACLs) | None |
-| `kafka-ui` | CN=kafka-ui | Read-only | All topics, all groups, cluster describe | 1MB/s produce, 50MB/s consume |
-| `apicurio-registry` | CN=apicurio-registry | Scoped R/W | `__apicurio*` topics, `apicurio*` groups | 10MB/s produce, 20MB/s consume |
-| `litmus-chaos` | CN=litmus-chaos | Full CRUD | All topics, `litmus*` groups, cluster describe | None |
+| `kates-backend` | User:kates-backend | **superUser** | All (bypasses ACLs) | None |
+| `kafka-ui` | User:kafka-ui | Read-only | All topics, all groups, cluster describe | 1MB/s produce, 50MB/s consume |
+| `apicurio-registry` | User:apicurio-registry | Scoped R/W | `__apicurio*`, `kafkasql-*`, `registry-*` topics, `apicurio*` groups | 10MB/s produce, 20MB/s consume |
+| `litmus-chaos` | User:litmus-chaos | Full CRUD | All topics, `litmus*` groups, cluster describe | None |
+| `kates-connect` | User:kates-connect | Scoped R/W | `kates-*`, `cdc*` topics, `kates-connect*`, `connect-*` groups | 50MB/s produce, 50MB/s consume |
 
 ::: {.callout-note}
 The `kates-backend` user has superUser status because it needs to create test topics, manage consumer groups, and read cluster metadata during benchmark runs. In a production deployment, you would scope this down to only the specific topics and operations Kates requires.
@@ -286,10 +289,10 @@ graph TD
     ClusterCA --> ControllerCert["Controller Certs"]
     ClusterCA --> CCCert["Cruise Control Cert"]
 
-    ClientsCA["Clients CA<br/>5yr validity<br/>Renew 180d before expiry"] --> UserCert1["kates-backend cert"]
-    ClientsCA --> UserCert2["kafka-ui cert"]
-    ClientsCA --> UserCert3["apicurio-registry cert"]
+    ClientsCA["Clients CA<br/>5yr validity<br/>Renew 180d before expiry"] --> UserCert["Client certs for KafkaUsers<br/>with authentication.type: tls"]
 ```
+
+The Clients CA issues certificates only for `KafkaUser` resources with `authentication.type: tls`. The default managed users all authenticate with SCRAM-SHA-512, so they receive password Secrets rather than client certificates.
 
 | Property | Value | Purpose |
 |----------|-------|---------|
@@ -323,42 +326,52 @@ Set up a Prometheus alert for certificates expiring within 30 days:
     description: "Secret {{ $labels.secret }} in namespace {{ $labels.namespace }} will expire soon. Trigger a certificate renewal."
 ```
 
+::: {.callout-caution}
+This alert is an approximation, not a measurement of the certificate itself. `kube_secret_created` reports when the Secret was **first created** — not the certificate's `NotAfter` date — and the hardcoded `157680000` seconds mirrors the chart's 1825-day CA validity (`clusterCa.validityDays`). Strimzi renews certificates by updating the Secret in place, so the metric never resets: after the first in-place renewal the alert fires permanently, and it drifts silently if you change the validity period. Treat the `openssl x509 -noout -dates` check above as the source of truth.
+:::
+
+
 ## Audit Logging
 
-Kafka provides configurable audit logging for tracking who accessed what, and when. To enable audit logging on the krafter cluster, add the following to your Kafka CR's `config` section:
+Kafka's authorizer can log every authorization decision — who accessed what, and when. The authorizer itself is already configured on the krafter cluster: Strimzi derives it from `spec.kafka.authorization` (`type: simple`), and it does not allow `authorizer.class.name` to be set directly in the `config` section — unsupported keys placed there are filtered out. What you control is the log level of `kafka.authorizer.logger`, which lives under `spec.kafka.logging` in the Kafka CR:
 
 ```yaml
-config:
-  # Log all authorization decisions (allow and deny)
-  authorizer.class.name: org.apache.kafka.metadata.authorizer.StandardAuthorizer
-  # Log authorization decisions at DEBUG level
-  log4j.logger.kafka.authorizer.logger: "DEBUG, authorizerAppender"
+spec:
+  kafka:
+    logging:
+      type: inline
+      loggers:
+        rootLogger.level: INFO
+        # Kafka 4.x brokers use Log4j2: declare the logger by name, then set its level
+        logger.authorizer.name: kafka.authorizer.logger
+        logger.authorizer.level: DEBUG
 ```
 
-Once enabled, every produce, consume, and admin operation generates an audit entry that includes the principal, the resource, the operation, and the decision (ALLOWED or DENIED). These logs are invaluable during security incident investigations.
+At the default `INFO` level the authorizer logs denied operations only. At `DEBUG`, every produce, consume, and admin operation generates an audit entry that includes the principal, the resource, the operation, and the decision (ALLOWED or DENIED). These logs are invaluable during security incident investigations.
 
 ::: {.callout-tip}
-For lighter-weight auditing, Kates automatically logs all CLI operations to the `kates-audit` topic. You can inspect the audit trail with `kates kafka consume kates-audit --from-beginning`.
+For lighter-weight auditing, Kates records every mutating operation issued through the backend — test creates and deletes, topic changes, disruption runs — in its audit log. Inspect the trail with `kates audit`, filtering with `--type` and `--since`.
 :::
 
 
 ## Network Policies
 
-Network policies are your last line of defense. Even if an attacker compromises a pod in your cluster, network policies prevent that pod from reaching the Kafka brokers unless it's explicitly allowed. The `kafka` namespace enforces **default-deny** for both ingress and egress:
+Network policies are your last line of defense. Even if an attacker compromises a pod in your cluster, network policies prevent that pod from reaching the Kafka brokers unless it's explicitly allowed. The `kafka` namespace enforces **default-deny** ingress and egress on all Strimzi cluster pods (the policy selects the `app.kubernetes.io/part-of: strimzi-krafter` label rather than using an empty pod selector):
 
 ```mermaid
 graph TD
-    subgraph Default["default-deny (all pods)"]
+    subgraph Default["default-deny (Strimzi pods)"]
         DNS["allow-dns<br/>UDP/TCP 53"]
     end
 
     subgraph Broker Rules
         B1["kates namespace → 9092, 9093"]
-        B2["litmus namespace → 9092"]
-        B3["kafka-ui pod → 9092"]
-        B4["apicurio pod → 9092"]
-        B5["monitoring namespace → 9404"]
-        B6["any → 9094 (NodePort external)"]
+        B2["litmus namespace → 9092, 9093"]
+        B3["kafka-ui pod → 9092, 9093"]
+        B4["apicurio pod → 9092, 9093"]
+        B5["connect namespace → 9092, 9093"]
+        B6["monitoring namespace → 9404"]
+        B7["any → 9094 (NodePort external)"]
     end
 
     subgraph Controller Rules
@@ -366,7 +379,7 @@ graph TD
     end
 
     subgraph Operator Rules
-        O1["monitoring → 8080 (metrics)"]
+        O1["any → 8080 (kubelet probes, metrics)"]
         O2["operator → krafter pods"]
         O3["operator → K8s API (443, 6443)"]
     end
@@ -376,14 +389,18 @@ graph TD
 
 | Policy | Target | Ingress From | Ports |
 |--------|--------|-------------|-------|
-| `default-deny` | All pods | None | None |
-| `allow-dns` | All pods | — (egress only) | 53 UDP/TCP |
-| `kafka-brokers` | Broker pods | kates, litmus, kafka-ui, apicurio, monitoring | 9091–9094, 9404 |
-| `kafka-controllers` | Controller pods | krafter cluster pods | 9090, 9091 |
-| `strimzi-operator` | Operator pod | monitoring | 8080 |
+| `default-deny` | Strimzi cluster pods | None | None |
+| `allow-dns` | Strimzi cluster pods | — (egress only) | 53 UDP/TCP |
+| `kafka-brokers` | Broker pods | kates, litmus, kafka-ui, apicurio, connect, monitoring, operator | 9091–9094, 9404 |
+| `kafka-controllers` | Controller pods | krafter cluster pods, operator | 9090, 9091 |
+| `strimzi-operator` | Operator pod | Any (kubelet probes, metrics) | 8080 |
 | `kafka-ui` | Kafka UI pod | Any | 8080 |
 | `cruise-control` | CC pod | Operator, monitoring | 9090, 9404 |
 | `strimzi-drain-cleaner` | Drain Cleaner | Any (webhook) | 8443 |
+| `kafka-connect` | Connect pods | monitoring, kates | 8083, 9404 |
+| `kafka-mirror-maker` | MirrorMaker 2 pods | monitoring | 9404 |
+| `entity-operator` | Entity Operator pod | monitoring | 8080, 8081 |
+| `kafka-exporter` | Kafka Exporter pod | monitoring | 9404 |
 
 ### Testing Network Policies
 
@@ -436,6 +453,7 @@ Per-user quotas prevent denial-of-service from misbehaving clients. Without quot
 |------|:------------:|:------------:|:---------:|
 | `kafka-ui` | 1 MB/s | 50 MB/s | 10% |
 | `apicurio-registry` | 10 MB/s | 20 MB/s | 15% |
+| `kates-connect` | 50 MB/s | 50 MB/s | 25% |
 | `litmus-chaos` | Unlimited | Unlimited | Unlimited |
 
 ::: {.callout-note}
@@ -461,7 +479,7 @@ graph LR
 
 ### Cluster Policies
 
-Kates ships four `ClusterPolicy` resources, deployed conditionally when `kyvernoPolicy.enabled=true` in the Helm values:
+The kates chart ships four `ClusterPolicy` resources, deployed conditionally when `kyvernoPolicy.enabled=true` in the Helm values (the kafka-cluster and kates-chaos charts ship additional policies of their own):
 
 | Policy | Category | Severity | Description |
 |--------|----------|----------|-------------|
@@ -513,8 +531,7 @@ kyvernoPolicy:
       MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE...
       -----END PUBLIC KEY-----
     imagePatterns:
-      - "ghcr.io/bmscomp/kates-*"
-      - "ghcr.io/bmscomp/kates-tester*"
+      - "ghcr.io/bmscomp/*"
 ```
 
 When enabled, unsigned or tampered images from the specified registries are rejected at admission time. The policy also mutates image references to use digests (`mutateDigest: true`) for immutable deployments.
@@ -525,7 +542,7 @@ The `kates-generate-network-policies` policy implements **zero-trust networking*
 
 1. **`default-deny-ingress`** — blocks all inbound traffic
 2. **`default-deny-egress`** — blocks all outbound traffic
-3. **`allow-dns-egress`** — allows DNS resolution to `kube-system` on port 53
+3. **`allow-dns-egress`** — allows DNS egress on port 53 (UDP and TCP) to any namespace
 
 These policies are synchronized (`synchronize: true`) — Kyverno continuously reconciles them if they are manually deleted. This means even if someone accidentally (or maliciously) deletes the default-deny policies, they're automatically recreated.
 
@@ -537,6 +554,7 @@ Certain system and infrastructure namespaces are excluded from automatic Network
 |--------------------|--------|
 | `kube-system` | Core Kubernetes components |
 | `kube-public` | Public cluster metadata |
+| `kube-node-lease` | Node heartbeat Lease objects |
 | `kyverno` | Kyverno's own namespace |
 | `strimzi-operator` | Strimzi Operator requires API server and Kafka namespace egress |
 | `monitoring` | Prometheus must scrape metrics across all namespaces |

--- a/docs/book/18-upgrade-playbook.md
+++ b/docs/book/18-upgrade-playbook.md
@@ -16,34 +16,41 @@ graph LR
 
 ### Version Compatibility Matrix
 
-| Strimzi | Kafka (min) | Kafka (max) | KRaft |
-|:-------:|:-----------:|:-----------:|:-----:|
-| 0.49.0 | 3.7.0 | 3.9.0 | ✅ |
-| 0.50.0 | 3.8.0 | 4.0.0 | ✅ |
-| 1.0.0 | 3.9.0 | 4.1.1 | ✅ |
+Each Strimzi release supports only a narrow window of Kafka versions, and that window moves with every release — always check the [Strimzi supported versions](https://strimzi.io/downloads/) page before planning an upgrade. This repository pins its versions centrally:
+
+| Component | Pinned version | Source |
+|-----------|----------------|--------|
+| Strimzi operator | 1.0.0 | `STRIMZI_VERSION` in `versions.env` |
+| Kafka image | `quay.io/strimzi/kafka:1.0.0-kafka-4.2.0` | `STRIMZI_KAFKA_VERSION` in `versions.env` |
+| Chart default (`kafkaVersion`) | 4.2.0 | `charts/kafka-cluster/values.yaml` |
 
 ### Procedure
 
 **Step 1 — Backup:**
 
 ```bash
-# Create pre-upgrade backup
+# Ensure the Velero backup schedule exists
+# (config/kafka/kafka-backup.yaml defines the kafka-daily-backup Schedule)
 kubectl apply -f config/kafka/kafka-backup.yaml
 
-# Wait for backup completion
+# Take an ad-hoc pre-upgrade backup
+velero backup create kafka-pre-upgrade --include-namespaces kafka --wait
+
+# Confirm completion
 kubectl get backup kafka-pre-upgrade -n velero -o jsonpath='{.status.phase}'
 ```
 
 **Step 2 — Pre-flight validation:**
 
 ```bash
+# Record the current Kafka version for the post-upgrade comparison
+kubectl get kafka krafter -n kafka -o jsonpath='{.spec.kafka.version}'
+
 # Run baseline performance test
-kates test create --type LOAD --records 100000 --acks all --wait \
-  --label upgrade=pre --label version=$(kubectl get kafka krafter -n kafka \
-  -o jsonpath='{.spec.kafka.version}')
+kates test create --type LOAD --records 100000 --acks all --wait
 
 # Run integrity test
-kates test create --type INTEGRITY --records 50000 --wait --label upgrade=pre
+kates test create --type INTEGRITY --records 50000 --wait
 
 # Record the test IDs for post-upgrade comparison
 ```
@@ -72,19 +79,18 @@ kubectl get pods -n kafka -w
 # Watch Kafka status
 watch kubectl get kafka krafter -n kafka -o jsonpath='{.status.conditions[0].type}={.status.conditions[0].status}'
 
-# Check Strimzi operator logs
-kubectl logs deployment/strimzi-cluster-operator -n kafka -f
+# Check Strimzi operator logs (the operator runs in its own namespace)
+kubectl logs deployment/strimzi-cluster-operator -n strimzi-operator -f
 ```
 
 **Step 5 — Post-upgrade validation:**
 
 ```bash
 # Re-run baseline tests
-kates test create --type LOAD --records 100000 --acks all --wait \
-  --label upgrade=post --label version=4.1.1
+kates test create --type LOAD --records 100000 --acks all --wait
 
 # Compare pre vs post
-kates report diff <pre-id> <post-id>
+kates report compare <pre-id>,<post-id>
 
 # Run full GameDay
 make gameday
@@ -92,16 +98,7 @@ make gameday
 
 ### Rollback
 
-```bash
-# Revert the version in kafka.yaml
-spec:
-  kafka:
-    version: <previous-version>
-
-kubectl apply -f config/kafka/kafka.yaml
-```
-
-Strimzi will roll back one broker at a time.
+Revert `spec.kafka.version` in `config/kafka/kafka.yaml` and re-apply — Strimzi rolls the brokers back one at a time. See [Kafka Version Rollback](#kafka-version-rollback) under Rollback Procedures for the full procedure and the KRaft metadata caveat.
 
 ## Strimzi Operator Upgrade
 
@@ -109,31 +106,29 @@ Strimzi will roll back one broker at a time.
 
 **Step 1 — Check release notes** for breaking changes at [Strimzi releases](https://github.com/strimzi/strimzi-kafka-operator/releases).
 
-**Step 2 — Upgrade via Helm:**
+**Step 2 — Upgrade via Helm.** The operator is installed from the OCI chart as the `strimzi-operator` release in its own `strimzi-operator` namespace (see `scripts/deploy-kafka.sh`):
 
 ```bash
-helm repo update strimzi
-
-helm upgrade strimzi-kafka-operator strimzi/strimzi-kafka-operator \
+helm upgrade strimzi-operator oci://quay.io/strimzi-helm/strimzi-kafka-operator \
   --version <new-version> \
-  --namespace kafka \
+  --namespace strimzi-operator \
   --reuse-values
 ```
 
 **Step 3 — Verify:**
 
 ```bash
-kubectl get pods -n kafka | grep strimzi-cluster-operator
-kubectl logs deployment/strimzi-cluster-operator -n kafka --tail=20
+kubectl get pods -n strimzi-operator
+kubectl logs deployment/strimzi-cluster-operator -n strimzi-operator --tail=20
 ```
 
 ### Post-Upgrade — API Migration
 
-Strimzi periodically deprecates API versions. When upgrading to a version that drops `v1beta2`:
+Strimzi periodically deprecates API versions. The manifests in this repository already use `kafka.strimzi.io/v1` (see `config/kafka/kafka.yaml`). When a future Strimzi release drops an API version your manifests still use, migrate them in bulk — this is the pattern used for the `v1beta2` → `v1` migration:
 
 ```bash
-# Update all CRDs to v1
-sed -i '' 's|kafka.strimzi.io/v1beta2|kafka.strimzi.io/v1|g' \
+# GNU sed; on macOS use `sed -i ''` instead of `sed -i`
+sed -i 's|kafka.strimzi.io/v1beta2|kafka.strimzi.io/v1|g' \
   config/kafka/kafka.yaml \
   config/kafka/kafka-users.yaml \
   config/kafka/kafka-topics.yaml \
@@ -144,12 +139,14 @@ kubectl apply -f config/kafka/
 
 ## Drain Cleaner Upgrade
 
+Drain Cleaner is not a standalone Helm release in this repository — it is deployed by the `kafka-cluster` chart (`charts/kafka-cluster/templates/drain-cleaner.yaml`) when `drainCleaner.enabled` is true (the prod values enable it), with the image pinned by the `drainCleaner.image` value (default `quay.io/strimzi/drain-cleaner:1.0.0`). To upgrade it, bump the image tag and re-deploy the chart:
+
 ```bash
-helm upgrade strimzi-drain-cleaner strimzi/strimzi-drain-cleaner \
-  --version <new-version> \
-  --namespace kafka \
-  --set certManager.create=false \
-  --set image.imagePullPolicy=IfNotPresent
+# Update drainCleaner.image in charts/kafka-cluster/values.yaml, then:
+make kafka-upgrade
+
+# Verify
+kubectl get pods -n kafka -l app=strimzi-drain-cleaner
 ```
 
 ## Kates Application Upgrade
@@ -161,7 +158,8 @@ helm upgrade strimzi-drain-cleaner strimzi/strimzi-drain-cleaner \
 make kates-build
 
 # Rolling restart
-make kates-redeploy
+kubectl rollout restart deployment/kates -n kates
+kubectl rollout status deployment/kates -n kates --timeout=300s
 ```
 
 ### Native Image Mode
@@ -177,11 +175,13 @@ kubectl logs deployment/kates -n kates | head -1
 
 ## Monitoring Stack Upgrade
 
+The `monitoring` release is installed into the `kafka` namespace (see the `monitoring` target in the Makefile):
+
 ```bash
-helm dependency update charts/monitoring
+helm dependency build charts/monitoring
 
 helm upgrade monitoring charts/monitoring \
-  --namespace monitoring \
+  --namespace kafka \
   --reuse-values
 ```
 
@@ -196,11 +196,13 @@ Kyverno upgrades require special attention because admission webhooks are in the
 **Step 2 — Upgrade the Kyverno CRDs first:**
 
 ```bash
-# Download and apply the latest CRDs before upgrading the controller
-kubectl apply -f https://raw.githubusercontent.com/kyverno/kyverno/main/config/crds/kyverno/kyverno.io_clusterpolicies.yaml
-kubectl apply -f https://raw.githubusercontent.com/kyverno/kyverno/main/config/crds/kyverno/kyverno.io_policyexceptions.yaml
-kubectl apply -f https://raw.githubusercontent.com/kyverno/kyverno/main/config/crds/policyreport/wgpolicyk8s.io_clusterpolicyreports.yaml
-kubectl apply -f https://raw.githubusercontent.com/kyverno/kyverno/main/config/crds/policyreport/wgpolicyk8s.io_policyreports.yaml
+# Pin to the release tag you are upgrading to — never `main`
+KYVERNO_TAG=<release-tag>   # e.g. from https://github.com/kyverno/kyverno/releases
+
+kubectl apply -f https://raw.githubusercontent.com/kyverno/kyverno/${KYVERNO_TAG}/config/crds/kyverno/kyverno.io_clusterpolicies.yaml
+kubectl apply -f https://raw.githubusercontent.com/kyverno/kyverno/${KYVERNO_TAG}/config/crds/kyverno/kyverno.io_policyexceptions.yaml
+kubectl apply -f https://raw.githubusercontent.com/kyverno/kyverno/${KYVERNO_TAG}/config/crds/policyreport/wgpolicyk8s.io_clusterpolicyreports.yaml
+kubectl apply -f https://raw.githubusercontent.com/kyverno/kyverno/${KYVERNO_TAG}/config/crds/policyreport/wgpolicyk8s.io_policyreports.yaml
 ```
 
 ::: {.callout-warning}
@@ -254,12 +256,12 @@ After upgrading Kyverno, verify that existing `PolicyException` resources are st
 # List all PolicyExceptions
 kubectl get policyexceptions -A
 
-# Verify no exceptions are in an error state
-kubectl get policyexceptions -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}: {.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}'
+# Check which API version each exception is stored as
+kubectl get policyexceptions -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}: {.apiVersion}{"\n"}{end}'
 ```
 
 ::: {.callout-important}
-Kyverno v2 introduced the `PolicyException` CRD with a different API shape than v1 exceptions. When upgrading from Kyverno 1.x to 2.x, migrate any existing exception configurations to the new `kyverno.io/v2` API. Refer to the [Kyverno migration guide](https://kyverno.io/docs/upgrading/) for details.
+The `PolicyException` API was introduced in Kyverno 1.9 and has moved through several API versions since (`kyverno.io/v2alpha1` → `v2beta1` → `v2`). After upgrading Kyverno, make sure your exceptions use an API version the new release still serves — alpha and beta versions are dropped over time. Check the [Kyverno release notes](https://github.com/kyverno/kyverno/releases) for API deprecations before upgrading.
 :::
 
 
@@ -268,7 +270,7 @@ Kyverno v2 introduced the `PolicyException` CRD with a different API shape than 
 Run through this before any upgrade:
 
 - [ ] Velero backup completed successfully
-- [ ] Baseline performance test recorded (with `--label upgrade=pre`)
+- [ ] Baseline performance test recorded (note the test ID for the post-upgrade comparison)
 - [ ] Integrity test passed (zero data loss)
 - [ ] All brokers in Running state
 - [ ] Kafka CR status is `Ready: True`
@@ -326,18 +328,18 @@ watch kubectl get kafka krafter -n kafka -o jsonpath='{.status.conditions[0].typ
 
 ```bash
 # Verify broker version
-kubectl exec krafter-kafka-0 -n kafka -- /opt/kafka/bin/kafka-broker-api-versions.sh \
+kubectl exec krafter-brokers-alpha-0 -n kafka -- /opt/kafka/bin/kafka-broker-api-versions.sh \
   --bootstrap-server localhost:9092 | head -1
 
 # Run integrity test
-kates test create --type INTEGRITY --records 50000 --wait --label rollback=kafka
+kates test create --type INTEGRITY --records 50000 --wait
 
 # Verify no data loss
 kates test get <id>
 ```
 
 ::: {.callout-warning}
-Kafka version rollback is **NOT possible** after upgrading the KRaft metadata format (`kafka-storage.sh format` with a newer metadata version). KRaft metadata format changes are irreversible — the brokers cannot read older metadata formats. Always test the new version thoroughly in staging before upgrading the metadata format in production.
+Kafka version rollback is **NOT possible** once the KRaft metadata version has been raised. Strimzi controls this through `spec.kafka.metadataVersion` in the Kafka CR (exposed as `kafka.metadataVersion` in the `kafka-cluster` chart values): upgrade the broker `version` first while leaving `metadataVersion` at the previous level — in that state a rollback is still possible. Once you raise `metadataVersion`, the brokers can no longer read the older metadata format and downgrade is irreversible. Only bump `metadataVersion` after the new version has passed validation.
 :::
 
 
@@ -347,17 +349,17 @@ Kafka version rollback is **NOT possible** after upgrading the KRaft metadata fo
 
 ```bash
 # List Helm history
-helm history strimzi-kafka-operator -n kafka
+helm history strimzi-operator -n strimzi-operator
 
 # Rollback to previous revision
-helm rollback strimzi-kafka-operator <previous-revision> -n kafka
+helm rollback strimzi-operator <previous-revision> -n strimzi-operator
 ```
 
 **Step 2 — Verify the operator is running:**
 
 ```bash
-kubectl get pods -n kafka | grep strimzi-cluster-operator
-kubectl logs deployment/strimzi-cluster-operator -n kafka --tail=20
+kubectl get pods -n strimzi-operator
+kubectl logs deployment/strimzi-cluster-operator -n strimzi-operator --tail=20
 ```
 
 **Step 3 — Post-rollback validation:**
@@ -367,7 +369,7 @@ kubectl logs deployment/strimzi-cluster-operator -n kafka --tail=20
 kubectl get kafka,kafkatopic,kafkauser -n kafka
 
 # Run a quick smoke test
-kates test create --type LOAD --records 10000 --wait --label rollback=strimzi
+kates test create --type LOAD --records 10000 --wait
 ```
 
 ::: {.callout-warning}
@@ -407,7 +409,7 @@ kates cluster check
 kates schedule list
 
 # Run a baseline test
-kates test create --type LOAD --records 50000 --wait --label rollback=kates
+kates test create --type LOAD --records 50000 --wait
 ```
 
 ### Rollback Decision Matrix

--- a/docs/book/19-multi-tenancy.md
+++ b/docs/book/19-multi-tenancy.md
@@ -64,6 +64,8 @@ Each tenant gets:
 
 ### Step 1 — Define Topics
 
+Tenant topics are declared alongside the platform topics in `config/kafka/kafka-topics.yaml`:
+
 ```yaml
 apiVersion: kafka.strimzi.io/v1
 kind: KafkaTopic
@@ -100,6 +102,8 @@ spec:
 ```
 
 ### Step 2 — Create User with Scoped ACLs
+
+Add the user to `config/kafka/kafka-users.yaml`:
 
 ```yaml
 apiVersion: kafka.strimzi.io/v1
@@ -138,7 +142,7 @@ spec:
 Add the service's namespace to the broker NetworkPolicy:
 
 ```yaml
-# In kafka-networkpolicies.yaml, under kafka-brokers ingress
+# In config/kafka/kafka-networkpolicies.yaml, under kafka-brokers ingress
 - from:
     - namespaceSelector:
         matchLabels:
@@ -219,7 +223,7 @@ When a client exceeds its quota, the broker delays its response by a calculated 
 | Consumer parallelism | Partitions ≥ max expected consumers |
 | Throughput | More partitions = more parallel I/O |
 | Broker count | At least = broker count for even spread |
-| Overhead | Each partition costs ~10KB of metadata and file handles |
+| Overhead | Each partition adds controller metadata and open file handles on every replica |
 
 **Recommended sizing:**
 
@@ -275,97 +279,75 @@ flowchart TD
 
 ### Quick-Start Script
 
-Automate the onboarding steps with the Kates CLI:
+There is no dedicated CLI command for tenant onboarding — the workflow is declarative. Append the tenant's `KafkaTopic`, `KafkaUser`, and NetworkPolicy entries to the files in `config/kafka/`, then apply and verify:
 
 ```bash
-# Onboard a new service in one command
-kates tenant onboard my-service \
-  --produce-rate 10MB \
-  --consume-rate 20MB \
-  --cpu-percent 15 \
-  --topics events,commands,dlq \
-  --namespace my-service-namespace
+# Apply the tenant's declarative resources
+kubectl apply -f config/kafka/kafka-topics.yaml
+kubectl apply -f config/kafka/kafka-users.yaml
+kubectl apply -f config/kafka/kafka-networkpolicies.yaml
 
-# Verify the onboarding
-kates tenant verify my-service
-```
+# Wait for the User Operator to reconcile the credentials
+kubectl wait kafkauser/my-service --for=condition=Ready -n kafka --timeout=60s
 
-Expected output:
-
-```
-  ▸ Onboarding: my-service
-    ✓ KafkaUser created (scram-sha-512)
-    ✓ ACLs configured (prefix: my-service)
-    ✓ Quotas set (produce=10MB/s, consume=20MB/s, cpu=15%)
-    ✓ Topics created: my-service-events, my-service-commands, my-service-dlq
-    ✓ Secret generated: my-service (namespace: kafka)
-    ✓ NetworkPolicy updated
-    ✓ Connectivity verified (produce + consume OK)
-  Tenant my-service is ready ✅
+# Confirm the generated secret and topics
+kubectl get secret my-service -n kafka
+kubectl get kafkatopic -n kafka -l app.kubernetes.io/part-of=my-service
 ```
 
 ## Quota Monitoring
 
-Use these PromQL queries to track per-tenant resource usage and detect quota breaches before they impact application performance.
+Kafka's per-user quota and throttle-time MBeans are not mapped by the JMX exporter rules in `config/kafka/kafka-metrics.yaml`, so there are no per-user Prometheus metrics in this setup. Tenant usage is tracked indirectly — by topic prefix and consumer group.
 
-### Per-User Bandwidth Monitoring
+### Per-Tenant Bandwidth Monitoring
 
 ```promql
-# Produce bandwidth per user (bytes/sec)
-sum by (user) (
-  rate(kafka_server_fetch_session_cache_metrics_produce_throttle_time_total{user=~".+"}[5m])
-) > 0
+# Produce bandwidth per tenant topic (bytes/sec)
+sum by (topic) (
+  rate(kafka_server_brokertopicmetrics_bytesin_total{topic=~"my-service.*"}[5m])
+)
 
-# Actual produce rate vs quota — shows how close each user is to their limit
-rate(kafka_server_brokertopicmetrics_bytesin_total{topic=~"my-service.*"}[5m])
-  / on() group_left() (10 * 1024 * 1024)  # divide by quota (10MB/s)
+# Fraction of the tenant's 10MB/s produce quota in use
+sum(rate(kafka_server_brokertopicmetrics_bytesin_total{topic=~"my-service.*"}[5m]))
+  / (10 * 1024 * 1024)
 ```
 
-### Per-User CPU Usage
+### Request Handler Saturation
+
+The `requestPercentage` quota is enforced per user inside the broker, but only the pool-wide utilization is exported:
 
 ```promql
-# Request handler utilization per user (percentage of broker request handler pool)
-sum by (user) (
-  rate(kafka_server_request_handler_pool_usage{user=~".+"}[5m])
-) * 100
+# Broker request handler idle percentage (shared across all tenants)
+kafka_server_kafkarequesthandlerpool_requesthandleravgidlepercent
 ```
 
 ### Throttling Detection
 
-```promql
-# Detect users being actively throttled (produce or fetch)
-sum by (user) (
-  rate(kafka_server_throttle_time_total{user=~".+"}[5m])
-) > 0
-```
+Broker-side throttle-time metrics are not exported by the current JMX rules. Quota throttling surfaces client-side instead: the broker delays responses, so a throttled tenant sees increased produce/fetch latency without errors (see the quota enforcement diagram above).
 
-### Grafana Alert Rules
+### Alert Rules
 
-Set up alerts for quota breaches:
+The cluster's alerts are defined as a `PrometheusRule` in `config/kafka/kafka-alerts.yaml`. Two of them catch tenant-level problems:
 
 ```yaml
-# In your Grafana alert rules
-groups:
-  - name: kafka-tenant-quotas
-    rules:
-      - alert: TenantNearQuotaLimit
-        expr: |
-          sum by (user) (rate(kafka_server_brokertopicmetrics_bytesin_total[5m]))
-          / on(user) group_left() kafka_user_quota_produce_bytes_rate > 0.8
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          summary: "Tenant {{ $labels.user }} is using >80% of produce quota"
+# From config/kafka/kafka-alerts.yaml
+- alert: KafkaConsumerGroupLag
+  expr: kafka_consumergroup_lag_sum > 1000000
+  for: 15m
+  labels:
+    severity: warning
+  annotations:
+    summary: "Consumer group lag exceeds threshold"
+    description: "Consumer group {{ $labels.consumergroup }} has {{ $value }} messages lag."
 
-      - alert: TenantThrottled
-        expr: |
-          sum by (user) (rate(kafka_server_throttle_time_total[5m])) > 0
-        for: 10m
-        labels:
-          severity: warning
-        annotations:
-          summary: "Tenant {{ $labels.user }} is being throttled for >10 minutes"
+- alert: KafkaRequestHandlerSaturated
+  expr: kafka_server_kafkarequesthandlerpool_requesthandleravgidlepercent < 0.3
+  for: 10m
+  labels:
+    severity: warning
+  annotations:
+    summary: "Kafka request handlers over 70% busy"
+    description: "Broker {{ $labels.kubernetes_pod_name }} handler idle is {{ $value | humanizePercentage }} — consider adding threads or brokers."
 ```
 
 ## Decommissioning a Tenant
@@ -378,7 +360,7 @@ kubectl delete kafkauser my-service -n kafka
 kubectl delete kafkatopic -n kafka -l app.kubernetes.io/part-of=my-service
 
 # 3. Remove NetworkPolicy entry for the namespace
-# Edit kafka-networkpolicies.yaml and re-apply
+# Edit config/kafka/kafka-networkpolicies.yaml and re-apply
 
 # 4. Verify cleanup
 kubectl get kafkauser,kafkatopic -n kafka | grep my-service

--- a/docs/book/20-installation-guide.md
+++ b/docs/book/20-installation-guide.md
@@ -95,7 +95,9 @@ You should see the Kyverno admission controller, background controller, cleanup 
 
 **How Kyverno integrates with Kates:**
 
-When `kyvernoPolicy.enabled=true` is set in the kafka-cluster Helm chart values, the chart deploys four `ClusterPolicy` resources that leverage Kyverno's admission webhooks:
+When `podSecurityPolicy.enabled=true` is set in the kafka-cluster Helm chart values, the chart deploys the `kafka-pod-security-standards` `ClusterPolicy`, which mutates and validates workloads to enforce restricted Pod Security Standards — non-root, drop ALL capabilities, seccomp `RuntimeDefault`, no privilege escalation, no host namespaces.
+
+The Kates backend chart (`charts/kates`) ships additional `ClusterPolicy` resources, enabled via its own `kyvernoPolicy.*` values:
 
 | Policy | What It Does |
 |--------|-------------|
@@ -105,7 +107,7 @@ When `kyvernoPolicy.enabled=true` is set in the kafka-cluster Helm chart values,
 | `kates-generate-network-policies` | Automatically generates default-deny NetworkPolicies in new namespaces |
 
 ::: {.callout-tip}
-Start with `kyvernoPolicy.action: Audit` (the default) to observe policy violations without blocking deployments. Switch to `Enforce` once you're confident all workloads comply. See [Chapter 17: Security & Compliance](17-security.md) for details on each policy.
+Start with `podSecurityPolicy.action: Audit` (the default) to observe policy violations without blocking deployments. Switch to `Enforce` once you're confident all workloads comply. See [Chapter 17: Security & Compliance](17-security.md) for details on each policy.
 :::
 
 
@@ -213,23 +215,24 @@ done
 
 **What this does:** Creates three StorageClasses, one per availability zone. The `WaitForFirstConsumer` binding mode ensures PVCs are bound only after a pod is scheduled, respecting node affinity.
 
-### 3.2 Step 2 — Add the Strimzi Helm Repository
+### 3.2 Step 2 — Install the Strimzi Operator
 
-The kafka-cluster chart has a **dependency** on the Strimzi operator chart. Helm needs to know where to find it:
+The kafka-cluster chart creates Strimzi custom resources, but it does **not** bundle the Strimzi operator — the operator must already be running in the cluster. If you deploy with `kates deploy` (section 3.4), the CLI installs the operator for you. To install it manually:
 
 ```bash
-helm repo add strimzi https://strimzi.io/charts/
-helm repo update
+helm upgrade --install strimzi-operator oci://quay.io/strimzi-helm/strimzi-kafka-operator \
+  --version 1.0.0 \
+  --namespace strimzi-operator --create-namespace \
+  --set watchAnyNamespace=true \
+  --wait
 ```
 
-Then download the dependency:
+The chart's only Helm dependency is the optional SeaweedFS subchart, whose packaged archive (`charts/seaweedfs-3.68.0.tgz`) ships with the repository. To re-download it:
 
 ```bash
 cd charts/kafka-cluster
 helm dependency update
 ```
-
-This creates a `charts/strimzi-kafka-operator-1.0.0.tgz` file inside the chart directory. Helm will install the operator automatically when you install the chart.
 
 ### 3.3 Step 3 — Review and Customize Values
 
@@ -239,11 +242,13 @@ The chart ships with sensible defaults in `values.yaml`, but you should review k
 
 ```yaml
 clusterName: krafter       # Name of the Kafka cluster
-kafkaVersion: "4.1.1"      # Apache Kafka version
+kafkaVersion: "4.2.0"      # Apache Kafka version
 strimziVersion: "1.0.0"   # Strimzi operator version
 ```
 
 **Broker pools — define one pool per availability zone:**
+
+In the shipped `values.yaml`, `brokerPools` and `controllerPools` default to empty lists — run `kates detect --generate-values` to generate zone-matched pools for your cluster, or define them manually:
 
 ```yaml
 brokerPools:
@@ -287,8 +292,8 @@ The `kates deploy` command handles Strimzi operator installation, values file de
 # Detect your cluster topology and deploy
 kates deploy --topology isolated
 
-# With high availability (3 broker replicas per pool)
-kates deploy --topology isolated --ha
+# High availability (multi-AZ) is enabled by default; disable it for small clusters
+kates deploy --topology isolated --ha=false
 
 # Deploy Kafka + Kafka Connect in one shot
 kates deploy --topology isolated --with-kafka-connect
@@ -308,9 +313,7 @@ Use `kates deploy` for interactive development. Use direct Helm commands (below)
 
 **Alternative — Direct Helm installation:**
 
-There are two installation modes, depending on whether the Strimzi operator is already installed.
-
-**Mode A — Install everything (operator + cluster) in one shot:**
+With the Strimzi operator already installed (section 3.2), install the chart:
 
 ```bash
 helm upgrade --install kafka-cluster charts/kafka-cluster \
@@ -320,22 +323,17 @@ helm upgrade --install kafka-cluster charts/kafka-cluster \
   --wait
 ```
 
-This installs the Strimzi operator as a subchart and then creates all Kafka resources. The `--wait` flag tells Helm to block until all deployments are ready.
+The `--wait` flag tells Helm to block until all deployments are ready.
 
-**Mode B — Operator already installed (e.g., shared cluster):**
+If the Strimzi CRDs are managed externally (e.g., by a cluster admin), skip the chart's CRD upgrade hook:
 
 ```bash
 helm upgrade --install kafka-cluster charts/kafka-cluster \
   --namespace kafka \
-  --set strimziOperator.enabled=false \
   --set crdUpgrade.enabled=false \
   --timeout 600s \
   --wait
 ```
-
-Setting `strimziOperator.enabled=false` skips the operator subchart. This is the correct mode when:
-- A cluster admin already installed Strimzi at the cluster level
-- You're upgrading only the Kafka cluster resources
 
 ### 3.5 Step 5 — Watch the Deployment
 
@@ -345,11 +343,7 @@ After `helm install` or `helm upgrade` starts, open a second terminal and watch 
 kubectl get pods -n kafka -w
 ```
 
-Or use the kates CLI which shows deployment progress automatically:
-
-```bash
-kates kafka status
-```
+If you deployed with `kates deploy`, the CLI already shows per-component deployment progress in its own UI.
 
 You should see pods appear in this order:
 
@@ -459,27 +453,44 @@ krafter-kafka-bootstrap.kafka.svc:9093  (TLS + mTLS)
 Example — connect from a debug pod:
 
 ```bash
-kubectl run kafka-debug -it --rm --image=quay.io/strimzi/kafka:latest-kafka-4.1.1 \
+# Get the SCRAM password first (you'll paste it into the client config below):
+kubectl get secret kates-backend -n kafka -o jsonpath='{.data.password}' | base64 -d
+
+kubectl run kafka-debug -it --rm --image=quay.io/strimzi/kafka:latest-kafka-4.2.0 \
   -n kafka -- /bin/bash
 
-# Inside the pod:
+# Inside the pod — create the client config with the SCRAM credentials:
+cat > /tmp/client.properties <<'EOF'
+security.protocol=SASL_PLAINTEXT
+sasl.mechanism=SCRAM-SHA-512
+sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="kates-backend" password="<password>";
+EOF
+
 bin/kafka-topics.sh --bootstrap-server krafter-kafka-bootstrap:9092 --list \
   --command-config /tmp/client.properties
 ```
 
 ### 5.2 From Outside the Cluster (NodePort)
 
-The `external` listener exposes Kafka on NodePort `32100`:
+The `external` listener is exposed as a NodePort service — Kubernetes assigns the port:
 
 ```bash
 # Get the node IP
 NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
 
+# Get the assigned NodePort of the external bootstrap service
+NODE_PORT=$(kubectl get service krafter-kafka-external-bootstrap -n kafka \
+  -o jsonpath='{.spec.ports[0].nodePort}')
+
+# Extract the cluster CA certificate
+kubectl get secret krafter-cluster-ca-cert -n kafka \
+  -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/ca.crt
+
 # Get the SCRAM password
 PASSWORD=$(kubectl get secret kates-backend -n kafka -o jsonpath='{.data.password}' | base64 -d)
 
 # Connect with kafkacat/kcat
-kcat -b ${NODE_IP}:32100 -X security.protocol=SASL_SSL \
+kcat -b ${NODE_IP}:${NODE_PORT} -X security.protocol=SASL_SSL \
   -X sasl.mechanism=SCRAM-SHA-512 \
   -X sasl.username=kates-backend \
   -X sasl.password=${PASSWORD} \
@@ -636,7 +647,7 @@ graph TD
             BNP["KafkaNodePool: brokers ×3"]
         end
         subgraph "Data Management"
-            T["KafkaTopic ×7"]
+            T["KafkaTopic ×8"]
             U["KafkaUser ×5"]
             RB["KafkaRebalance ×2"]
         end
@@ -649,7 +660,7 @@ graph TD
         subgraph "Security"
             NP["NetworkPolicy ×12"]
             SA["ServiceAccount + RBAC"]
-            KP["Kyverno ClusterPolicy ×4"]
+            KP["Kyverno ClusterPolicy"]
         end
         subgraph "Operations"
             DC["Drain Cleaner"]
@@ -672,7 +683,7 @@ Every template file in the chart and what it produces:
 | `kafka.yaml` | `Kafka` CR (cluster spec, listeners, CA, entity operator, Cruise Control, exporter) | Always |
 | `nodepool-controllers.yaml` | `KafkaNodePool` for controller pods (one per zone) | `controllerPools[]` |
 | `nodepool-brokers.yaml` | `KafkaNodePool` for broker pods (one per zone) | `brokerPools[]` |
-| `topics.yaml` | `KafkaTopic` × 7 (managed topic declarations) | `topics.enabled` |
+| `topics.yaml` | `KafkaTopic` × 8 (managed topic declarations) | `topics.enabled` |
 | `users.yaml` | `KafkaUser` × 5 (SCRAM users with ACLs and quotas) | `users.enabled` |
 | `rebalance.yaml` | `KafkaRebalance` × 2 (`full-rebalance` + `add-broker-rebalance`) | `rebalance.enabled` |
 | `networkpolicies.yaml` | `NetworkPolicy` × 12 (default-deny, DNS, broker, controller, operator, etc.) | `networkPolicies.enabled` |
@@ -689,7 +700,7 @@ Every template file in the chart and what it produces:
 | `seaweedfs.yaml` | SeaweedFS subchart resources (master, volume, filer) | `seaweedfs.enabled` |
 | `backup.yaml` | Velero `Schedule`, `Backup`, optional `PVC` | `backup.enabled` |
 | `external-secrets.yaml` | `SecretStore`, `PushSecret`, `ExternalSecret` | `externalSecrets.enabled` |
-| `pod-security-policy.yaml` | Kyverno `ClusterPolicy` × 4 (PSS, workload, image, network) | `podSecurityPolicy.enabled` |
+| `pod-security-policy.yaml` | Kyverno `ClusterPolicy` (`kafka-pod-security-standards` — restricted PSS) | `podSecurityPolicy.enabled` |
 | `tests/test-connection.yaml` | 9 test `Pod` specs (Helm test hooks, tiers 1–9) | Always (test hooks) |
 | `tests/test-performance.yaml` | Performance benchmark test pod | Always (test hooks) |
 | `tests/test-profiler.yaml` | JFR profiler test pod | Always (test hooks) |
@@ -809,7 +820,7 @@ This section documents every default topic and user the chart creates. You rarel
 
 ### 10.1 Default Topics
 
-The chart creates 7 topics, each designed for a specific data pipeline:
+The chart creates 8 topics, each designed for a specific data pipeline:
 
 | Topic | Partitions | Replicas | Retention | Compression | Cleanup | Purpose |
 |-------|:----------:|:--------:|:---------:|:-----------:|:-------:|---------|
@@ -820,6 +831,7 @@ The chart creates 7 topics, each designed for a specific data pipeline:
 | `kates-dlq` | 3 | 3 | forever | — | compact | Dead letter queue for failed messages (compacted to keep latest per key) |
 | `cdc-schema-history` | 1 | 3 | forever | — | compact | Debezium schema history for CDC connectors |
 | `cdc-heartbeat` | 1 | 3 | 1 day | — | delete | CDC liveness heartbeats (detects stalled connectors) |
+| `test-sink-topic` | 3 | 3 | 1 day | — | delete | Sink target for Kafka Connect sink connector validation |
 
 **Why these specific configurations?**
 
@@ -850,10 +862,10 @@ The chart creates 5 users with different permission levels:
 
 Quotas prevent a single user from monopolizing cluster resources. For example, `kafka-ui` is limited to 1 MB/s produce because a monitoring dashboard should never produce significant data. The `requestPercentage` quota limits the percentage of broker request handler threads the user can consume.
 
-To list all users using the kates CLI:
+To list all users:
 
 ```bash
-kates kafka users
+kubectl get kafkausers -n kafka -l strimzi.io/cluster=krafter
 ```
 
 ### 10.3 User Secrets
@@ -1222,7 +1234,7 @@ backup:
 ```
 
 ::: {.callout-caution}
-Do **not** set `snapshotVolumes: true`. Broker PVC snapshots are crash-consistent and can corrupt data on restore. See the README section "Why NetBackup is Incompatible with Kafka" for the full rationale.
+Do **not** set `snapshotVolumes: true`. Broker PVC snapshots are crash-consistent and can corrupt data on restore. See the section "Why NetBackup is Incompatible with Kafka" in the chart's README (`charts/kafka-cluster/README.md`) for the full rationale.
 :::
 
 
@@ -1264,14 +1276,13 @@ externalSecrets:
 
 **Why they exist:** Kubernetes deprecated PodSecurityPolicies (PSP) in v1.25. The chart uses [Kyverno](https://kyverno.io/) ClusterPolicies as a modern replacement, enforcing Pod Security Standards (PSS) at the `restricted` level.
 
-**4 ClusterPolicies:**
+**The ClusterPolicy:**
 
 | Policy | Validates / Mutates | Key Rules |
 |--------|:-------------------:|-----------|
 | `kafka-pod-security-standards` | Both | Non-root, drop ALL capabilities, seccomp RuntimeDefault, no privilege escalation, no host namespaces |
-| `kates-workload-standards` | Validate | Required labels, health probes, pinned image tags |
-| `kates-image-verification` | Validate | Cosign signature verification from trusted registries |
-| `kates-generate-network-policies` | Generate | Auto-creates default-deny NetworkPolicies in new namespaces |
+
+The `kates-workload-standards`, `kates-image-verification`, and `kates-generate-network-policies` policies listed in section 1.5 ship with the Kates backend chart (`charts/kates`), not with kafka-cluster.
 
 ```yaml
 podSecurityPolicy:
@@ -1387,7 +1398,7 @@ helm test kafka-cluster -n kafka --filter name=krafter-test-produce-consume
 ```
 
 ::: {.callout-tip}
-If tier 2 (produce/consume) fails but tier 1 passes, the issue is usually authentication — check that the user secret exists and the SCRAM password is populated. Run `kates kafka users` to verify user status.
+If tier 2 (produce/consume) fails but tier 1 passes, the issue is usually authentication — check that the user secret exists and the SCRAM password is populated. Run `kubectl get kafkausers -n kafka` to verify user status.
 :::
 
 
@@ -1406,7 +1417,6 @@ kates deploy --topology isolated
 # Alternative — direct Helm command
 helm upgrade kafka-cluster charts/kafka-cluster \
   --namespace kafka \
-  --set strimziOperator.enabled=false \
   --set crdUpgrade.enabled=false \
   --timeout 600s
 ```
@@ -1415,14 +1425,14 @@ The operator performs a **rolling restart** — one broker at a time, maintainin
 
 ### 14.2 Upgrading Kafka Version
 
-1. Update `values.yaml`:
+1. Update `values.yaml` with the new version (it must be supported by the installed Strimzi operator):
    ```yaml
-   kafkaVersion: "4.2.0"
+   kafkaVersion: "<new-version>"
    ```
 2. Run `helm upgrade` or `kates deploy --topology isolated`
 3. Monitor the rolling update:
    ```bash
-   kates kafka status
+   kubectl get pods -n kafka -w
    ```
 
 The operator upgrades brokers one at a time, waiting for ISR to heal before proceeding to the next broker.
@@ -1524,21 +1534,11 @@ kubectl logs -n kafka -l strimzi.io/name=krafter-entity-operator -c user-operato
 
 ```bash
 # ── Kates CLI (preferred) ────────────────────────────────────────
-# Cluster status (shows CR readiness, pod health, listeners)
-kates kafka status
-
-# List all managed topics with partition/replica info
+# List all topics with partition, replication, and ISR health
 kates kafka topics
 
-# List all managed users with ACL summary
-kates kafka users
-
-# Show broker details (node pools, zones, replicas)
+# List brokers with ID, host, port, rack, and controller status
 kates kafka brokers
-
-# Tail broker logs (add -f for follow mode)
-kates kafka logs
-kates kafka logs -f
 
 # Run the 9-tier Helm test suite
 kates test helm
@@ -1575,13 +1575,12 @@ helm test kafka-cluster -n kafka
 | Value | Default | Description |
 |-------|---------|-------------|
 | `clusterName` | `krafter` | Name of the Kafka cluster |
-| `kafkaVersion` | `4.1.1` | Apache Kafka version |
-| `strimziOperator.enabled` | `true` | Install Strimzi operator as subchart |
-| `controllers.replicas` | `3` | Number of KRaft controllers |
-| `brokerPools` | 3 zone pools | List of broker pool definitions |
+| `kafkaVersion` | `4.2.0` | Apache Kafka version |
+| `controllerPools` | `[]` | Controller pool definitions (generate with `kates detect --generate-values`) |
+| `brokerPools` | `[]` | Broker pool definitions (generate with `kates detect --generate-values`) |
 | `brokerDefaults.resources.requests.memory` | `4Gi` | Broker memory request |
 | `kafka.config` | *see values.yaml* | Kafka broker configuration |
-| `topics` | 7 topics | List of managed topics |
+| `topics` | 8 topics | List of managed topics |
 | `users` | 5 users | List of managed users |
 | `networkPolicies.enabled` | `true` | Create default-deny + allow rules |
 | `alerts.enabled` | `true` | Create PrometheusRule alerts |

--- a/docs/book/21-kafka-connect.md
+++ b/docs/book/21-kafka-connect.md
@@ -55,32 +55,42 @@ graph TB
 
 ## Helm Chart Structure
 
-The `connect-cluster` chart lives at `charts/connect-cluster/` and produces two Strimzi CRDs:
+The `connect-cluster` chart lives at `charts/connect-cluster/` and produces the Strimzi `KafkaConnect` and `KafkaConnector` resources (plus an optional chart-managed `KafkaUser`):
 
 ```
 charts/connect-cluster/
-├── Chart.yaml                          # v1.0.0, appVersion 4.2.0
+├── Chart.yaml                          # v1.2.0, appVersion 4.2.0
 ├── values.yaml                         # Production defaults
-├── values-generic.yaml                    # Kind cluster overlay
+├── values-generic.yaml                 # Generic cluster overlay (no Prometheus CRDs)
+├── values-kind.yaml                    # Kind overlay (generic + local DB egress, Schema Registry)
 ├── values-dev.yaml                     # Development overlay
 ├── values-prod.yaml                    # Production overlay
 ├── values.schema.json                  # Input validation
 ├── README.md                           # Chart documentation
-├── templates/
-│   ├── _helpers.tpl                    # Naming, labels, namespace helpers
-│   ├── kafka-connect.yaml              # KafkaConnect CR
-│   ├── kafka-connectors.yaml           # KafkaConnector CRs
-│   ├── validate-connectors.yaml        # Pre-install CI validation hook
-│   ├── network-policy.yaml             # Ingress/egress rules
-│   ├── service-account.yaml            # Dedicated RBAC
-│   ├── service.yaml                    # REST API Service
-│   ├── ingress.yaml                    # Optional REST API Ingress
-│   ├── prometheus-alerts.yaml          # 8 alert rules
-│   ├── pod-monitor.yaml                # Prometheus PodMonitor
-│   ├── grafana-dashboard.yaml          # 8-panel dashboard
-│   └── tests/
-│       └── test-connect-api.yaml       # Helm test pod (REST API health)
-└── NOTES.txt                           # Post-install instructions
+└── templates/
+    ├── NOTES.txt                       # Post-install instructions
+    ├── _helpers.tpl                    # Naming, labels, namespace helpers
+    ├── kafka-connect.yaml              # KafkaConnect CR
+    ├── connectors.yaml                 # KafkaConnector CRs
+    ├── kafka-user.yaml                 # Managed KafkaUser (SCRAM + auto ACLs)
+    ├── kafka-user-secret-sync.yaml     # Cross-namespace credentials Secret sync
+    ├── kafka-connect-logging.yaml      # External log4j configuration
+    ├── metrics-configmap-connect.yaml  # JMX Prometheus exporter rules
+    ├── validate-connectors.yaml        # Pre-install/pre-upgrade validation hook
+    ├── networkpolicies.yaml            # Explicit ingress/egress allow rules
+    ├── networkpolicy-default-deny.yaml # Default-deny policy for Connect pods
+    ├── secret-reader-rbac.yaml         # RBAC for KubernetesSecretConfigProvider
+    ├── serviceaccount.yaml             # Dedicated ServiceAccount
+    ├── service-rest-api.yaml           # REST API Service
+    ├── ingress.yaml                    # Optional REST API Ingress
+    ├── hpa.yaml                        # Optional HorizontalPodAutoscaler
+    ├── alerts-connect.yaml             # Prometheus alert rules
+    ├── podmonitor-connect.yaml         # Prometheus PodMonitor
+    ├── dashboard-connect.yaml          # Grafana dashboard
+    └── tests/
+        ├── test-connect.yaml           # Helm test pod (REST API connectivity)
+        ├── test-connectors.yaml        # helm-test example KafkaConnectors
+        └── test-topics.yaml            # helm-test KafkaTopics
 ```
 
 ### Deployment
@@ -89,13 +99,14 @@ The recommended way to deploy Kafka Connect is through the **Kates CLI**, which 
 
 ```bash
 # Deploy the full stack including Kafka Connect
+# (--ha defaults to true, so this gives you 3 workers)
 kates deploy --topology isolated --with-kafka-connect
 
-# Deploy with HA (3 workers)
-kates deploy --topology isolated --with-kafka-connect --ha
+# Single-worker deployment (resource-constrained clusters)
+kates deploy --topology isolated --with-kafka-connect --ha=false
 ```
 
-The CLI deploys the `connect-cluster` chart as a separate Helm release, automatically applying the Kind overlay on Kind clusters and provisioning the PostgreSQL credentials secret.
+The CLI deploys the `connect-cluster` chart as a separate Helm release (into the `connect` namespace by default under the isolated topology), automatically applying the Kind overlay on Kind clusters and provisioning the PostgreSQL credentials secret.
 
 #### Direct Helm (alternative)
 
@@ -140,9 +151,9 @@ sequenceDiagram
 | Setting | Default | Purpose |
 |---------|---------|---------|
 | `groupId` | `kates-connect-cluster` | All workers sharing this ID form a single cluster |
-| `replicas` | 3 (prod) / 1 (kind) | Number of worker pods |
+| `replicas` | 3 (the CLI sets 1 with `--ha=false`; the dev overlay uses 1) | Number of worker pods |
 | `image` | `ghcr.io/bmscomp/connect:3.6.0` | Pre-built image with Debezium + Apicurio plugins |
-| `bootstrapServers` | `krafter-kafka-bootstrap:9093` | TLS-encrypted connection to Kafka |
+| `kafka.bootstrapServers` | `""` — computed as `<clusterName>-kafka-bootstrap.<ns>.svc:9092` (9093 when `kafka.tls.enabled`) | Connection to Kafka |
 | `version` | 4.2.0 | Kafka protocol version |
 
 ### Internal Topics
@@ -164,7 +175,7 @@ Never delete the offsets topic. If deleted, all source connectors lose their pos
 
 ### Authentication
 
-Connect authenticates to Kafka using SCRAM-SHA-512 over TLS:
+Connect authenticates to Kafka using SCRAM-SHA-512 (TLS is off by default and switched on with `kafka.tls.enabled`):
 
 ```yaml
 authentication:
@@ -176,10 +187,10 @@ authentication:
 tls:
   trustedCertificates:
     - secretName: krafter-cluster-ca-cert
-      pattern: "*.crt"
+      certificate: ca.crt
 ```
 
-The `kates-connect` KafkaUser must be created in the Kafka namespace with appropriate ACLs for topic creation, group management, and connector offset storage.
+The `kates-connect` KafkaUser can be managed by the chart itself: setting `kafkaUser.create: true` provisions the `KafkaUser` in the Kafka namespace, and with `authorization.mode: auto` derives least-privilege ACLs from the chart values (`groupId`, the internal topics, exactly-once transactional IDs, and the data-topic prefixes in `kafkaUser.topicGrants`). When Connect runs in a different namespace than Kafka, `kafkaUser.secretSync` makes the generated credentials Secret available in the Connect namespace — either via a hook Job that copies it (re-run on upgrades for rotation) or via kubernetes-reflector annotations. This requires the Strimzi User Operator; the ACLs take effect when the Kafka cluster has authorization enabled.
 
 ## Connector Lifecycle
 
@@ -278,25 +289,16 @@ build:
           version: "4.8.3"
 ```
 
-#### 2. Using the Init Container Script
+#### 2. Using the Plugin Loader Script
 
-For environments where Strimzi image builds aren't possible, use the provided plugin loader script as an init container to download JARs at pod startup:
+For environments where Strimzi image builds aren't possible, the repo ships `scripts/connect-plugin-loader.sh`, which downloads plugin JARs from Maven Central and extracts them into a `/plugins` directory:
 
-```yaml
-template:
-  pod:
-    metadata: {}
-    initContainers:
-      - name: plugin-loader
-        image: ghcr.io/bmscomp/connect:3.6.0
-        command: ["/bin/bash", "-c", "curl -sfL https://raw.githubusercontent.com/bmscomp/kates/main/scripts/connect-plugin-loader.sh | bash"]
-        env:
-          - name: EXTRA_PLUGINS
-            value: "org.apache.camel.kafkaconnector:camel-aws-s3-sink-kafka-connector:4.8.3"
-        volumeMounts:
-          - name: extra-plugins
-            mountPath: /plugins
+```bash
+EXTRA_PLUGINS="org.apache.camel.kafkaconnector:camel-aws-s3-sink-kafka-connector:4.8.3" \
+  ./scripts/connect-plugin-loader.sh
 ```
+
+The script is written to run as an init container that populates a shared volume on the worker's `plugin.path`, but the chart does not wire this up for you — its `template.pod` passthrough only covers pod metadata, so using the script this way means customizing the `KafkaConnect` resource yourself. In most cases, prefer `spec.build` above or bake the plugins into the image (`make connect-build`).
 
 ### PostgreSQL CDC Pipeline
 
@@ -337,7 +339,7 @@ connectors:
       database.hostname: postgresql.database.svc
       database.port: "5432"
       database.user: debezium
-      database.password: "${dir:/mnt/pg-credentials:password}"
+      database.password: "${secrets:connect/connect-pg-credentials:password}"
       database.dbname: orders
       topic.prefix: cdc
       schema.include.list: public
@@ -367,19 +369,19 @@ The `tasksMax` for a Debezium PostgreSQL connector must always be `1`. PostgreSQ
 
 ### External Configuration (Secrets)
 
-Database credentials are mounted as files via Strimzi's `externalConfiguration`:
+The chart enables three Kafka config providers on every worker — `file`, `dir`, and `secrets` (Strimzi's `KubernetesSecretConfigProvider`):
 
 ```yaml
-externalConfiguration:
-  volumes:
-    - name: pg-credentials
-      secretName: connect-pg-credentials
+config.providers: file,dir,secrets
+config.providers.file.class: org.apache.kafka.common.config.provider.FileConfigProvider
+config.providers.dir.class: org.apache.kafka.common.config.provider.DirectoryConfigProvider
+config.providers.secrets.class: io.strimzi.kafka.KubernetesSecretConfigProvider
 ```
 
-This mounts the secret at `/mnt/pg-credentials/` inside each worker pod. Connectors reference values using the `${dir:/mnt/pg-credentials:password}` syntax (Kafka's `DirectoryConfigProvider`).
+Connectors reference Kubernetes Secrets directly with the `${secrets:<namespace>/<secret-name>:<key>}` syntax — no volume mounts required. The chart's `secret-reader-rbac.yaml` grants the Connect ServiceAccount read access to Secrets in its namespace.
 
 ::: {.callout-tip}
-ConfigMap volumes are also supported. Use `type: configMap` and `configMapName` for non-sensitive data like SMT scripts or external lookup tables.
+By default the secret-reader Role covers all Secrets in the namespace. Set `rbac.secretNames` to narrow the grant to the specific Secrets your connectors reference.
 :::
 
 
@@ -473,7 +475,7 @@ rack:
   topologyKey: topology.kubernetes.io/zone
 ```
 
-For Kind clusters, all scheduling constraints are disabled since all pods run on a single node.
+The base values use `whenUnsatisfiable: ScheduleAnyway`, so single-node clusters like Kind still schedule all workers; the dev overlay disables topology spread and anti-affinity entirely, while the prod overlay tightens spreading to `DoNotSchedule`.
 
 ## Pre-Deploy Validation
 
@@ -507,37 +509,37 @@ This catches misconfigurations at `helm upgrade` time rather than at runtime, pr
 
 ### Prometheus Alerts
 
-The chart deploys 8 alert rules:
+The chart deploys the following alert rules (thresholds are configurable under `alerts.thresholds`):
 
 | Alert | Condition | Severity |
 |-------|-----------|----------|
-| `KafkaConnectDown` | No running workers for 5min | critical |
-| `KafkaConnectorFailed` | Connector in FAILED state for 2min | critical |
-| `KafkaConnectorTaskFailed` | Task in FAILED state for 2min | warning |
-| `KafkaConnectRebalancing` | Cluster rebalancing for 10min | warning |
-| `KafkaConnectHighLatency` | Connector source lag >60s for 10min | warning |
-| `KafkaConnectHighErrorRate` | Error rate >5% for 5min | warning |
-| `KafkaConnectWorkerDown` | Worker count < expected for 5min | warning |
-| `KafkaConnectRestApiDown` | REST API unreachable for 3min | critical |
+| `KafkaConnectTaskFailed` | Failed task count > 0 for 2min | critical |
+| `KafkaConnectWorkerDown` | Worker reports 0 connectors for 3min | critical |
+| `KafkaConnectTaskCountMismatch` | Expected vs running task count differ for 5min | critical |
+| `KafkaConnectRebalanceStorm` | Completed-rebalance rate above threshold for 5min | warning |
+| `KafkaConnectHighErrorRate` | Task error-log rate above threshold for 5min | warning |
+| `KafkaConnectRebalanceTooLong` | A rebalance has been in progress for 5min | warning |
+| `KafkaConnectWorkerHeapHigh` | JVM heap usage above threshold (default 85%) for 5min | warning |
+| `KafkaConnectSourceLag` | Source task polled 0 records for `sourceLagMinutes` (default 15min) | warning |
 
 ### Grafana Dashboard
 
-The dashboard provides 8 panels:
+The dashboard ships the following panels:
 
 | Panel | Metric | Visualization |
 |-------|--------|---------------|
-| Worker Count | `kafka_connect_worker_info` | Stat |
-| Connector Status | `kafka_connect_connector_status` | Table |
-| Task Count (by state) | `kafka_connect_connector_task_status` | Pie chart |
-| Source Record Rate | `kafka_connect_source_task_source_record_poll_rate` | Time series |
-| Sink Record Rate | `kafka_connect_sink_task_sink_record_send_rate` | Time series |
-| Error Rate | `kafka_connect_task_error_total_record_errors` | Time series |
-| Rebalance Duration | `kafka_connect_worker_rebalance_rebalance_time_ms_total` | Time series |
+| Running Connectors | `kafka_connect_worker_metrics_connector_count` | Stat |
+| Failed Tasks | `kafka_connect_worker_metrics_connector_failed_task_count` | Stat |
+| Running Tasks | `kafka_connect_worker_metrics_task_count` | Stat |
+| Rebalance Rate | `rate(kafka_connect_worker_rebalance_metrics_completed_rebalances_total[5m])` | Stat |
+| Task Error Rate | `rate(kafka_connect_task_error_metrics_total_errors_logged[5m])` | Time series |
+| Source Records Poll Rate | `rate(kafka_connect_source_task_metrics_source_record_poll_total[5m])` | Time series |
+| Sink Records Put Rate | `rate(kafka_connect_sink_task_metrics_sink_record_send_total[5m])` | Time series |
 | JVM Heap Usage | `jvm_memory_bytes_used{area="heap"}` | Time series |
 
 ### Helm Test
 
-The chart includes a test pod that validates the Connect REST API is reachable:
+The chart includes Helm tests: a connectivity pod that probes the Connect REST API, plus example `KafkaTopic` and `KafkaConnector` resources (defined under `testTopics` / `testConnectors` in values) that are created during `helm test` and deleted when the test succeeds:
 
 ```bash
 # Run the CDC integration test via Kates CLI
@@ -547,25 +549,27 @@ kates kafka connect test
 helm test connect-cluster --namespace kafka --timeout 180s --logs
 ```
 
-The `kates kafka connect test` command runs a full end-to-end CDC integration test against the backend, with a Bubble Tea progress UI showing each phase (DB setup → source deploy → sink deploy → verification).
+The `kates kafka connect test` command runs a full end-to-end CDC integration test against the backend, with a Bubble Tea progress UI showing each phase (DB setup → topic creation → source deploy → sink deploy → verification → cleanup).
 
-The Helm test pod runs `curl http://<connect-service>:8083/connectors` and validates a 200 response.
+The connectivity test pod curls the Connect REST API on port 8083 (the root endpoint and `/connector-plugins`) — first by exec-ing into a worker pod, then falling back to the chart's REST API Service.
 
 ## Environment Overlays
 
-| Setting | Kind | Dev | Prod |
+The Kates CLI applies `values-kind.yaml` on Kind clusters and `values-generic.yaml` on other clusters — the two are identical except that the Kind overlay adds database egress to the local `kates` namespace and enables the Schema Registry integration. `values-dev.yaml` and `values-prod.yaml` are for direct Helm use. Cells marked *(base)* are inherited from `values.yaml` rather than set by the overlay:
+
+| Setting | Kind/Generic | Dev | Prod |
 |---------|:----:|:---:|:----:|
-| Replicas | 1 | 1 | 3 |
-| JVM Heap | 256–512m | 512m | 2048m |
-| Memory request/limit | 512Mi/1Gi | 1Gi/2Gi | 4Gi/6Gi |
-| Topology spread | Disabled | Disabled | Zone-aware, `DoNotSchedule` |
-| Pod anti-affinity | Disabled | Disabled | Per-hostname |
-| Rack awareness | Disabled | Disabled | Per-zone |
+| Replicas | 3 *(base)* — CLI sets 1 with `--ha=false` | 1 | 3 |
+| JVM Heap | 1024m *(base)* | 512m | 2048m |
+| Memory request/limit | 2Gi/4Gi *(base)* | 1Gi/2Gi | 4Gi/6Gi |
+| Topology spread | Zone-aware, `ScheduleAnyway` *(base)* | Disabled | Zone-aware, `DoNotSchedule` |
+| Pod anti-affinity | Per-hostname *(base)* | Disabled | Per-hostname |
 | Alerts | Off | Off | On |
 | PodMonitors | Off | On | On |
 | Dashboards | Off | On | On |
 | Tracing | Off | OpenTelemetry | OpenTelemetry |
-| Priority class | — | — | `system-cluster-critical` |
+| Schema Registry | On (Kind only) | Off *(base)* | Off *(base)* |
+| Priority class | `system-cluster-critical` *(base)* | — (cleared) | `system-cluster-critical` |
 
 ## CLI Reference
 
@@ -596,7 +600,7 @@ The `kates kafka connect` command group provides a complete operational interfac
 | `kates kafka connect tasks [name]` | Show task-level status |
 | `kates kafka connect delete [name]` | Delete a connector |
 
-All commands accept `-n <namespace>` (defaults to `kafka` or `$KATES_KAFKA_NS`) and `-o json` for machine-readable output.
+All commands accept `-n <namespace>` (resolved as `$KATES_CONNECT_NS` → auto-detect from the cluster's `KafkaConnect` CRs → `$KATES_KAFKA_NS` → `kafka`) and `-o json` for machine-readable output.
 
 ### Makefile Targets (CI/Chart Development)
 
@@ -612,7 +616,7 @@ For chart development and CI pipelines, Makefile targets are also available:
 
 ## Network Policies
 
-The chart generates egress rules for cross-namespace database connections:
+The chart ships a default-deny posture: a deny-all Ingress+Egress policy for the Connect pods (`networkPolicy.defaultDeny.enabled`, on by default) with every allowed flow — Kafka, DNS, the Kubernetes API, monitoring scrapes, the REST API, and databases — expressed as an explicit, individually configurable allow rule. For cross-namespace database connections it generates egress rules like these:
 
 ```mermaid
 graph LR
@@ -689,7 +693,7 @@ The Connect REST API (port 8083) is also exposed via a `ClusterIP` Service for d
 
 ```bash
 # Port-forward for local access
-kubectl port-forward -n kafka svc/connect-cluster-connect-api 8083:8083
+kubectl port-forward -n kafka svc/connect-cluster-rest-api 8083:8083
 
 # List connectors via REST
 curl -s http://localhost:8083/connectors | jq .
@@ -1010,12 +1014,12 @@ graph TB
     subgraph Connect Worker Pod
         TLS["TLS Truststore"]
         SASL["SASL Config"]
-        VOL["/mnt/pg-credentials/"]
+        PROV["secrets config provider"]
     end
 
     S1 -->|"mounted by Strimzi"| TLS
     S2 -->|"mounted by Strimzi"| SASL
-    S3 -->|"externalConfiguration"| VOL
+    S3 -->|"read via Kubernetes API"| PROV
 ```
 
 ### Rotation Procedures
@@ -1024,7 +1028,7 @@ graph TB
 |-----------|----------------|:--------:|
 | Kafka TLS CA | Strimzi auto-rotates 180 days before expiry | Zero — rolling restart |
 | SCRAM password | Update `KafkaUser` CR → Strimzi updates Secret | Zero — rolling restart |
-| Database password | Update K8s Secret → rolling restart of Connect | ~30s per worker |
+| Database password | Update K8s Secret → restart the connector | Seconds — connector restart only |
 | Connect REST API (if exposed) | Ingress-level auth (OAuth2 proxy, mTLS) | N/A |
 
 **Database credential rotation:**
@@ -1032,13 +1036,14 @@ graph TB
 ```bash
 # 1. Update the secret
 kubectl create secret generic connect-pg-credentials \
-  -n kafka \
+  -n connect \
   --from-literal=username=debezium \
   --from-literal=password=NEW_PASSWORD \
   --dry-run=client -o yaml | kubectl apply -f -
 
-# 2. Restart Connect workers to pick up new secret
-kubectl rollout restart deployment -n kafka -l strimzi.io/kind=KafkaConnect
+# 2. Restart the connector — the secrets config provider re-reads
+#    the Secret when the connector configuration is (re)applied
+kates kafka connect restart debezium-postgres-source
 ```
 
 ::: {.callout-important}
@@ -1081,7 +1086,7 @@ Connect's internal producer sends records to Kafka. These settings control batch
 | `batch.size` | JDBC Sink | 3000 | 5000–10000 | Rows per INSERT batch |
 
 ::: {.callout-tip}
-Monitor `kafka_connect_source_task_source_record_poll_rate` and `kafka_connect_source_task_source_record_write_rate` in Grafana. If poll rate >> write rate, the producer is the bottleneck — increase `producer.batch.size` and enable compression.
+Monitor `rate(kafka_connect_source_task_metrics_source_record_poll_total[5m])` and `rate(kafka_connect_source_task_metrics_source_record_write_total[5m])` in Grafana. If poll rate >> write rate, the producer is the bottleneck — increase `producer.batch.size` and enable compression.
 :::
 
 
@@ -1178,8 +1183,9 @@ Cross-database sync introduces eventual consistency. The sink always lags behind
 When a new Debezium or Kafka version is released:
 
 ```bash
-# 1. Build and push the new image
-DBZ_VERSION=3.1.0 make connect-build connect-push
+# 1. Bump ARG DEBEZIUM_VERSION in Dockerfile.connect (e.g. 3.7.0.Final),
+#    then build and push — the image tag is derived from that ARG
+make connect-build connect-push
 
 # 2. Deploy with updated image via Kates CLI
 kates deploy --with-kafka-connect
@@ -1187,7 +1193,7 @@ kates deploy --with-kafka-connect
 # Or update directly via Helm
 helm upgrade connect-cluster charts/connect-cluster \
   --namespace kafka --reuse-values \
-  --set image=ghcr.io/bmscomp/connect:3.1.0
+  --set image=ghcr.io/bmscomp/connect:3.7.0
 ```
 
 Strimzi performs a **rolling restart** — one worker at a time. Connectors are rebalanced to surviving workers during each restart, ensuring zero downtime.
@@ -1306,11 +1312,11 @@ kates kafka connect logs
 
 ### Rebalancing Takes Too Long
 
-**Symptom:** Connect cluster stuck in `REBALANCING` state for minutes
+**Symptom:** Connect cluster stuck in `REBALANCING` state for minutes (the `KafkaConnectRebalanceTooLong` alert fires after 5 minutes)
 
-**Cause:** Large number of connectors/tasks + default `group.initial.rebalance.delay.ms` of 3000ms
+**Cause:** A large number of connectors/tasks being reassigned, or workers repeatedly leaving and rejoining the group. (The chart also sets `group.initial.rebalance.delay.ms: 3000`, which adds a fixed 3-second wait before the *first* assignment when the group forms — that delay is intentional and not the problem here.)
 
-**Fix:** The chart sets `group.initial.rebalance.delay.ms: 3000`. If rebalancing takes more than 5 minutes, check for:
+**Fix:** If rebalancing takes more than 5 minutes, check for:
 - Workers crashing during rebalance (check pod events)
 - Network policies blocking inter-worker communication on port 8083
 - Insufficient memory causing OOM kills during task assignment
@@ -1360,7 +1366,7 @@ heartbeat.interval.ms: "10000"
 **Fix:** Read the hook pod logs to see which fields are missing:
 
 ```bash
-kubectl logs -n kafka -l helm.sh/hook=pre-install --tail=50
+kubectl logs -n kafka connect-cluster-validate-connectors --tail=50
 ```
 
 Fix the connector configs in `values.yaml` and re-run `helm upgrade`.
@@ -1375,4 +1381,4 @@ Fix the connector configs in `values.yaml` and re-run `helm upgrade`.
 | Apicurio Converter | 3.3.0 | Schema Registry integration |
 | Debezium JDBC | 3.6.0.Final | Apache 2.0 licensed JDBC sink connector |
 | Connect Image | `ghcr.io/bmscomp/connect:3.6.0` | Pre-built with all plugins |
-| Helm Chart | 1.0.0 | `charts/connect-cluster` |
+| Helm Chart | 1.2.0 | `charts/connect-cluster` |

--- a/docs/book/appendix-b-troubleshooting.md
+++ b/docs/book/appendix-b-troubleshooting.md
@@ -7,7 +7,7 @@ A consolidated index of troubleshooting procedures from across the book. Jump to
 | Symptom | Likely Cause | Chapter |
 |---------|-------------|---------|
 | Strimzi operator `CrashLoopBackOff` with `UnsupportedVersionException` | Local chart has mismatched Kafka image map | [Ch 15](15-kafka-deployment.md#strimzi-operator-crashloopbackoff) |
-| Brokers crash with `ConfigException: Invalid value -1 for local.retention.bytes` | Kafka 4.1.1 tightened validation — `-1` rejected when `retention.bytes` is set | [Ch 15](15-kafka-deployment.md#brokers-crash-with-configexception) |
+| Brokers crash with `ConfigException: Invalid value -1 for local.retention.bytes` | Kafka 4.1+ tightened validation — `-1` rejected when `retention.bytes` is set | [Ch 15](15-kafka-deployment.md#brokers-crash-with-configexception) |
 | Brokers crash immediately with `remote.log.storage.system.enable=true` | Tiered storage enabled without remote storage manager plugin JAR | [Ch 15](15-kafka-deployment.md#brokers-crash-with-remotelogmanager) |
 | `KafkaActiveControllerCount != 1` alert | Controller quorum lost or election in progress | [Ch 15](15-kafka-deployment.md#prometheus-alerts) |
 | Under-replicated partitions for extended period | Broker disk I/O saturated, network issues, or follower falling behind | [Ch 3](03-cluster.md#failure-tolerance-matrix) |
@@ -70,7 +70,7 @@ A consolidated index of troubleshooting procedures from across the book. Jump to
 
 ## Connectivity Debugging Flowchart
 
-When you can't connect to Kafka, work through this decision tree:
+When you can't connect to Kafka, work through this decision tree. The commands here and in [Quick Diagnostic Commands](#quick-diagnostic-commands) assume the chart defaults — cluster name `krafter` in namespace `kafka` (set in `charts/kafka-cluster/values.yaml`); adjust them if your deployment overrides these values.
 
 ```mermaid
 flowchart TD
@@ -109,7 +109,7 @@ Not every problem is a Kates problem. Use this guide to determine where to focus
 | Everything works locally but fails in CI | **CI environment** | Check resource limits, network access, Docker-in-Docker configuration |
 
 ::: {.callout-tip}
-When filing an issue, include the output of `kates doctor` — it runs 13 diagnostic checks and gives you a single summary of system health.
+When filing an issue, include the output of `kates doctor` — it runs a battery of diagnostic checks and gives you a single summary of system health.
 :::
 
 
@@ -117,7 +117,7 @@ When filing an issue, include the output of `kates doctor` — it runs 13 diagno
 
 | Symptom | Likely Cause | Fix |
 |---------|-------------|-----|
-| `kates cluster topology` returns "Cluster topology is only available when the Kates backend is deployed on Kubernetes" | Missing `ClusterRoleBinding` for the Kates service account — the backend can't query Strimzi CRDs | Verify RBAC: `kubectl get clusterrolebinding kates` — if missing, redeploy with `helm upgrade --install kates charts/kates -n kates` |
+| `kates cluster topology` returns "Cluster topology is only available when the Kates backend is deployed on Kubernetes with access to Strimzi CRDs" | Missing `ClusterRoleBinding` for the Kates service account — the backend can't query Strimzi CRDs | Verify RBAC: `kubectl get clusterrolebinding kates` — if missing, redeploy with `helm upgrade --install kates charts/kates -n kates` |
 | Test results show 0 records consumed even though producers succeeded | Consumer group hasn't started consuming, or topic has no committed offsets for the group | Check consumer lag: `kates kafka group <group-name>`. If lag equals total records, the consumer never started — check Kates backend logs for consumer errors |
 | `kates trend` shows no data even after running tests | Tests completed but trend queries require at least 2 data points of the same test type | Run the same test type at least twice. Trend analysis needs historical data to draw a line |
 
@@ -140,7 +140,7 @@ kubectl logs <broker-pod> -n kafka --previous --tail=30
 kubectl get kafka krafter -n kafka -o jsonpath='{range .status.conditions[*]}{.type}: {.status} - {.message}{"\n"}{end}'
 
 # Under-replicated partitions
-kubectl exec <broker-pod> -n kafka -- bin/kafka-metadata.sh --snapshot /var/lib/kafka/data-0/__cluster_metadata-0/00000000000000000000.log --cluster-id $(kubectl get kafka krafter -n kafka -o jsonpath='{.status.clusterId}')
+kubectl exec <broker-pod> -n kafka -- bin/kafka-topics.sh --describe --under-replicated-partitions --bootstrap-server localhost:9092
 
 # Consumer lag
 kubectl exec <broker-pod> -n kafka -- bin/kafka-consumer-groups.sh --bootstrap-server localhost:9092 --all-groups --describe

--- a/docs/book/appendix-c-cicd.md
+++ b/docs/book/appendix-c-cicd.md
@@ -1,6 +1,6 @@
 # Appendix C: CI/CD Pipeline
 
-This appendix documents the GitHub Actions workflows that automate building, testing, and releasing the Kates platform. Six workflows cover the full lifecycle — from pull-request validation to production image publishing and CLI binary releases.
+This appendix documents the GitHub Actions workflows that automate building, testing, and releasing the Kates platform. It covers the six core workflows — from pull-request validation to production image publishing and CLI binary releases. The repository carries additional workflows for the Kafka Connect image (`ci-connect.yml`, `publish-connect.yml`) and for documentation builds (`docs.yml`, `book.yml`); they follow the same patterns and are not covered here.
 
 ## Pipeline Overview
 
@@ -30,17 +30,20 @@ graph TB
     Push --> CID
     PR --> CID
     Push --> INT
+    PR --> INT
+    Manual --> INT
     Tag --> PD
     Manual --> PD
     Tag --> PT
+    Manual --> PT
     Tag --> RC
 
-    CI -->|"pass"| CID
-    CID -->|"images OK"| INT
-    PD -->|"GHCR"| Registry["ghcr.io/bmscomp/kates"]
-    PT -->|"GHCR"| Registry2["ghcr.io/bmscomp/kates-tester"]
-    RC -->|"binaries"| GHR["GitHub Release"]
+    PD -->|"multi-arch manifests"| Registry["ghcr.io/bmscomp/kates<br/>docker.io/bmscomp/kates"]
+    PT --> Registry2["ghcr.io/bmscomp/kates-tester<br/>docker.io/bmscomp/kates-tester"]
+    RC -->|"binaries"| GHR["GitHub Release + Homebrew tap"]
 ```
+
+The three validation workflows trigger independently — each has its own path filter and there is no chaining between them.
 
 ## Path-Based Change Detection
 
@@ -48,73 +51,83 @@ Several workflows use **path filters** to avoid unnecessary runs. Only changes t
 
 | Workflow | Monitored Paths |
 |----------|----------------|
-| `ci.yml` | `kates/**`, `cli/**`, `charts/**` |
-| `ci-docker.yml` | `kates/**`, `Dockerfile*` |
-| `integration.yml` | `kates/**`, `cli/**`, `charts/**`, `config/**` |
+| `ci.yml` | `kates/**`, `cli/**`, `charts/kates/**`, `config/**`, `images.env`, `versions.env`, the workflow file itself |
+| `ci-docker.yml` | `kates/**`, `cli/**`, `images.env`, `versions.env`, the workflow file itself |
+| `integration.yml` | `kates/**`, `cli/**`, `Makefile`, `images.env`, `versions.env`, the workflow file itself |
 
-This means documentation-only changes, README edits, or tutorial updates do not trigger CI builds — saving compute and reducing noise.
+Each filter also carries an explicit `!**/*.md` exclusion, so documentation-only changes, README edits, or tutorial updates do not trigger CI builds — saving compute and reducing noise.
 
 ---
 
 ## 1. Backend CI (`ci.yml`)
 
-**Purpose:** Validates backend code, CLI code, and Helm chart integrity on every push and pull request.
+**Purpose:** Validates backend code, CLI code, Helm chart integrity, Kyverno policies, and config YAML on every push and pull request.
 
 **Triggers:**
-- Push to `main` branch (paths: `kates/**`, `cli/**`, `charts/**`)
+- Push to `main` branch (paths in the table above)
 - Pull request targeting `main` (same paths)
 
 ### What It Runs
 
-| Stage | Runtime | Description |
-|-------|---------|-------------|
-| **Java Backend Tests** | Java 25 | Compiles the Quarkus backend and runs the full unit/integration test suite with `./mvnw verify` |
-| **Go CLI Tests** | Go (latest) | Runs `go test -race ./...` across all CLI packages with race detector enabled |
-| **Helm Lint** | Helm 3.x | Runs `helm lint` on all charts under `charts/` to catch template errors |
-| **Helm Dry-Run** | Helm 3.x | Runs `helm template` + `helm install --dry-run` to validate rendered manifests against the Kubernetes API schema |
+| Job | Runtime | Description |
+|-----|---------|-------------|
+| **Build & Test** | Java 21 (Temurin) | Compiles the Quarkus backend and runs the test suite with `./mvnw verify`; JUnit results are published as a check |
+| **CLI Tests** | Go 1.25 | Runs `go test -race` across all CLI packages with the race detector enabled |
+| **Helm Lint** | Helm v3.17.0 | Runs `helm dependency build` and `helm lint` on the `kates` chart, then `helm template` to verify the chart renders |
+| **Kyverno Policy Validation** | Kyverno CLI v1.13.0 | Renders the Kyverno policy templates from the `kates`, `kafka-cluster`, and `kates-chaos` charts and validates them with `kyverno apply` |
+| **YAML Validation** | Python + PyYAML | Parses every YAML file under `config/` to catch syntax errors |
 
 ### Key Details
 
-- **Java 25** is used as the build JDK, matching the project's target runtime
-- The **Go race detector** (`-race`) is always enabled to catch data races in CLI concurrency paths (e.g., streaming watch, dashboard refresh)
-- Helm dry-run validates that all template variables resolve correctly and that the rendered YAML passes Kubernetes schema validation
+- A first `changes` job (using `dorny/paths-filter`) detects whether code, chart, or config paths changed, and the remaining jobs run only for the relevant categories
+- **Java 21** is used as the build JDK, matching the project's compiler target (`maven.compiler.release`)
+- The **Go race detector** (`-race`) is always enabled to catch data races in CLI concurrency paths (e.g., streaming watch, dashboard refresh); packages run serially (`-p 1`) to keep memory in check
+- `helm template` validates that the `kates` chart renders without template errors
 
 ```yaml
 # Simplified workflow structure
 on:
   push:
     branches: [main]
-    paths: ['kates/**', 'cli/**', 'charts/**']
+    paths: ["kates/**", "cli/**", "charts/kates/**", "config/**",
+            "images.env", "versions.env", "!**/*.md"]
   pull_request:
     branches: [main]
-    paths: ['kates/**', 'cli/**', 'charts/**']
+    paths: # same as push
+
+env:
+  JAVA_VERSION: "21"
 
 jobs:
-  backend-tests:
+  build-and-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-java@v4
-        with: { java-version: '25' }
+        with: { distribution: temurin, java-version: "21" }
       - run: ./mvnw verify
+        working-directory: kates
 
-  cli-tests:
+  go-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v5
-      - run: go test -race ./...
+        with: { go-version: "1.25" }
+      - run: go test -p 1 ./... -race -count=1
+        working-directory: cli
 
   helm-lint:
     runs-on: ubuntu-latest
     steps:
-      - run: helm lint charts/*
-      - run: helm template kafka-cluster charts/kafka-cluster | kubectl apply --dry-run=client -f -
+      - run: helm dependency build charts/kates/
+      - run: helm lint charts/kates/
+      - run: helm template kates charts/kates/ > /dev/null
 ```
 
 ---
 
 ## 2. Docker Build Validation (`ci-docker.yml`)
 
-**Purpose:** Validates that all Docker images build successfully across target platforms without pushing to a registry.
+**Purpose:** Validates that the Kates Docker images build successfully without pushing to a registry.
 
 **Triggers:**
 - Push to `main` branch
@@ -124,113 +137,99 @@ jobs:
 
 | Variant | Base Image | Platforms | Description |
 |---------|-----------|-----------|-------------|
-| **JVM** | Eclipse Temurin | `linux/amd64`, `linux/arm64` | Standard JVM-based image with Java 25 runtime |
-| **Native** | `distroless` / `ubi-minimal` | `linux/amd64`, `linux/arm64` | GraalVM native image — sub-100ms startup, lower memory |
+| **JVM** | `eclipse-temurin:21-jre` | `linux/amd64`, `linux/arm64` | Standard JVM-based image with a Java 21 runtime |
+| **Native** | `ubi9-minimal` (Mandrel-built) | `linux/amd64` | GraalVM (Mandrel) native image — fast startup, lower memory |
 
 ### Key Details
 
-- Uses **Docker Buildx** with QEMU emulation for cross-platform builds
-- The matrix runs all 4 combinations (2 variants × 2 architectures) in parallel
-- Images are built with `--load` (local) or `--push=false` — no registry writes during validation
-- Build cache is stored via GitHub Actions cache to speed up subsequent builds
+- Uses **Docker Buildx** on native runners for each architecture — `ubuntu-latest` for amd64 and `ubuntu-24.04-arm` for arm64 — so no QEMU emulation is needed
+- The matrix runs three combinations in parallel; **native/arm64 is excluded** from CI because GraalVM native-image is too slow even on native ARM runners — that combination is validated at release time instead
+- Images are built with `push: false` — no registry writes during validation
+- Build cache is stored via GitHub Actions cache (scoped per variant and architecture) to speed up subsequent builds
 
 ```yaml
 strategy:
+  fail-fast: false
   matrix:
-    variant: [jvm, native]
-    platform: [linux/amd64, linux/arm64]
+    include:
+      - { variant: jvm,    arch: amd64, runner: ubuntu-latest }
+      - { variant: native, arch: amd64, runner: ubuntu-latest }
+      - { variant: jvm,    arch: arm64, runner: ubuntu-24.04-arm }
 ```
 
 ---
 
 ## 3. Integration Tests (`integration.yml`)
 
-**Purpose:** Deploys the full Kates stack on an ephemeral Kind cluster and runs end-to-end validation against a real Kafka cluster.
+**Purpose:** Spins up an ephemeral Kind cluster and validates that the charts, config manifests, and CLI work against a real Kubernetes API — cluster topology, the `kates detect` compatibility gate, chart linting, and server-side dry-runs of the Kafka manifests.
 
 **Triggers:**
-- Push to `main` branch (paths: `kates/**`, `cli/**`, `charts/**`, `config/**`)
+- Push to `main` branch (paths: `kates/**`, `cli/**`, `Makefile`, `images.env`, `versions.env`)
+- Pull request targeting `main` (same paths)
+- Manual `workflow_dispatch`
 
 ### Infrastructure Provisioned
 
-The workflow provisions a complete environment inside the GitHub Actions runner:
-
-```mermaid
-graph TD
-    subgraph Kind Cluster
-        K8S[Kubernetes API]
-        subgraph kafka namespace
-            Strimzi[Strimzi Operator]
-            Kafka[Kafka Brokers x3]
-            Controllers[KRaft Controllers x3]
-        end
-        subgraph monitoring namespace
-            Prom[Prometheus]
-            Graf[Grafana]
-        end
-        subgraph kates namespace
-            Backend[Kates Backend]
-        end
-    end
-```
+The workflow provisions a Kind cluster inside the GitHub Actions runner, created from `config/cluster.yaml` with three zone-labelled nodes (`alpha`, `sigma`, `gamma`):
 
 | Component | Version | Purpose |
 |-----------|---------|---------|
-| Kind | Latest | Ephemeral Kubernetes cluster (single-node) |
-| Strimzi | 1.0.0 | Kafka operator for KRaft-mode cluster |
-| Kafka | 4.1.1 | 3-broker, 3-controller KRaft cluster |
-| Prometheus + Grafana | Latest | Monitoring stack for metrics validation |
-| Kates Backend | Current build | The application under test |
+| Kind | v0.27.0 | Ephemeral Kubernetes cluster with three zone-labelled nodes |
+| kubectl | v1.33.0 | Applies and dry-runs manifests against the cluster |
+| Helm | v3.17.0 | Lints every chart under `charts/` |
+| Go | 1.25 | Builds the `kates` CLI from source for the compatibility gate |
 
 ### Validation Steps
 
-1. **Cluster readiness** — waits for all pods to reach `Running` / `Ready`
-2. **Kafka CR status** — verifies `Ready: True` on the Kafka custom resource
-3. **Helm test suite** — runs `helm test kafka-cluster` (connectivity, auth, ACLs)
-4. **Smoke test** — creates a LOAD test via the REST API, waits for completion, validates report
-5. **Integrity check** — runs an INTEGRITY test to verify zero message loss
-6. **Monitoring validation** — queries Prometheus to confirm metrics are being scraped
+1. **Cluster readiness** — waits for all Kind nodes to reach `Ready`
+2. **Topology check** — verifies one node exists per zone (`alpha`, `sigma`, `gamma`)
+3. **CI gate** — builds the CLI and runs `kates detect --fail-on-error --quiet` to confirm the cluster is compatible with a Kafka deployment
+4. **Helm lint** — builds dependencies and lints every chart under `charts/`
+5. **YAML validation** — parses all config files under `config/`
+6. **Manifest dry-runs** — applies the storage classes, creates the namespaces, and server-side dry-runs the Kafka topic and NetworkPolicy manifests
+7. **Monitoring config check** — verifies the Jaeger Helm values files are present
 
 ### Key Details
 
-- The Kind cluster uses a **custom node image** with pre-pulled Kafka images to reduce setup time
-- Total workflow runtime is typically **8–15 minutes** depending on cache availability
-- Artifacts (test reports, pod logs) are uploaded on failure for debugging
+- The Kafka manifests are validated with `kubectl apply --dry-run=server` — the Strimzi operator is **not** installed, so this checks manifest validity against the API server rather than deploying a running Kafka cluster
+- The job has a **30-minute timeout** and posts a per-check results table to the GitHub Actions step summary
+- The Kind cluster is deleted in an `always()` cleanup step, even on failure
 
 ---
 
 ## 4. Publish Kates Docker Image (`publish-docker.yml`)
 
-**Purpose:** Builds and pushes the production Kates backend image to GitHub Container Registry (GHCR).
+**Purpose:** Builds and pushes the production Kates backend image to GitHub Container Registry (GHCR) and Docker Hub.
 
 **Triggers:**
 - Tag push matching `v*` (e.g., `v1.0.0`, `v2.3.1-rc1`)
-- Manual workflow dispatch (for ad-hoc builds)
+- Manual workflow dispatch, with inputs to select the variant (`jvm`, `native`, or `both`) and target platforms
 
 ### Build Outputs
 
-| Variant | Image | Platforms |
-|---------|-------|-----------|
-| **JVM** | `ghcr.io/bmscomp/kates:1.17.0` | `linux/amd64`, `linux/arm64` |
-| **Native** | `ghcr.io/bmscomp/kates:1.17.0-native` | `linux/amd64`, `linux/arm64` |
+| Variant | Images | Platforms |
+|---------|--------|-----------|
+| **JVM** | `ghcr.io/bmscomp/kates:<version>`, `docker.io/bmscomp/kates:<version>` | `linux/amd64`, `linux/arm64` |
+| **Native** | `ghcr.io/bmscomp/kates:<version>-native`, `docker.io/bmscomp/kates:<version>-native` | `linux/amd64`, `linux/arm64` |
 
 ### Process
 
-1. **Checkout** at the tagged commit
-2. **Build** both JVM and native variants using Docker Buildx
-3. **Create multi-platform manifest** — a single tag resolves to the correct architecture at pull time
-4. **Push** to `ghcr.io/bmscomp/kates` with version tag and `latest`
-5. **Sign** images with Cosign (when signing keys are configured)
-6. **Attest** provenance using SLSA GitHub generator
+1. **Compute the matrix** — the version is derived from the tag; each platform is mapped to a native runner (amd64 → `ubuntu-latest`, arm64 → `ubuntu-24.04-arm`), so no QEMU emulation is used
+2. **Build and push per-architecture images** tagged `sha-<commit>-<arch>-<variant>` to both registries
+3. **Create multi-platform manifests** — `docker manifest create` combines the per-arch images so a single tag resolves to the correct architecture at pull time
+4. **Sign** the release manifests with Cosign keyless signing (`cosign sign --yes`), on tag builds
+5. **Verify** — pulls and inspects the published manifests
+6. **Update charts** — bumps `appVersion` in `charts/kates` and `charts/kates-chaos` on `main` and commits with `[skip ci]`
 
 ### Image Tags
 
 | Tag Pattern | Example | Description |
 |------------|---------|-------------|
-| `v<semver>` | `v1.2.0` | Specific release version |
-| `v<semver>-native` | `v1.2.0-native` | Native image variant |
-| `latest` | — | Latest release (JVM) |
-| `latest-native` | — | Latest release (native) |
-| `sha-<commit>` | `sha-abc1234` | Commit-specific build (manual dispatch) |
+| `<semver>` | `1.20.0` | Specific release version (the tag's leading `v` is stripped) |
+| `<major>.<minor>`, `<major>` | `1.20`, `1` | Floating minor and major tags |
+| `<semver>-native` | `1.20.0-native` | Native image variant |
+| `<short-sha>` | `abc1234` | Commit-specific manifest tag |
+| `sha-<commit>-<arch>-<variant>` | `sha-abc…-arm64-jvm` | Per-architecture intermediate build |
 
 ---
 
@@ -240,15 +239,16 @@ graph TD
 
 **Triggers:**
 - Tag push matching `v*`
+- Manual workflow dispatch
 
 ### Image Details
 
 | Property | Value |
 |----------|-------|
-| **Image** | `ghcr.io/bmscomp/kates-tester:1.17.0` |
-| **Base** | Minimal Alpine/distroless |
-| **Contents** | Pre-built Kates CLI binary, `curl`, `kafkacat`, connectivity test scripts |
-| **Platforms** | `linux/amd64`, `linux/arm64` |
+| **Images** | `ghcr.io/bmscomp/kates-tester:<version>`, `docker.io/bmscomp/kates-tester:<version>` |
+| **Base** | `debian:bookworm-slim` |
+| **Contents** | `kcat`, the Apache Kafka CLI scripts, `kubectl`, `curl`, `jq`, DNS and netcat utilities |
+| **Platforms** | `linux/amd64`, `linux/arm64` (cross-built with QEMU) |
 
 The tester image is referenced by the `kafka-cluster` Helm chart's test hooks (`helm test kafka-cluster`). It validates Kafka connectivity, SCRAM authentication, and ACL enforcement from inside the cluster.
 
@@ -272,11 +272,11 @@ The tester image is referenced by the `kafka-cluster` Helm chart's test hooks (`
 
 ### Release Process
 
-1. **Cross-compile** — `GOOS` and `GOARCH` environment variables target each platform
+1. **Cross-compile** — `GOOS` and `GOARCH` target each platform with `CGO_ENABLED=0`; the version, commit, and build date are embedded via `-ldflags`
 2. **Compress** — each binary is compressed with `tar.gz`
-3. **Checksum** — SHA-256 checksums are generated for all artifacts
-4. **Create GitHub Release** — uses the tag name as the release title
-5. **Upload assets** — all binaries, checksums, and the changelog are attached to the release
+3. **Checksum** — a SHA-256 checksum is generated per artifact, plus an aggregated `checksums.txt`
+4. **Create GitHub Release** — uses the tag as the release, with auto-generated release notes; all tarballs and checksums are attached
+5. **Update Homebrew tap** — regenerates `Formula/kates.rb` in the `bmscomp/homebrew-tap` repository so `brew install bmscomp/tap/kates` resolves to the new release
 
 ### Installation
 
@@ -299,27 +299,28 @@ kates version
 
 ## Workflow Dependencies
 
-The following diagram shows the dependency and sequencing relationships between workflows:
+The following diagram shows how the workflows relate:
 
 ```mermaid
 graph LR
-    subgraph "On Every PR / Push"
-        A[ci.yml] -->|"tests pass"| B[ci-docker.yml]
-        B -->|"builds pass"| C[integration.yml]
+    subgraph "On Every PR / Push (parallel, path-filtered)"
+        A[ci.yml]
+        B[ci-docker.yml]
+        C[integration.yml]
     end
 
-    subgraph "On Tag v*"
+    subgraph "On Tag v* (parallel)"
         D[publish-docker.yml]
         E[publish-tester.yml]
         F[release-cli.yml]
     end
 
-    C -.->|"merge to main + tag"| D
-    C -.->|"merge to main + tag"| E
+    A -.->|"merge to main + tag"| D
+    B -.->|"merge to main + tag"| E
     C -.->|"merge to main + tag"| F
 ```
 
-**PR / Push flow:** Every pull request and push to `main` runs the validation pipeline (`ci` → `ci-docker` → `integration`). All three must pass before merging.
+**PR / Push flow:** Every pull request and push to `main` runs the validation workflows in parallel. They are not chained — each triggers independently from its own path filter, so a given change may run one, two, or all three.
 
 **Release flow:** When a version tag is pushed, three independent release workflows run in parallel — publishing Docker images, the tester image, and CLI binaries.
 
@@ -329,10 +330,10 @@ The release workflows require these GitHub repository secrets:
 
 | Secret | Used By | Purpose |
 |--------|---------|---------|
-| `GITHUB_TOKEN` | All workflows | Automatic — used for GHCR login and release creation |
-| `COSIGN_PRIVATE_KEY` | `publish-docker.yml` | Cosign signing key for image signatures |
-| `COSIGN_PASSWORD` | `publish-docker.yml` | Passphrase for the Cosign key |
+| `GITHUB_TOKEN` | All workflows | Automatic — used for GHCR login, release creation, and chart-bump commits |
+| `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` | `publish-docker.yml`, `publish-tester.yml` | Docker Hub login for pushing images |
+| `HOMEBREW_TAP_TOKEN` | `release-cli.yml` | Pushes the updated formula to `bmscomp/homebrew-tap` |
 
 ::: {.callout-note}
-`GITHUB_TOKEN` is automatically provided by GitHub Actions. Only `COSIGN_*` secrets need manual configuration in the repository settings, and only if image signing is enabled.
+`GITHUB_TOKEN` is automatically provided by GitHub Actions; the Docker Hub and Homebrew tap credentials must be configured manually in the repository settings. Image signing uses Cosign **keyless** signing through the workflow's OIDC identity — no signing-key secrets are required.
 :::


### PR DESCRIPTION
## Summary

Phase 2 of the book enhancement plan: the **truth pass**. Every fabricated or drifted claim identified by the 28-agent audit gets corrected, chapter by chapter, with each fix verified against the actual source (CLI Go files, Java resources, `kates.proto`, charts, Makefile, workflows) before the edit.

All 24 chapters are complete and verified; the branch is rebased onto main so the diff is pure phase 2.

## What gets fixed (across the full pass)

**Fabricated features removed** — content that documented things that don't exist:
- `INTEGRITY_CHAOS` test type (4 chapters) → the real pattern: `integrity-tx` scenario + a chapter-7 disruption
- gRPC `StreamTestStatus` streaming RPC (never in the proto) — diagram, section, and selling points removed
- The claim that Kates corrects for coordinated omission "in the LatencyHistogram" (it doesn't)
- `kates tenant onboard/verify` quick-start with fake transcripts → working kubectl-based replacement
- `kates rebalance`, `kates kafka status/users/logs`, `gate -f`, `test create --label/--enable-idempotence/--enable-crc`, `make gameday PLAYBOOK=…`, `make images/registry-status/chaos-experiments`, invented error transcripts and PromQL

**Drift corrected** — true once, wrong now:
- Kafka 4.1.1 → 4.2.0, Java 25 → 21, image tags 1.17.0 → 1.20.0, Drain Cleaner 1.5.0 → 1.0.0, connect chart 1.0.0 → 1.2.0
- 10 → 13 disruption types; alert/dashboard counts vs the real PrometheusRule and dashboard files; LOAD defaults; the corrupted `10241.0.000` value
- Migration-history table (real V5–V15), hybrid chaos provider behavior, Lab median-mode behavior, gRPC unified-server port story, REST disruption endpoints, Strimzi OCI install commands
- Request/response examples regenerated from the actual proto and JAX-RS resources

## Verification

- Each editor agent verified findings against the repo before editing and skipped anything already correct
- Banned-token sweep passes on all landed chapters (`INTEGRITY_CHAOS`, `StreamTestStatus`, phantom flags — zero hits)
- Full gate before ready-for-review: adversarial verifiers on the six biggest rewrites, link/anchor validation, full local Quarto render

