### PR TITLE
ci(book): never let the PDF block the site; bound the build

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -23,6 +23,7 @@ jobs:
   build:
     name: Render Book
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 
@@ -41,13 +42,19 @@ jobs:
       - name: Prepare sources for Quarto
         run: ./scripts/prepare-book-render.sh
 
-      - name: Render (HTML only, PR gate)
-        if: github.event_name == 'pull_request'
-        run: quarto render docs/book --to html
-
-      - name: Render (HTML + PDF)
+      # The PDF (102 chromium-rendered diagrams + xelatex) is best-effort:
+      # a slow or wedged PDF build must never block publishing the site.
+      # On failure the site's PDF download link 404s until the next
+      # successful run — acceptable degradation. Rendered before HTML so
+      # the site output is always the final, complete state in _book.
+      - name: Render PDF (best-effort)
         if: github.event_name == 'push'
-        run: quarto render docs/book
+        continue-on-error: true
+        timeout-minutes: 25
+        run: quarto render docs/book --to pdf
+
+      - name: Render HTML
+        run: quarto render docs/book --to html
 
       - name: Upload site artifact
         if: github.event_name == 'push'


### PR DESCRIPTION
## Summary

The first main-branch Book run wedged in the combined HTML+PDF render step (102 Chromium-rendered mermaid diagrams + xelatex on a 2-core runner) and would have burned the 6-hour default job limit — the site never published. I cancelled that run.

## What changed

- `timeout-minutes: 45` backstop on the build job
- The PDF renders as its own best-effort step (`continue-on-error: true`, 25-minute cap), and renders *before* HTML so the uploaded site is always the final complete state of `_book` — a failed or slow PDF now only means the site's PDF download link 404s until the next successful run
- HTML renders unconditionally on both PR and push

After merge I'll re-trigger the main run; the site should then publish at https://bmscomp.github.io/kates/ (Pages is already enabled with the Actions source).
