### PR TITLE
docs(book): style sheet, mechanical conformance, and CI lint (phase 4)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Verify book version matrix matches repo pins
         run: ./scripts/gen-version-matrix.sh --check
 
+      - name: Verify book style rules
+        run: ./scripts/check-book-style.sh
+
   link-check:
     name: Markdown Link Check
     runs-on: ubuntu-latest

--- a/docs/book/02-architecture.md
+++ b/docs/book/02-architecture.md
@@ -145,7 +145,7 @@ Key methods:
 | Method | Lock | Purpose |
 |--------|------|---------|
 | `recordLatency(latencyMs)` | Write | Record a single latency observation |
-| `getPercentile(p)` | Read | Compute p50/p95/p99 from cumulative distribution |
+| `getPercentile(p)` | Read | Compute P50/P95/P99 from cumulative distribution |
 | `exportBuckets()` | Read | Compress to 25 heatmap ranges (non-destructive) |
 | `snapshotAndReset()` | Write | Atomic capture + reset for windowed collection |
 
@@ -454,5 +454,4 @@ Distributed systems fail in partial ways. Kates is designed to degrade gracefull
 ::: {.callout-note}
 The backend's resilience depends on Kafka's durability guarantees. Because test results are written to `kates-results` (RF=3, `acks=all`) before being persisted to PostgreSQL, the Kafka topic serves as a durable write-ahead log. This is a deliberate architectural choice — Kafka is the source of truth, PostgreSQL is the queryable projection.
 :::
-
 

--- a/docs/book/03-cluster.md
+++ b/docs/book/03-cluster.md
@@ -62,7 +62,6 @@ Strimzi's `rack` configuration uses these labels to ensure:
 You can verify the zone distribution at any time with `kates cluster topology`. If all brokers end up in the same zone, rack-aware assignment won't protect you from a zone failure — and your chaos tests will give you false confidence.
 :::
 
-
 ## Resource Budget
 
 | Component | Memory (req=limit) | CPU (req / limit) | Storage | JVM Heap |
@@ -121,7 +120,6 @@ This matrix is the most important table in this chapter. It tells you exactly wh
 Notice that **2 brokers down** means writes are rejected, but **no data is lost**. This is the difference between *availability* and *durability*. With `min.insync.replicas=2`, Kafka trades availability for durability — it would rather refuse writes than risk losing data. Understanding this trade-off is fundamental to designing meaningful chaos experiments.
 :::
 
-
 ### What Happens During a Broker Failure
 
 When a broker goes down, the sequence of events matters for understanding your test results:
@@ -179,7 +177,6 @@ kubectl label node gamma topology.kubernetes.io/zone-
 ::: {.callout-warning}
 Remember to re-apply zone labels after testing. Without rack awareness, a single node failure can cause data loss if all replicas of a partition happen to be on the same node.
 :::
-
 
 ## Listeners
 

--- a/docs/book/04-performance-theory.md
+++ b/docs/book/04-performance-theory.md
@@ -39,7 +39,7 @@ For Kafka, throughput is measured in two dimensions:
 
 Both matter. A system processing 100,000 tiny 100-byte messages/s has very different characteristics than one processing 10,000 large 10KB messages/s — even though the MB/s might be similar.
 
-In Kates, we measure:
+Kates measures:
 
 - **Average throughput** — total records / total duration
 - **Peak throughput** — highest throughput observed in any sampling window
@@ -125,7 +125,6 @@ In Kafka, tail latency is caused by:
 ::: {.callout-tip}
 GC pauses are the most common source of tail latency in Kates benchmarks. Switching to **ZGC** reduces GC pauses to under 1ms regardless of heap size. Kates deploys with generational ZGC by default (`-XX:+UseZGC -XX:+ZGenerational` on its JDK 21 base image; newer JDKs make generational mode the default) — see [Deployment Guide](12-deployment.md#jvm-tuning) for details.
 :::
-
 
 ## Coordinated Omission
 

--- a/docs/book/05-test-types.md
+++ b/docs/book/05-test-types.md
@@ -106,7 +106,6 @@ Healthy ranges are environment-dependent — treat these as starting points and 
 For iterative parameter tuning, use `kates lab` instead of individual `test create` commands. Lab lets you tweak parameters, run tests, and compare results in a single session — see [Lab — Interactive Performance Tuning](10b-lab.md).
 :::
 
-
 ---
 
 ## STRESS Test

--- a/docs/book/08-data-integrity.md
+++ b/docs/book/08-data-integrity.md
@@ -58,7 +58,7 @@ graph TB
 
 Each message in an INTEGRITY test carries a 28-byte binary header (`SequencedPayload`), zero-padded to the configured record size:
 
-```
+```text
 [8 bytes] sequence number   (long)
 [8 bytes] timestamp nanos   (long)
 [8 bytes] run ID hash       (long)
@@ -249,7 +249,7 @@ A clean run contains only the final `SUMMARY` event.
 
 ### PASS — Zero Data Loss
 
-```
+```text
   ▸ Data Integrity
   Sent                     100.0K
   Acked                    100.0K
@@ -267,7 +267,7 @@ This is the expected result for a properly configured cluster with `acks=all` an
 
 ### DATA_LOSS — Messages Missing
 
-```
+```text
   ▸ Data Integrity
   Sent                     100.0K
   Acked                    100.0K
@@ -299,7 +299,7 @@ Data loss indicates a serious issue. Common causes:
 
 ### PASS with Unacked Messages
 
-```
+```text
   ▸ Data Integrity
   Sent                     100.0K
   Acked                    100.0K
@@ -369,7 +369,7 @@ Ad-hoc `create` runs use the backend defaults: CRC verification is on, but idemp
 
 With `--wait`, `kates test apply` shows a spinner per scenario and a summary table once each test finishes, including the SLA gates from the `validate:` block:
 
-```
+```text
   Applying 1 scenario(s) from integrity-tx.yaml
 
   ▸ Transactional Integrity Verification (INTEGRITY)...
@@ -392,7 +392,7 @@ kates test get <id>
 
 The report starts with the test details, configuration, and per-phase results; for INTEGRITY tests it ends with a Data Integrity section. A successful `integrity-tx` run produces:
 
-```
+```text
   ▸ Data Integrity
   Sent                     200.0K
   Acked                    200.0K
@@ -425,7 +425,7 @@ The report starts with the test details, configuration, and per-phase results; f
 
 If the test detects data loss, the Data Integrity section changes to:
 
-```
+```text
   ▸ Data Integrity
   Sent                     200.0K
   Acked                    200.0K

--- a/docs/book/09-observability.md
+++ b/docs/book/09-observability.md
@@ -80,7 +80,6 @@ Finally, open the **Replication** row of the **Kafka Performance Testing** dashb
 Get in the habit of following this sequence — cluster health → performance → internals → replication — after every test. It takes 60 seconds and catches problems that aggregate metrics hide. If a test result surprises you, the dashboards will almost always explain why.
 :::
 
-
 ---
 
 ## Kafka Grafana Dashboards
@@ -167,7 +166,7 @@ The **Strimzi Operator & Kafka Connect** dashboard (`strimzi-operator-dashboard.
 
 | Panel | Metric | Alert Level |
 |-------|--------|:---:|
-| Reconciliation p99 | `strimzi_reconciliations_duration_seconds_bucket` | > 120s = warning |
+| Reconciliation P99 | `strimzi_reconciliations_duration_seconds_bucket` | > 120s = warning |
 | Success/failure rate | `strimzi_reconciliations_{successful,failed}_total` | > 3 failures in 15m |
 | Queue depth | Pending reconciliations | > 20 = critical |
 | Resources per kind | `strimzi_resources{kind=...}` | Informational |
@@ -175,7 +174,7 @@ The **Strimzi Operator & Kafka Connect** dashboard (`strimzi-operator-dashboard.
 | Connect records/min | `kafka_connect_sink_task_sink_record_send_total` | Informational |
 | Connect error rate | `kafka_connect_task_error_total_errors_logged` | > 5 in 10m = warning |
 
-**Reconciliation p99** matters because Strimzi applies your desired state (topics, users, broker config) through a reconciliation loop. If reconciliations are slow, your configuration changes take longer to apply. **Queue depth** above 20 means the operator is overwhelmed — usually because too many resources changed simultaneously.
+**Reconciliation P99** matters because Strimzi applies your desired state (topics, users, broker config) through a reconciliation loop. If reconciliations are slow, your configuration changes take longer to apply. **Queue depth** above 20 means the operator is overwhelmed — usually because too many resources changed simultaneously.
 
 ---
 
@@ -193,8 +192,8 @@ This is your real-time view during active benchmark runs. Open it *while a test 
 |---|---|
 | Benchmark Status | Active runs, total records, total errors, SLA violations |
 | Throughput | Records/sec and MB/sec timeseries |
-| Latency | Percentiles (p50/p95/p99/p99.9) and max latency |
-| Phase Detail | Throughput by phase, latency by phase (p99), records by phase |
+| Latency | Percentiles (P50/P95/P99/P99.9) and max latency |
+| Phase Detail | Throughput by phase, latency by phase (P99), records by phase |
 | SLA & Errors | Error rate and SLA violations by metric/severity |
 
 **Template variables:** `$run_id`, `$test_type` — use these to drill down into a specific test run or compare different test types side by side.
@@ -208,10 +207,10 @@ Where the Benchmark dashboard shows one test, the Trend dashboard shows *all* te
 | Row | Panels |
 |---|---|
 | Throughput Trend | Peak throughput across runs |
-| Latency Trend | p99 and p99.9 latency trend |
+| Latency Trend | P99 and P99.9 latency trend |
 | Regression Detection | Total records per run |
-| Platform Stats | Tests completed (by outcome), test duration (p50/p95/p99), SLA pass/fail rate, records processed rate |
-| Disruptions | Disruption completion rate, disruption duration (p50/p95) |
+| Platform Stats | Tests completed (by outcome), test duration (P50/P95/P99), SLA pass/fail rate, records processed rate |
+| Disruptions | Disruption completion rate, disruption duration (P50/P95) |
 
 **Template variable:** `$test_type`
 
@@ -224,7 +223,7 @@ This dashboard monitors the Kates engine itself — not Kafka, not the test resu
 | Row | Panels |
 |---|---|
 | Pod Status | Pods ready, restart count, uptime, Postgres ready |
-| HTTP Server | Request rate (by method), error rate (4xx/5xx), request latency (p50/p95/p99) |
+| HTTP Server | Request rate (by method), error rate (4xx/5xx), request latency (P50/P95/P99) |
 | JVM | Heap memory (used/committed/max), GC pause duration, thread count (live/daemon/peak) |
 | Database | Agroal pool connections (active/available/max used), DB acquire time |
 | Resource Usage | CPU usage (per pod), memory RSS and working set |
@@ -243,7 +242,7 @@ This is the most specialized dashboard in the stack. It correlates LitmusChaos e
 | Kafka Health During Chaos | Broker pod status, restarts, CPU usage, memory usage |
 | Chaos Experiment History | Experiment duration over time |
 | RTO / RPO / Data Integrity | Producer RTO, consumer RTO, data loss %, RPO, E2E latency, producer throughput |
-| Kates During Chaos | Benchmark throughput overlay, p99 latency overlay, error rate during chaos |
+| Kates During Chaos | Benchmark throughput overlay, P99 latency overlay, error rate during chaos |
 
 The **RTO / RPO / Data Integrity** row is particularly valuable — it shows exactly how long your producers and consumers were unable to operate (RTO), how much data was at risk (RPO), and whether any messages were lost. These are the metrics that matter for disaster recovery SLAs.
 
@@ -262,7 +261,7 @@ Registered by `BenchmarkMetrics.java` and labeled with `run_id`, `test_type`, an
 | `kates_benchmark_active_runs` | Gauge | Number of active benchmark runs |
 | `kates_benchmark_throughput_rec_sec` | Gauge | Current throughput in records/sec |
 | `kates_benchmark_throughput_mb_sec` | Gauge | Current throughput in MB/sec |
-| `kates_benchmark_latency_ms` | Summary | Request latency distribution (p50/p95/p99/p99.9) |
+| `kates_benchmark_latency_ms` | Summary | Request latency distribution (P50/P95/P99/P99.9) |
 | `kates_benchmark_records_total` | Counter | Total records processed |
 | `kates_benchmark_errors_total` | Counter | Total errors |
 | `kates_benchmark_sla_violations` | Counter | SLA violation events |
@@ -274,12 +273,12 @@ Registered by `KatesMetrics.java` and persistent across benchmark runs. These me
 | Prometheus Metric | Type | Description |
 |---|---|---|
 | `kates_tests_completed_total` | Counter | Total tests completed (by test_type, outcome) |
-| `kates_tests_duration_seconds` | Timer | Test execution duration (p50/p95/p99) |
+| `kates_tests_duration_seconds` | Timer | Test execution duration (P50/P95/P99) |
 | `kates_tests_throughput_rec_sec` | Summary | Final throughput per completed test (records/sec) |
 | `kates_tests_throughput_mb_sec` | Summary | Final throughput per completed test (MB/sec) |
 | `kates_sla_evaluations_total` | Counter | SLA evaluation outcomes (pass/fail) |
 | `kates_disruptions_completed_total` | Counter | Disruption executions completed (by type, outcome) |
-| `kates_disruptions_duration_seconds` | Timer | Disruption execution duration (p50/p95) |
+| `kates_disruptions_duration_seconds` | Timer | Disruption execution duration (P50/P95) |
 | `kates_records_processed_total` | Counter | Cumulative records processed across all tests |
 
 ---
@@ -402,7 +401,7 @@ There is no output-file flag: when stdout is a terminal, the export is written t
 
 ### REST API
 
-```
+```text
 GET /api/tests/{id}/report/heatmap?format=json
 GET /api/tests/{id}/report/heatmap?format=csv
 ```
@@ -447,7 +446,7 @@ kates trend --type LOAD --metric throughputRecordsPerSec --days 30
 
 The CLI renders sparkline charts for quick visual assessment:
 
-```
+```text
   P99 Latency (ms) — LOAD tests, last 30 days
   ▁▁▂▁▁▁▂▁▃▁▁▁▁▂▁▁▁▅▂▁▁▁▁▂▁▁▁▃▁▁
   min: 8.2   avg: 12.5   max: 45.3   current: 11.8
@@ -530,7 +529,7 @@ Kates uses **OpenTelemetry** to propagate traces across the entire request lifec
 Tracing is configured in `application.properties`:
 
 | Property | Value | Purpose |
-|----------|-------|---------| 
+|----------|-------|---------|
 | `quarkus.otel.enabled` | `true` | Master switch for OpenTelemetry |
 | `quarkus.otel.exporter.otlp.endpoint` | `http://jaeger-collector.monitoring.svc:4317` | Jaeger collector address (`http://localhost:4317` in dev) |
 | `quarkus.otel.exporter.otlp.protocol` | `grpc` | Export spans via OTLP over gRPC |
@@ -541,11 +540,10 @@ Tracing is configured in `application.properties`:
 The `0.1` sampling rate in production means only 10% of requests generate traces. This is a deliberate trade-off — tracing adds overhead, and at high throughput you don't need every request traced to spot patterns. In development, 100% sampling is used so you can trace any request.
 :::
 
-
 ### What Gets Traced
 
 | Layer | Span Name Pattern | Details |
-|-------|-------------------|---------| 
+|-------|-------------------|---------|
 | JAX-RS | `GET /api/tests/{id}` | HTTP method + path |
 | Kafka Producer | `kates-results send` | Topic, partition, serialized size |
 | Kafka Consumer | `kates-dlq receive` | Topic, consumer group, lag |
@@ -605,7 +603,7 @@ This alert fires when a consumer group falls behind, meaning messages are being 
         description: "Consumer group {{ $labels.consumergroup }} has {{ $value }} messages lag."
 ```
 
-**When it fires:** Consumer lag exceeds 1 million messages for 15 continuous minutes (warning) or 10 million for 5 minutes (critical).  
+**When it fires:** Consumer lag exceeds 1 million messages for 15 continuous minutes (warning) or 10 million for 5 minutes (critical).
 **What to do:** Check that consumer pods are running (`kubectl get pods`). If they're healthy, consider scaling the consumer group or investigating whether the consumer is blocked on downstream dependencies.
 
 #### Offline Partitions
@@ -625,7 +623,7 @@ This is the most critical Kafka alert. Offline partitions mean messages can't be
         description: "{{ $value }} partitions are offline on cluster krafter."
 ```
 
-**When it fires:** Any partition has no leader for more than 2 minutes.  
+**When it fires:** Any partition has no leader for more than 2 minutes.
 **What to do:** Check which brokers are down (`kates cluster watch`). If a broker crashed, Kafka should elect new leaders automatically — if it doesn't within a couple of minutes, check the KRaft controller logs for election failures.
 
 #### Under-Replicated Partitions (Sustained)
@@ -645,7 +643,7 @@ Transient under-replication is normal during broker restarts. Sustained under-re
         description: "{{ $value }} partitions are under-replicated on {{ $labels.kubernetes_pod_name }}."
 ```
 
-**When it fires:** Any partition has ISR < replication factor for more than 5 minutes.  
+**When it fires:** Any partition has ISR < replication factor for more than 5 minutes.
 **What to do:** Check broker disk I/O and network throughput. Slow disks or saturated networks prevent followers from keeping up with the leader. Also verify that `min.insync.replicas` is correctly configured — see [The Cluster Under Test](03-cluster.md).
 
 ---

--- a/docs/book/10-cli-reference.md
+++ b/docs/book/10-cli-reference.md
@@ -22,7 +22,6 @@ sudo codesign -f -s - /usr/local/bin/kates
 ```
 :::
 
-
 ## Common Workflows
 
 Before diving into individual commands, here are the workflows you'll use most often. Each one chains multiple commands into a real-world task — they're the reason the CLI exists as a unified tool rather than a collection of scripts.
@@ -37,13 +36,13 @@ kates health
 
 # 2. Run a baseline load test on the current Kafka version
 kates test create --type LOAD --records 100000 --wait
-# → note the test ID, e.g. t-a1b2c3
+# Note the test ID (e.g. t-a1b2c3)
 
 # 3. Perform the Kafka upgrade (outside of Kates)
 
 # 4. Run the same load test on the new version
 kates test create --type LOAD --records 100000 --wait
-# → note the new test ID, e.g. t-d4e5f6
+# Note the new test ID (e.g. t-d4e5f6)
 
 # 5. Compare the two runs side by side
 kates report diff t-a1b2c3 t-d4e5f6
@@ -125,7 +124,6 @@ kates gate --min-grade B --type LOAD --records 100000
 See [CI/CD Pipeline](appendix-c-cicd.md) for complete GitHub Actions, GitLab CI, and Jenkins pipeline examples.
 :::
 
-
 ## Configuration
 
 Kates CLI uses a config file at `~/.kates.yaml` for managing server contexts.
@@ -206,7 +204,7 @@ kates health
 
 Expected output:
 
-```
+```text
  Kates Health Dashboard — System Status: UP
 
   Engine
@@ -235,7 +233,7 @@ kates status
 
 Expected output:
 
-```
+```text
   ✓ local │ UP │ Kafka ✓ │ 12 configs │ 0 running │ 8 done │ 0 failed
 ```
 
@@ -251,7 +249,7 @@ kates version
 
 #### doctor
 
-Aliases: `preflight`, `check`
+Aliases: `pre-flight`, `check`
 
 Pre-flight cluster readiness checklist. The doctor command verifies that the Kates API is reachable, Kafka is connected, the broker count meets the 3-broker minimum, ISR health is clean, topics are listable, and benchmark backends are available. It also checks whether Kyverno is installed with active policies and no workload violations (Kyverno checks warn rather than fail — it's optional but recommended). Failing checks come with remediation hints. It's the first command to run when something "feels wrong" but `kates health` reports healthy.
 
@@ -263,7 +261,7 @@ kates check
 
 Expected output:
 
-```
+```text
  Kates Doctor — Pre-flight cluster readiness
 
   Check                Status   Detail
@@ -330,7 +328,7 @@ kates cluster info
 
 Expected output:
 
-```
+```text
  Kafka Cluster — Cluster ID: dQw4w9WgXcQ
 
   Overview
@@ -372,7 +370,7 @@ kates cluster topology -o json
 
 Expected output (abbreviated — full output includes all sections listed below):
 
-```
+```text
  Kafka Cluster Topology — Cluster: krafter  │  Kafka 4.2.0  │  KRaft Mode
 
   Kubernetes Platform
@@ -581,7 +579,7 @@ kates test scaffold export --all           # export every template
 
 | Template | Type | Description |
 |----------|------|-------------|
-| `quick-load` | LOAD | Quick smoke test — 50k records, 2 producers, p99 < 100ms gate |
+| `quick-load` | LOAD | Quick smoke test — 50k records, 2 producers, P99 < 100ms gate |
 | `production-load` | LOAD | Production-grade — 1M records, 8 producers, acks=all, lz4, strict SLA |
 | `stress-test` | STRESS | High-throughput stress — 5M records, 16 producers, find breaking points |
 | `endurance-soak` | ENDURANCE | 1-hour soak at 5k msg/s — detect GC pauses and log compaction issues |
@@ -608,7 +606,7 @@ Display the full report for a test run.
 
 Expected output:
 
-```
+```text
  Performance Report — Test: a1b2c3
 
   Throughput
@@ -710,7 +708,7 @@ kates trend phases --type SPIKE --days 30
 
 Expected output:
 
-```
+```text
  Trend Analysis — LOAD · p99LatencyMs · 30d window
 
   Baseline:   20.10
@@ -995,7 +993,7 @@ kates deploy status
 
 Expected output:
 
-```
+```text
   Operators & CRDs
     Strimzi Operator      [Healthy]
     Cert-Manager          [Healthy]
@@ -1025,7 +1023,7 @@ kates clean --force
 
 #### detect
 
-Aliases: `preflight-cluster`, `cluster-check`
+Aliases: `pre-flight-cluster`, `cluster-check`
 
 Deep cluster compatibility report for 3-AZ Kafka.
 
@@ -1363,7 +1361,7 @@ kates kafka topics
 
 Expected output:
 
-```
+```text
  Kafka Topics (42)
 
   Topic                    Type       Partitions   Rep. Factor   ISR Health

--- a/docs/book/10b-lab.md
+++ b/docs/book/10b-lab.md
@@ -20,7 +20,7 @@ kates lab
 
 Lab splits the terminal into two panes:
 
-```
+```text
 ┌─────────────────────────────────────────────────────────┐
 │  Kates Lab  ·  Interactive Performance Tuning  →  URL   │
 ├──────────────────────────┬──────────────────────────────┤
@@ -104,7 +104,7 @@ Each completed test creates an **iteration** — a snapshot of parameters and re
 
 While a test runs, the status bar shows the iteration number and elapsed time, updating every second:
 
-```
+```text
 ⏳ Running iteration #4…  (12s)
 ```
 
@@ -116,7 +116,7 @@ Throughput and latency metrics appear once the test completes.
 
 Press `d` to see a side-by-side comparison of the last two iterations (or the currently pinned pair):
 
-```
+```text
 Diff: #2 vs #3
 
 Metric            #2              #3              Change
@@ -137,7 +137,7 @@ The diff view highlights which parameters changed between the two iterations alo
 
 Press `c` to open the pin-select view, where you can pick **any** two iterations using `↑↓` for A and `←→` for B:
 
-```
+```text
 Select Iterations to Compare
 
   ↑↓ = iteration A    ←→ = iteration B
@@ -157,7 +157,7 @@ Auto-sweep systematically tests every value of a parameter while holding all oth
 2. Press `s`
 3. Lab runs a test for each value: 16384 → 32768 → 65536 → 131072 → 262144
 
-```
+```text
 ⟳ Sweep Batch Size = 65536 (3/5)
 ```
 
@@ -169,7 +169,7 @@ The JVM needs time to JIT-compile hot code paths. The first 1–3 runs in a fres
 
 Press `W` to cycle the warmup count (1 → 2 → 3 → 4 → 5 → off):
 
-```
+```text
 🔥 Warmup: 2 iteration(s) before measuring
 ```
 
@@ -179,14 +179,13 @@ When you press `Enter`, Lab runs 2 silent warmup iterations (results discarded) 
 For stress tests with `acks=all`, set warmup to **2**. For quick load tests, **1** is usually enough.
 :::
 
-
 ## Median Mode (`m`)
 
 Even after warmup, individual runs vary due to GC pauses, I/O scheduling, and OS jitter. Median mode runs the **same configuration 3 times** and records only the median result (by throughput), eliminating outliers.
 
 Press `m` to start:
 
-```
+```text
 📊 Median mode: running 2/3…
 ```
 
@@ -196,14 +195,13 @@ After all 3 runs complete, a single iteration is added to the history with the m
 Median mode ignores the warmup setting: pressing `m` always runs exactly 3 back-to-back tests, with no warmup iterations inserted. Warmup applies only to tests started with `Enter`. In practice the first of the 3 median runs absorbs most of the warmup effect anyway.
 :::
 
-
 ## Export & Sessions
 
 ### CSV Export (`e`)
 
 Exports all iterations with full parameters to a timestamped CSV file:
 
-```
+```text
 ~/kates-lab-20260313-213045.csv
 ```
 
@@ -227,7 +225,7 @@ Press `x` during a running test to cancel it immediately. Lab sends a `POST /api
 
 If a test fails (network error, timeout, etc.), the status bar shows:
 
-```
+```text
 ✖ connection refused  ·  press r to retry
 ```
 

--- a/docs/book/11-api-reference.md
+++ b/docs/book/11-api-reference.md
@@ -32,13 +32,15 @@ Requests without a key receive `401 Unauthorized`; requests with a wrong key rec
 | `Authorization` | `Bearer <api-key>` | When security enabled | API key (alternative: `X-API-Key`) |
 | `X-API-Key` | `<api-key>` | When security enabled | API key (alternative to `Authorization`) |
 
-> **Tip:** In Quarkus dev mode and in tests, security is switched off (`%dev.kates.api.security-enabled=false`), so no authentication headers are needed there.
+::: {.callout-tip}
+In Quarkus dev mode and in tests, security is switched off (`%dev.kates.api.security-enabled=false`), so no authentication headers are needed there.
+:::
 
 ---
 
 ## Base URL
 
-```
+```text
 http://localhost:30083
 ```
 
@@ -249,7 +251,7 @@ When an SLA is violated, `overallSlaVerdict.violations` contains entries of the 
 
 Export report as CSV. **Response:** `200 OK` with `Content-Type: text/csv`
 
-```
+```text
 runId,testType,backend,phase,recordsSent,throughputRecPerSec,throughputMBPerSec,avgLatencyMs,p50LatencyMs,p95LatencyMs,p99LatencyMs,maxLatencyMs,error
 a1b2c3d4,LOAD,native,ramp-up,10000,5234.1,5.1,4.8,3.2,9.6,18.4,45.2,
 a1b2c3d4,LOAD,native,steady-state,90000,8412.7,8.2,2.4,1.8,5.6,12.3,34.1,

--- a/docs/book/12-deployment.md
+++ b/docs/book/12-deployment.md
@@ -11,7 +11,7 @@ This chapter walks you through those decisions. You'll start with the architectu
 ## Prerequisites
 
 | Tool | Version | Purpose |
-|------|---------|---------| 
+|------|---------|---------|
 | Docker | 20.10+ | Container runtime |
 | Kind | 0.20+ | Local Kubernetes cluster |
 | kubectl | 1.28+ | Kubernetes CLI |
@@ -48,7 +48,6 @@ The Kates stack uses four namespaces by default:
 ::: {.callout-tip}
 For local Kind deployments, the multi-namespace layout still works — `make all` prompts you to choose between a single-namespace topology (everything in `kates-stack`) and the isolated multi-namespace topology, and the underlying `kates deploy` command defaults to `--topology isolated`. The only time single-namespace makes sense is throwaway CI environments where fast teardown (`kubectl delete namespace`) matters more than isolation.
 :::
-
 
 ### NodePort vs Ingress vs LoadBalancer
 
@@ -145,7 +144,6 @@ The following table shows resource requirements per component. Use this to right
 ::: {.callout-important}
 The **Minimal** profile (16 GB) runs everything but leaves almost no headroom. If your laptop has 16 GB of RAM, close memory-heavy applications (browsers, IDEs with large projects) before running `make all`. Docker Desktop should be configured with at least 10 GB of memory allocation.
 :::
-
 
 ---
 
@@ -298,7 +296,6 @@ monitoring:
 These YAML overlays are passed via `helm upgrade --install -f values-eks.yaml` (or `-f values-gke.yaml`, etc.) alongside the base `values.yaml`. They override only the keys specified — all other defaults remain unchanged.
 :::
 
-
 ---
 
 ## Quick Deployment
@@ -384,12 +381,12 @@ make litmus
 
 # Access Litmus UI
 make chaos-ui
-# → http://localhost:9091 (admin/litmus)
+# Opens http://localhost:9091 (admin/litmus)
 
 # Run the chaos chart's Helm tests
 make litmus-test
 
-# Trigger the GameDay validation via the chaos chart
+# Trigger the Game Day validation via the chaos chart
 make litmus-gameday
 
 # Check chaos status
@@ -455,7 +452,6 @@ The `-Xms512m -Xmx2560m` settings give ZGC a 512 MB starting heap that can grow 
 If you observe `Allocation Stall` warnings in the Kates logs during stress tests, increase `-Xmx` to 3072m or 4096m. This gives ZGC more headroom to collect without stalling application threads.
 :::
 
-
 ### Kates CLI
 
 ```bash
@@ -472,7 +468,6 @@ make cli-clean
 ::: {.callout-note}
 **macOS:** `make cli-install` automatically strips provenance/quarantine extended attributes and ad-hoc codesigns the binary. See [CLI Reference](10-cli-reference.md#installation) for manual install instructions.
 :::
-
 
 ## Access Points
 
@@ -607,7 +602,7 @@ make kates-native
 
 # Verify
 kubectl logs deployment/kates -n kates | head -1
-# → started in 0.047s
+# Expect a startup line like: started in 0.047s
 ```
 
 | Target | Description |
@@ -620,10 +615,10 @@ kubectl logs deployment/kates -n kates | head -1
 | `make test-volume` | Run volume test |
 | `make test-capacity` | Run capacity test |
 | `make litmus-test` | Run the chaos chart's Helm tests |
-| `make litmus-gameday` | Trigger GameDay validation via the chaos chart |
+| `make litmus-gameday` | Trigger Game Day validation via the chaos chart |
 | `make chaos-status` | Check chaos status |
 | `make chaos-ui` | Port-forward the Litmus UI (localhost:9091) |
-| `make gameday` | Run automated GameDay validation pipeline |
+| `make gameday` | Run automated Game Day validation pipeline |
 | `make velero` | Deploy Velero backup |
 | `make chart-lint` | Lint Kates Helm chart |
 | `make ports` | Start port forwarding |
@@ -666,11 +661,11 @@ ACLs are declared via `KafkaUser` CRs (GitOps):
 Kates uses PostgreSQL as its persistent data store for everything that outlives a single test run. Specifically, it stores:
 
 - **Test run metadata** — timestamps, configuration snapshots, which topics and partitions were tested
-- **Performance results** — throughput measurements, latency percentiles (p50/p95/p99), error counts per run
+- **Performance results** — throughput measurements, latency percentiles (P50/P95/P99), error counts per run
 - **Historical baselines** — aggregated metrics used by the `kates report compare` and `kates test compare` commands to detect regressions
 - **Audit records** — who ran what test, when, and with which parameters
 
-Why PostgreSQL and not Kafka itself? Kafka is optimized for sequential append and time-windowed retention — it's not designed for the random-access queries that trend analysis and historical comparison require. PostgreSQL gives you indexed queries like "show me p99 latency for topic X across the last 30 runs" that would be impractical with Kafka's log-based storage.
+Why PostgreSQL and not Kafka itself? Kafka is optimized for sequential append and time-windowed retention — it's not designed for the random-access queries that trend analysis and historical comparison require. PostgreSQL gives you indexed queries like "show me P99 latency for topic X across the last 30 runs" that would be impractical with Kafka's log-based storage.
 
 #### Read-Only Filesystem Compliance
 
@@ -703,8 +698,7 @@ volumes:
 These `emptyDir` volumes are ephemeral — they do not survive pod restarts. This is safe because `/var/run/postgresql` and `/tmp` contain only runtime artifacts (sockets, lock files, temp data). Persistent data is stored on the PVC-backed `/var/lib/postgresql/data` volume.
 :::
 
-
-## GameDay Validation
+## Game Day Validation
 
 Run an automated 7-phase validation pipeline:
 

--- a/docs/book/13-scenario-files.md
+++ b/docs/book/13-scenario-files.md
@@ -291,7 +291,7 @@ kates test apply -f scenarios.yaml --wait
 
 Running with `--wait`:
 
-```
+```text
   ▸ Baseline Load Test (LOAD)...
   ✓   Created: 3f8a2c1e-9b4…
   ✓ Baseline Load Test → DONE
@@ -414,7 +414,7 @@ scenarios:
 
 SLA threshold values must be plain numbers, not strings with units — the field name already indicates the unit (e.g., `maxP99LatencyMs` implies milliseconds). A string value fails YAML decoding, so the whole run aborts with the raw parse error:
 
-```
+```text
   ✖ Invalid scenario file: yaml: unmarshal errors:
   line 8: cannot unmarshal !!str `50ms` into float64
 ```

--- a/docs/book/14-recipes.md
+++ b/docs/book/14-recipes.md
@@ -36,7 +36,7 @@ kates report diff <baseline-id> <new-id>
 
 Expected output:
 
-```
+```text
   ▸ Report Diff: a1b2c3d4 vs e5f6a7b8
   ┌─────────────────────┬───────────┬───────────┬────────┐
   │ Metric              │ Baseline  │ New       │ Delta  │
@@ -52,7 +52,6 @@ Expected output:
 ::: {.callout-tip}
 If you see `Test run not found` errors, make sure you noted the test IDs from Step 1 output before starting the upgrade. Test IDs are printed after each `kates test apply` or `kates test create` command.
 :::
-
 
 ### Suggested Scenario File
 
@@ -129,7 +128,7 @@ kates trend --type LOAD --metric avgThroughputRecPerSec --days 30
 
 Expected output:
 
-```
+```text
   ▸ Trend: LOAD / p99LatencyMs (30 days, 30 runs)
     Min: 8.2ms  Max: 14.1ms  Avg: 10.5ms
     ▁▁▂▁▁▁▂▁▃▁▁▁▂▁▁▁▁▂▁▁▁▁▁▁▁▇▁▁▁▁
@@ -144,7 +143,6 @@ Expected output:
 ::: {.callout-tip}
 If the schedule doesn't trigger, verify the Kates backend pod is running with `kubectl get pods -n kates -l app.kubernetes.io/name=kates` — the scheduler runs inside the backend, not as a separate pod. The cron expression uses UTC — adjust for your timezone.
 :::
-
 
 A sudden spike in the sparkline indicates a regression. Use `kates report diff` to compare the anomalous run against its predecessor.
 
@@ -213,7 +211,7 @@ kates resilience run -f resilience.json
 
 Expected output:
 
-```
+```text
   Resilience Test Results
   Status: COMPLETED
 
@@ -236,7 +234,6 @@ Expected output:
 ::: {.callout-tip}
 Each playbook run prints an SLA grade at the end. If you need a hard pass/fail gate for CI — exit code 1 on SLA violation — run a custom disruption plan instead: `kates disruption run --config plan.json --fail-on-sla-breach`. Use `kates disruption playbook list` to see the available playbooks and what each one does.
 :::
-
 
 ---
 
@@ -310,7 +307,6 @@ Expected output:
 If the diff shows degraded throughput but the heatmap has no obvious pattern, check the GC logs. Run `kubectl logs <broker-pod> -n kafka | grep 'GC pause'` — JVM garbage collection pauses are a common hidden cause of latency spikes.
 :::
 
-
 If under-replicated or offline partitions show up during the test, the cluster was under stress.
 
 ---
@@ -349,7 +345,7 @@ kates trend --type CAPACITY --metric avgThroughputRecPerSec --days 90
 
 Expected output:
 
-```
+```text
   ▸ Capacity Test Results
   ┌───────┬────────────┬───────────────┬──────────────┐
   │ Phase │ Producers  │ Throughput    │ P99 Latency  │
@@ -367,7 +363,6 @@ Expected output:
 ::: {.callout-tip}
 If capacity results seem unexpectedly low, check that no resource quotas or Kafka user throttling limits are active. Run `kubectl get kafkauser -n kafka -o yaml` and verify the `quotas` section isn't constraining your test user.
 :::
-
 
 ---
 
@@ -424,7 +419,7 @@ kates report compare <id1>,<id2>,<id3>,<id4>
 
 Expected output:
 
-```
+```text
   ▸ Comparison: 4 runs
   ┌───────────────────────┬───────────────┬──────────────┬───────────────────┐
   │ Scenario              │ Throughput    │ P99 Latency  │ Error Rate        │

--- a/docs/book/15-kafka-deployment.md
+++ b/docs/book/15-kafka-deployment.md
@@ -303,7 +303,7 @@ Users are declared as `KafkaUser` CRDs — Strimzi creates a Kubernetes Secret w
 
 **Secret flow:**
 
-```
+```text
 KafkaUser CR → Strimzi User Operator → Kubernetes Secret (name = user name)
                                        → SCRAM credentials in Kafka
                                        → ACLs applied to authorization
@@ -406,11 +406,9 @@ graph LR
 The operator ingress on port `8080` is intentionally open to **all sources** (not scoped to a specific namespace). This is required because Kubelet health probes originate from the node's host network — not from a pod with namespace labels. Restricting ingress to a namespace selector would silently block liveness and readiness checks, causing the operator pod to be restarted by the Kubelet.
 :::
 
-
 ::: {.callout-caution}
 **Do not set `generateNetworkPolicy: true` in the Strimzi Helm values** unless you also provide explicit egress rules in `operatorNetworkPolicy.egress`. When enabled with no egress rules, Strimzi creates an operator NetworkPolicy with empty egress — Kubernetes interprets this as "deny all outgoing traffic." The operator cannot reach the Kafka controllers' admin API (port 9090), causing the Kafka CR to remain `NotReady` indefinitely. Set `generateNetworkPolicy: false` and manage operator network policies manually.
 :::
-
 
 ## Operational Components
 
@@ -460,7 +458,7 @@ These metrics power the consumer lag alerts in `kafka-alerts.yaml`.
 
 The Drain Cleaner intercepts Kubernetes node drain events and gracefully rolls Kafka pods instead of abruptly killing them:
 
-```
+```text
 kubectl drain node → Drain Cleaner webhook intercepts →
   Annotates pod with strimzi.io/delete-pod-and-pvc →
   Strimzi operator performs controlled rolling restart →
@@ -510,8 +508,8 @@ The alerting rules in `kafka-alerts.yaml` cover six categories:
 
 | Alert | Condition | Severity |
 |-------|-----------|----------|
-| `KafkaRequestLatencyHigh` | p99 > 1s for 10min | warning |
-| `KafkaLogFlushLatencyHigh` | p99 > 500ms for 10min | warning |
+| `KafkaRequestLatencyHigh` | P99 > 1s for 10min | warning |
+| `KafkaLogFlushLatencyHigh` | P99 > 500ms for 10min | warning |
 | `KafkaRequestHandlerSaturated` | Handler idle < 30% for 10min | warning |
 | `KafkaISRShrinkRate` | ISR shrinking for 5min | warning |
 
@@ -610,7 +608,7 @@ helm upgrade --install strimzi-operator oci://quay.io/strimzi-helm/strimzi-kafka
 
 **Cause:** The `kafka-ui` Secret is created by the Strimzi Entity Operator (User Operator sub-component) when it reconciles the `KafkaUser` CR. The dependency chain is:
 
-```
+```text
 Kafka CR Ready → Entity Operator deploys → User Operator reconciles KafkaUser → Secret created
 ```
 

--- a/docs/book/16-grpc-api.md
+++ b/docs/book/16-grpc-api.md
@@ -308,7 +308,7 @@ Transport-level codes such as `UNAVAILABLE` come from the gRPC runtime itself (e
 
 **Error output format:**
 
-```
+```text
 ERROR:
   Code: NotFound
   Message: Test not found: abc-123

--- a/docs/book/17-security.md
+++ b/docs/book/17-security.md
@@ -34,7 +34,6 @@ graph TD
 The default performance test listener (`plain`, port 9092) uses SCRAM authentication but **no TLS encryption**. This is intentional — TLS adds measurable CPU overhead, and performance baselines should isolate Kafka throughput from encryption cost. For production deployments, always use the `tls` listener (port 9093) or the `external` listener (port 9094, which enables TLS by default).
 :::
 
-
 ## Security Architecture Overview
 
 ```mermaid
@@ -99,7 +98,6 @@ kubectl get secret kafka-ui -n kafka -o jsonpath='{.data.password}' | base64 -d
 Kubernetes Secrets are base64-encoded, **not encrypted**. Anyone with RBAC permission to read Secrets in the `kafka` namespace can extract every SCRAM password. This is why namespace-level RBAC and NetworkPolicies are not optional — they're the outer wall protecting your credentials.
 :::
 
-
 ### Password Rotation
 
 Strimzi does not automatically rotate SCRAM passwords, but you can trigger a rotation without downtime:
@@ -115,16 +113,15 @@ kubectl wait --for=condition=Ready kafkauser/kates-backend -n kafka --timeout=60
 kubectl get secret kates-backend -n kafka -o jsonpath='{.data.password}' | base64 -d
 ```
 
-If your application runs in a different namespace and uses a Kyverno-synced copy of the secret, the sync policy will automatically propagate the new password. The application will pick up the new credentials on its next reconnection cycle.
+If your application runs in a different namespace and uses a Kyverno-synced copy of the secret, the sync policy propagates the new password automatically, and the application picks up the new credentials on its next reconnection cycle.
 
 ::: {.callout-caution}
 During the brief window between deleting the old Secret and the Entity Operator creating the new one, any application that restarts will fail to authenticate. Time your rotations during low-traffic periods, and ensure your application has retry logic for authentication failures.
 :::
 
-
 ### Cross-Namespace Credential Synchronization
 
-When a `KafkaUser` is created, Strimzi generates the credential Secret only in the namespace where the Strimzi operator and Kafka cluster reside (usually `kafka`). 
+When a `KafkaUser` is created, Strimzi generates the credential Secret only in the namespace where the Strimzi operator and Kafka cluster reside (usually `kafka`).
 
 If your application runs in a different namespace (e.g., `kates`), you must securely synchronize this Secret. **Do not copy it manually**, as Strimzi may rotate the password. Instead, use a Kyverno `ClusterPolicy` to automatically clone and synchronize the Secret:
 
@@ -195,7 +192,6 @@ Every Kafka operation (produce, consume, describe, create, delete) is checked ag
 The `kates-backend` user has superUser status because it needs to create test topics, manage consumer groups, and read cluster metadata during benchmark runs. In a production deployment, you would scope this down to only the specific topics and operations Kates requires.
 :::
 
-
 ### Adding a New Service
 
 When you onboard a new service to your Kafka cluster, follow the principle of least privilege — grant only the permissions the service actually needs. Here's a template:
@@ -236,7 +232,7 @@ The `patternType: prefix` is key — it means the service can access any topic o
 
 ### Granting Full Cluster Rights (Super-User)
 
-If you need to create a service account (like an administrator or automated testing tool) that has **full rights** across the entire Kafka cluster, you must explicitly grant it `All` operations on the `cluster`, `topic`, and `group` resources. 
+If you need to create a service account (like an administrator or automated testing tool) that has **full rights** across the entire Kafka cluster, you must explicitly grant it `All` operations on the `cluster`, `topic`, and `group` resources.
 
 Create a file named `kafka-admin-user.yaml` with the following content:
 
@@ -274,7 +270,7 @@ Apply this file to your cluster:
 kubectl apply -f kafka-admin-user.yaml
 ```
 
-Once the Strimzi Operator processes the resource, it will automatically generate a Kubernetes Secret in the `kafka` namespace with the credentials. You can retrieve the generated SCRAM password using:
+Once the Strimzi Operator processes the resource, it generates a Kubernetes Secret in the `kafka` namespace with the credentials. You can retrieve the generated SCRAM password using:
 ```bash
 kubectl get secret admin-user -n kafka -o jsonpath="{.data.password}" | base64 -d
 ```
@@ -330,7 +326,6 @@ Set up a Prometheus alert for certificates expiring within 30 days:
 This alert is an approximation, not a measurement of the certificate itself. `kube_secret_created` reports when the Secret was **first created** — not the certificate's `NotAfter` date — and the hardcoded `157680000` seconds mirrors the chart's 1825-day CA validity (`clusterCa.validityDays`). Strimzi renews certificates by updating the Secret in place, so the metric never resets: after the first in-place renewal the alert fires permanently, and it drifts silently if you change the validity period. Treat the `openssl x509 -noout -dates` check above as the source of truth.
 :::
 
-
 ## Audit Logging
 
 Kafka's authorizer can log every authorization decision — who accessed what, and when. The authorizer itself is already configured on the krafter cluster: Strimzi derives it from `spec.kafka.authorization` (`type: simple`), and it does not allow `authorizer.class.name` to be set directly in the `config` section — unsupported keys placed there are filtered out. What you control is the log level of `kafka.authorizer.logger`, which lives under `spec.kafka.logging` in the Kafka CR:
@@ -352,7 +347,6 @@ At the default `INFO` level the authorizer logs denied operations only. At `DEBU
 ::: {.callout-tip}
 For lighter-weight auditing, Kates records every mutating operation issued through the backend — test creates and deletes, topic changes, disruption runs — in its audit log. Inspect the trail with `kates audit`, filtering with `--type` and `--since`.
 :::
-
 
 ## Network Policies
 
@@ -460,7 +454,6 @@ Per-user quotas prevent denial-of-service from misbehaving clients. Without quot
 The `litmus-chaos` user intentionally has no quotas. Chaos experiments sometimes need to generate burst traffic to test broker behavior under pressure. Limiting the chaos agent would defeat the purpose.
 :::
 
-
 ## Kyverno Policy Integration & Admission Control
 
 The Kates platform integrates **Kyverno** as a Kubernetes-native policy engine for enforcing security standards via admission control. Think of Kyverno as a security guard at the door of your cluster — it inspects every resource creation and modification request and either fixes it, approves it, or rejects it.
@@ -516,7 +509,6 @@ The `kates-pod-security-standards` policy combines **mutation** (auto-patching) 
 ::: {.callout-note}
 Mutation uses the `+(key)` conditional anchor syntax — values are injected only if the field is not already set. This prevents Kyverno from overwriting explicitly declared security contexts. If a developer explicitly sets `runAsUser: 5000`, Kyverno respects that choice.
 :::
-
 
 ### Cosign Image Verification
 
@@ -601,7 +593,6 @@ All Kyverno policies support two operational modes, controlled by the `kyvernoPo
 Start with `Audit` mode. Review the `PolicyReport` violations with `kates kyverno violations` to see what would break, then switch to `Enforce` once you've resolved all legitimate violations. Jumping straight to `Enforce` on a running cluster is a recipe for cascading failures.
 :::
 
-
 Switch modes at runtime using the Kates CLI (see below) or by patching the Helm values.
 
 ### Kates CLI: `kyverno` Subcommands
@@ -637,7 +628,6 @@ kates kyverno audit kates-pod-security-standards
 - For a full index of Kyverno-related troubleshooting, see [Troubleshooting Index](appendix-b-troubleshooting.md#deployment-issues).
 :::
 
-
 ## Security Checklist
 
 Use this checklist when auditing your deployment. Each item links to the section that explains how to verify it:
@@ -655,13 +645,13 @@ Use this checklist when auditing your deployment. Each item links to the section
 
 ### Validating Policy Compliance
 
-To automate the verification of Kyverno policies, Strimzi operator health, and NetworkPolicy connectivity, you can use the built-in `make` target. This script will ensure your generic cluster is not blocking the Kafka deployment:
+To automate the verification of Kyverno policies, Strimzi operator health, and NetworkPolicy connectivity, you can use the built-in `make` target. The target verifies that your generic cluster is not blocking the Kafka deployment:
 
 ```bash
 make kafka-verify-policies
 ```
 
-This script will:
+The target performs these checks:
 1. Scan the `kafka` namespace events for any Kyverno rejections.
 2. Verify the Strimzi Operator is `Running`.
 3. Check the Kafka cluster CR status to ensure it successfully reached the `Ready` state.

--- a/docs/book/18-upgrade-playbook.md
+++ b/docs/book/18-upgrade-playbook.md
@@ -92,7 +92,7 @@ kates test create --type LOAD --records 100000 --acks all --wait
 # Compare pre vs post
 kates report compare <pre-id>,<post-id>
 
-# Run full GameDay
+# Run the full Game Day pipeline
 make gameday
 ```
 
@@ -209,7 +209,6 @@ kubectl apply -f https://raw.githubusercontent.com/kyverno/kyverno/${KYVERNO_TAG
 Always upgrade CRDs before the controller. If the new controller version expects CRD fields that don't exist yet, the admission webhook may fail open or reject all requests.
 :::
 
-
 **Step 3 — Upgrade the Kyverno controller via Helm:**
 
 ```bash
@@ -263,7 +262,6 @@ kubectl get policyexceptions -A -o jsonpath='{range .items[*]}{.metadata.namespa
 ::: {.callout-important}
 The `PolicyException` API was introduced in Kyverno 1.9 and has moved through several API versions since (`kyverno.io/v2alpha1` → `v2beta1` → `v2`). After upgrading Kyverno, make sure your exceptions use an API version the new release still serves — alpha and beta versions are dropped over time. Check the [Kyverno release notes](https://github.com/kyverno/kyverno/releases) for API deprecations before upgrading.
 :::
-
 
 ## Pre-Upgrade Checklist
 
@@ -342,7 +340,6 @@ kates test get <id>
 Kafka version rollback is **NOT possible** once the KRaft metadata version has been raised. Strimzi controls this through `spec.kafka.metadataVersion` in the Kafka CR (exposed as `kafka.metadataVersion` in the `kafka-cluster` chart values): upgrade the broker `version` first while leaving `metadataVersion` at the previous level — in that state a rollback is still possible. Once you raise `metadataVersion`, the brokers can no longer read the older metadata format and downgrade is irreversible. Only bump `metadataVersion` after the new version has passed validation.
 :::
 
-
 ### Strimzi Operator Rollback
 
 **Step 1 — Rollback via Helm:**
@@ -375,7 +372,6 @@ kates test create --type LOAD --records 10000 --wait
 ::: {.callout-warning}
 If the new Strimzi version migrated CRDs to a new API version (e.g., `v1beta2` → `v1`), rolling back the operator will **not** revert the CRDs. You must manually restore the CRDs from backup or re-apply the old CRD definitions.
 :::
-
 
 ### Kates Application Rollback
 

--- a/docs/book/19-multi-tenancy.md
+++ b/docs/book/19-multi-tenancy.md
@@ -42,7 +42,7 @@ Each tenant gets:
 
 ## Topic Naming Convention
 
-```
+```text
 <service-name>-<domain>[-<qualifier>]
 ```
 

--- a/docs/book/20-installation-guide.md
+++ b/docs/book/20-installation-guide.md
@@ -53,7 +53,6 @@ You need a running Kubernetes cluster with:
 If you are using a **managed Kubernetes service** (EKS, GKE, AKS), the StorageClasses are usually pre-configured (e.g., `gp3` on AWS, `standard-rw` on GKE). For local Kind clusters, you must create them manually — see section 3.1.
 :::
 
-
 ### 1.3 Namespaces
 
 The chart deploys everything into a single namespace (default: `kafka`). Create it before installing:
@@ -111,7 +110,6 @@ The Kates backend chart (`charts/kates`) ships additional `ClusterPolicy` resour
 ::: {.callout-tip}
 Start with `podSecurityPolicy.action: Audit` (the default) to observe policy violations without blocking deployments. Switch to `Enforce` once you're confident all workloads comply. See [Security & Compliance](17-security.md) for details on each policy.
 :::
-
 
 ---
 
@@ -312,7 +310,6 @@ The CLI automatically:
 Use `kates deploy` for interactive development. Use direct Helm commands (below) in CI pipelines where you need fine-grained control.
 :::
 
-
 **Alternative — Direct Helm installation:**
 
 With the Strimzi operator already installed (section 3.2), install the chart:
@@ -364,7 +361,6 @@ You should see pods appear in this order:
 The initial deployment takes **3–8 minutes**. The operator generates TLS certificates, configures the KRaft quorum, and waits for each broker to join the cluster sequentially. This is normal.
 :::
 
-
 ---
 
 ## 4. Verification
@@ -395,7 +391,7 @@ kubectl get kafkanodepools -n kafka \
 
 Expected:
 
-```
+```text
 NAME              REPLICAS   ROLES        READY
 brokers-alpha     1          broker       True
 brokers-gamma     1          broker       True
@@ -447,7 +443,7 @@ The test suite includes:
 
 Any pod in an allowed namespace can connect using the internal bootstrap address:
 
-```
+```text
 krafter-kafka-bootstrap.kafka.svc:9092  (plain + SCRAM)
 krafter-kafka-bootstrap.kafka.svc:9093  (TLS + mTLS)
 ```
@@ -713,7 +709,6 @@ Every template file in the chart and what it produces:
 Many resources are opt-in via boolean flags in `values.yaml`. A minimal installation with only core CRDs creates ~15 resources. A full production deployment with all features enabled creates 50+ resources.
 :::
 
-
 ---
 
 ## 9. Kafka Listeners & Authentication
@@ -803,7 +798,6 @@ kafka:
 When adding or removing listeners, the Strimzi operator performs a **rolling restart** of all brokers. Plan listener changes during a maintenance window.
 :::
 
-
 ### 9.4 Bootstrap Addresses
 
 Each listener gets its own bootstrap service. Use these addresses in your client configurations:
@@ -888,7 +882,6 @@ kubectl get secret kates-backend -n kafka -o jsonpath='{.data.password}' | base6
 ::: {.callout-important}
 Secrets are only created after the Kafka cluster reaches `Ready` state. If secrets are missing, check that the Entity Operator pod is running (see [Section 16: Troubleshooting](#16-troubleshooting)).
 :::
-
 
 ---
 
@@ -984,7 +977,6 @@ After `helm upgrade`, the broker NetworkPolicy is regenerated with the new ingre
 The `allowedClientNamespaces` setting uses `namespaceSelector` with broad pod selectors. Only add namespaces you trust, as **all pods** in the namespace will be able to reach Kafka brokers.
 :::
 
-
 ### 11.5 Disabling Network Policies
 
 For development or Kind clusters where NetworkPolicy enforcement isn't needed:
@@ -997,7 +989,6 @@ networkPolicies:
 ::: {.callout-warning}
 Never disable network policies in production. They are a critical layer of defense-in-depth.
 :::
-
 
 ---
 
@@ -1058,10 +1049,10 @@ The chart creates a single `PrometheusRule` resource with 17 alerts organized in
 | | `KafkaConsumerGroupLagCritical` | critical | > 10M messages lag | 5m | Consumer severely behind — likely stuck or dead |
 | **kafka.kraft** | `KafkaRaftLeaderElectionRate` | warning | > 0.5 elections/s | 5m | Frequent leader elections indicate controller instability |
 | | `KafkaRaftUncommittedRecords` | warning | > 1000 uncommitted | 5m | Metadata backlog — controllers may be overloaded |
-| **kafka.network** | `KafkaRequestLatencyHigh` | warning | p99 > 1000ms | 10m | Slow requests — disk I/O, network, or overloaded brokers |
+| **kafka.network** | `KafkaRequestLatencyHigh` | warning | P99 > 1000ms | 10m | Slow requests — disk I/O, network, or overloaded brokers |
 | **strimzi.operator** | `StrimziOperatorDown` | critical | operator unreachable | 5m | Operator down — no reconciliation of Kafka CRs |
 | **kafka.replication** | `KafkaISRShrinkRate` | warning | ISR shrink > 0/s | 5m | Replicas falling out of sync — network or disk problems |
-| **kafka.performance** | `KafkaLogFlushLatencyHigh` | warning | p99 > 500ms | 10m | Slow disk writes — check I/O scheduler and disk health |
+| **kafka.performance** | `KafkaLogFlushLatencyHigh` | warning | P99 > 500ms | 10m | Slow disk writes — check I/O scheduler and disk health |
 | | `KafkaRequestHandlerSaturated` | warning | idle < 30% | 10m | Request handlers over 70% busy — add threads or brokers |
 | **kafka.cruisecontrol** | `CruiseControlAnomalyDetected` | warning | > 0 anomalies/10m | 5m | Cruise Control detected cluster imbalance or failures |
 | **kafka.certificates** | `KafkaCertificateExpiringSoon` | warning | < 30 days to expiry | 1h | Certificate renewal needed — auto-renewal should handle this |
@@ -1073,7 +1064,7 @@ The chart creates 4 Grafana dashboards as ConfigMaps with the `grafana_dashboard
 
 | Dashboard | ConfigMap | Key Panels | Controlled By |
 |-----------|-----------|------------|---------------|
-| **Broker Overview** | `kafka-broker-dashboard` | Messages in/out rate, bytes in/out, request latency p99, ISR metrics, disk usage | `dashboards.brokerDashboard` |
+| **Broker Overview** | `kafka-broker-dashboard` | Messages in/out rate, bytes in/out, request latency P99, ISR metrics, disk usage | `dashboards.brokerDashboard` |
 | **KRaft Controller** | `kafka-kraft-dashboard` | Leader election rate, uncommitted records, metadata log size, quorum health | `dashboards.kraftDashboard` |
 | **Cruise Control** | `kafka-cruise-control-dashboard` | Anomaly count, rebalance status, optimization goals, broker capacity | `dashboards.cruiseControlDashboard` |
 | **Kafka Connect** | `kafka-connect-dashboard` | Connector status, task failures, source/sink throughput, offset commit rate | `dashboards.connectDashboard` |
@@ -1124,7 +1115,6 @@ crdUpgrade:
 The Job runs with a dedicated `ServiceAccount` and `ClusterRole` scoped only to CRD read/write. It cleans itself up after success (`hook-delete-policy: before-hook-creation,hook-succeeded`).
 :::
 
-
 ### 13.2 Drain Cleaner
 
 **Why it exists:** When a Kubernetes node is drained (e.g., during upgrades), the kubelet evicts pods immediately. For Kafka, this can cause data loss if a broker is killed without transferring partition leadership first.
@@ -1151,7 +1141,6 @@ drainCleaner:
 ::: {.callout-tip}
 Enable Drain Cleaner in any environment where nodes are regularly drained — EKS managed node groups, GKE node auto-upgrades, or spot/preemptible instances.
 :::
-
 
 ### 13.3 Tiered Storage
 
@@ -1186,7 +1175,6 @@ tieredStorage:
 ::: {.callout-warning}
 Tiered storage requires Kafka 3.6+. Enabling it on older versions will cause broker startup failures.
 :::
-
 
 ### 13.4 SeaweedFS
 
@@ -1238,7 +1226,6 @@ backup:
 ::: {.callout-caution}
 Do **not** set `snapshotVolumes: true`. Broker PVC snapshots are crash-consistent and can corrupt data on restore. See the section "Why NetBackup is Incompatible with Kafka" in the chart's README (`charts/kafka-cluster/README.md`) for the full rationale.
 :::
-
 
 ### 13.6 External Secrets Operator
 
@@ -1297,7 +1284,6 @@ podSecurityPolicy:
 ::: {.callout-tip}
 Always start with `action: Audit`. Run `kubectl get policyreport -A` to see which pods would be blocked, then fix them before switching to `Enforce`.
 :::
-
 
 ### 13.8 Cruise Control & Rebalance
 
@@ -1363,7 +1349,6 @@ kafka:
 The `KafkaCertificateExpiringSoon` alert (see [Section 12.2](#122-prometheusrule-alerts-17-alerts)) fires 30 days before expiry. With a 180-day renewal window, you should never see this alert under normal operations — if you do, Strimzi's automatic renewal may be stuck.
 :::
 
-
 ### 13.10 Helm Test Suite (9 Tiers)
 
 The chart includes a comprehensive test suite executed via `kates test helm` (or `helm test kafka-cluster -n kafka`). Tests are organized in 9 tiers, running in order from basic connectivity to full observability validation:
@@ -1402,7 +1387,6 @@ helm test kafka-cluster -n kafka --filter name=krafter-test-produce-consume
 ::: {.callout-tip}
 If tier 2 (produce/consume) fails but tier 1 passes, the issue is usually authentication — check that the user secret exists and the SCRAM password is populated. Run `kubectl get kafkausers -n kafka` to verify user status.
 :::
-
 
 ---
 
@@ -1443,7 +1427,6 @@ The operator upgrades brokers one at a time, waiting for ISR to heal before proc
 Always test Kafka version upgrades in a staging environment first. Some versions change log format or protocol versions, which can affect client compatibility.
 :::
 
-
 ---
 
 ## 15. Uninstalling
@@ -1457,7 +1440,6 @@ helm uninstall kafka-cluster -n kafka
 ::: {.callout-caution}
 By default, the chart sets `helm.sh/resource-policy: keep` on the `Kafka` CR, `KafkaNodePool` CRs, `KafkaTopic` CRs, and `KafkaUser` CRs. This means `helm uninstall` **will not delete your data** or Kafka resources. This is intentional — it prevents accidental data loss.
 :::
-
 
 ### 15.2 Full Removal (Including Data)
 

--- a/docs/book/21-kafka-connect.md
+++ b/docs/book/21-kafka-connect.md
@@ -59,7 +59,7 @@ graph TB
 
 The `connect-cluster` chart lives at `charts/connect-cluster/` and produces the Strimzi `KafkaConnect` and `KafkaConnector` resources (plus an optional chart-managed `KafkaUser`):
 
-```
+```text
 charts/connect-cluster/
 ├── Chart.yaml                          # v1.2.0, appVersion 4.2.0
 ├── values.yaml                         # Production defaults
@@ -173,7 +173,6 @@ These topics are automatically created by Connect workers on first startup. The 
 ::: {.callout-important}
 Never delete the offsets topic. If deleted, all source connectors lose their position and will re-snapshot their entire database on restart.
 :::
-
 
 ### Authentication
 
@@ -368,7 +367,6 @@ connectors:
 The `tasksMax` for a Debezium PostgreSQL connector must always be `1`. PostgreSQL logical replication uses a single replication slot per connector — multiple tasks would cause duplicate events or slot conflicts.
 :::
 
-
 ### External Configuration (Secrets)
 
 The chart enables three Kafka config providers on every worker — `file`, `dir`, and `secrets` (Strimzi's `KubernetesSecretConfigProvider`):
@@ -519,7 +517,6 @@ extraConfig:
 EOS requires `min.insync.replicas >= 2` on the data topics and `acks=all` on the Connect producer. The krafter cluster satisfies both by default.
 :::
 
-
 ### When to Disable EOS
 
 | Scenario | Recommendation |
@@ -586,7 +583,6 @@ This chain:
 The `ExtractNewRecordState` SMT is almost always recommended for Debezium connectors. Without it, downstream consumers must understand the full Debezium envelope schema.
 :::
 
-
 ---
 
 ## Schema Registry Integration
@@ -634,7 +630,7 @@ config:
 
 The chart automatically computes the full Schema Registry URL from the service name, port, path, and cluster domain:
 
-```
+```text
 http://apicurio-apicurio-registry.<namespace>.svc.<clusterDomain>:80/apis/ccompat/v7
 ```
 
@@ -650,7 +646,6 @@ http://apicurio-apicurio-registry.<namespace>.svc.<clusterDomain>:80/apis/ccompa
 ::: {.callout-warning}
 Changing the converter from `JsonConverter` to `AvroConverter` on an existing connector requires reprocessing all data. The existing JSON records in Kafka are not automatically re-serialized. Plan a migration window with a new topic prefix.
 :::
-
 
 ---
 
@@ -696,7 +691,6 @@ connectors:
 ::: {.callout-caution}
 Setting `errors.tolerance: all` without a DLQ silently drops bad records. Always configure a DLQ topic when using tolerant error handling.
 :::
-
 
 ---
 
@@ -780,6 +774,5 @@ This is useful for:
 ::: {.callout-note}
 Cross-database sync introduces eventual consistency. The sink always lags behind the source by the time it takes to process through Kafka. Monitor `kafka_consumergroup_lag` to measure the delay.
 :::
-
 
 ---

--- a/docs/book/STYLE.md
+++ b/docs/book/STYLE.md
@@ -1,0 +1,57 @@
+# Book Style Sheet
+
+One page. Every chapter follows it; `scripts/check-book-style.sh` enforces the machine-checkable rules in CI. When editing, match the file you're in; when in doubt, this sheet wins.
+
+## Voice
+
+- Second person ("you"), present tense, active voice. Contractions are fine.
+- Describe tool behavior in the present: "Strimzi generates the Secret", never "Strimzi will generate".
+- "We" only inside quoted material. "The user" only for Kafka principals/`KafkaUser` resources.
+
+## Headings
+
+- H1 is the plain chapter title — **no** "Chapter N:" prefix. Numbering comes from the order in `_quarto.yml`; filenames are stable IDs and are never renumbered.
+- H2/H3 in Title Case, unnumbered, no terminal punctuation except `?`. Exception: step-by-step install chapters may use decimal numbering (`## 3. Deploy the Chart`) — currently only the Installing Kafka chapter and the CI/CD appendix.
+- Troubleshooting symptom headings: Title Case with literal error strings in backticks.
+
+## Callouts
+
+Quarto callouts are the only admonition syntax — never bold-blockquotes (`> **Note:**`):
+
+- `callout-note` context worth knowing · `callout-tip` shortcut or best practice · `callout-important` must-read constraint · `callout-warning` risk of breakage · `callout-caution` risk of data loss or downtime
+
+Exactly one blank line after the closing `:::`. Genuine quotations may use plain blockquotes.
+
+## Code fences
+
+- Every fence carries a language tag: `bash`, `yaml`, `json`, `properties`, `promql`, `sql`, `protobuf`, `xml`, `mermaid`, or `text` for terminal output and ASCII UI. Never `sh`, `console`, or `shell`.
+- Commands carry no `$` prompt. Captured output goes in a separate `text` block introduced by "Output:"; short inline annotations are ordinary `#` comments (no `# →` arrows).
+- Mermaid uses plain ```` ```mermaid ```` fences (GitHub-renderable); the CI build converts them for Quarto.
+
+## Cross-references
+
+- Link text is the target chapter's H1 title, verbatim: `[Kafka Deployment Engineering](15-kafka-deployment.md)`. Never "Chapter N" or "Ch N" — numbers are assigned at render time and drift when the order changes.
+- Appendices by title too; letters are assigned by Quarto.
+
+## Terminology
+
+| Use | Not | Notes |
+|-----|-----|-------|
+| Kates | KATES | `kates` (backticked) only as command/namespace/resource |
+| `krafter`, `panda` | bare names | Always backticked; gloss on first use per chapter ("the `krafter` Kafka cluster", "the `panda` Kind cluster") |
+| Game Day | GameDay | The methodology and its automated pipeline (`make gameday`) |
+| LitmusChaos | — | Full name on first use per chapter; "Litmus" after |
+| Kafka UI | kafka-ui in prose | `kafka-ui` only as resource/user name |
+| Kubernetes | K8s in prose | K8s acceptable only in space-constrained tables and diagram labels |
+| P50 / P95 / P99 / P99.9 | p99 in prose | Lowercase only inside code, JSON fields, and PromQL |
+| pre-flight | preflight | Pre-Flight in Title Case headings |
+| LOAD, ROUND_TRIP, INTEGRITY | Load, Round-Trip | Enum form whenever naming a Kates test type; lowercase "round-trip" only for the generic latency concept |
+
+## Punctuation
+
+- Spaced em dash ( — ) for asides; straight quotes only; `--` never as a prose dash (kubectl/CLI flag separators in code excepted).
+
+## Facts
+
+- No hardcoded counts unless the enumeration sits beside them. Versions live in the [Version & Compatibility Matrix](appendix-d-versions.md) — chapters point there instead of pinning their own.
+- Documenting a command? It must exist — link or name the implementing source file in the PR description.

--- a/docs/book/appendix-a-glossary.md
+++ b/docs/book/appendix-a-glossary.md
@@ -23,8 +23,7 @@ Quick reference for terms used throughout this book.
 | **Drain Cleaner** | Strimzi component that intercepts Kubernetes node drain events and gracefully rolls Kafka pods instead of killing them |
 | **emptyDir** | A Kubernetes volume type that provides an empty directory backed by the node's filesystem. Used for ephemeral writable paths under read-only root filesystems |
 | **Entity Operator** | Strimzi component running both the Topic Operator and User Operator in a single pod |
-| **Game Day** | A structured chaos engineering session with defined hypotheses, controlled experiments, and documented findings |
-| **GameDay** | An automated 7-phase validation pipeline (pre-flight → baseline → chaos → observe → recover → post-flight → report) run via `make gameday` |
+| **Game Day** | A structured chaos engineering session with defined hypotheses, controlled experiments, and documented findings; Kates automates it as a 7-phase pipeline (pre-flight → baseline → chaos → observe → recover → post-flight → report) run via `make gameday` |
 | **GraalVM Native Image** | An ahead-of-time compilation technology that compiles Java applications into standalone native binaries. Reduces startup time from seconds to milliseconds. The Kates backend supports native image builds for faster cold starts |
 | **gRPC** | Google Remote Procedure Call — a high-performance binary protocol using HTTP/2 and Protocol Buffers for service-to-service communication |
 | **Heatmap** | A visualization showing the full latency distribution over time. Each row is one second; each column is a latency bucket |

--- a/docs/book/appendix-b-troubleshooting.md
+++ b/docs/book/appendix-b-troubleshooting.md
@@ -112,7 +112,6 @@ Not every problem is a Kates problem. Use this guide to determine where to focus
 When filing an issue, include the output of `kates doctor` — it runs a battery of diagnostic checks and gives you a single summary of system health.
 :::
 
-
 ## Common Issues (Additional)
 
 | Symptom | Likely Cause | Fix |

--- a/docs/book/operating-kafka-connect.md
+++ b/docs/book/operating-kafka-connect.md
@@ -74,7 +74,6 @@ sequenceDiagram
 Cross-AZ data transfer costs apply when a connector in zone alpha reads from a database in zone sigma. This is an acceptable tradeoff for seamless failover — CDC downtime during a rebalance is typically under 30 seconds.
 :::
 
-
 ### Scheduling Configuration
 
 ```yaml
@@ -102,7 +101,7 @@ The base values use `whenUnsatisfiable: ScheduleAnyway`, so single-node clusters
 
 Each Connect worker consumes memory proportional to the number of tasks it runs and the batch sizes configured:
 
-```
+```text
 Worker Memory = JVM Heap + Off-Heap
              = (-Xmx) + (Direct Buffers + Thread Stacks + JMX + GC Overhead)
              ≈ -Xmx × 2
@@ -192,7 +191,6 @@ Connect's internal producer sends records to Kafka. These settings control batch
 ::: {.callout-tip}
 Monitor `rate(kafka_connect_source_task_metrics_source_record_poll_total[5m])` and `rate(kafka_connect_source_task_metrics_source_record_write_total[5m])` in Grafana. If poll rate >> write rate, the producer is the bottleneck — increase `producer.batch.size` and enable compression.
 :::
-
 
 ---
 
@@ -394,7 +392,6 @@ kates kafka connect restart debezium-postgres-source
 Update the database password in PostgreSQL **before** updating the Kubernetes Secret. If you update the Secret first, Connect workers will restart and immediately fail authentication.
 :::
 
-
 ---
 
 ## Upgrade Procedures
@@ -447,7 +444,6 @@ helm upgrade connect-cluster charts/connect-cluster \
 If the new Debezium version changed the internal offset format, rolling back may cause connectors to fail with deserialization errors. Always test in staging first.
 :::
 
-
 ---
 
 ## Disaster Recovery
@@ -490,7 +486,6 @@ kates deploy --with-kafka-connect --ha
 ::: {.callout-tip}
 The internal topics (`*-offsets`, `*-configs`, `*-status`) are the only persistent state for the Connect cluster. As long as these topics survive in Kafka (with RF=3), the Connect cluster is fully rebuildable from the Helm chart alone.
 :::
-
 
 ### Backup Strategy
 

--- a/scripts/check-book-style.sh
+++ b/scripts/check-book-style.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Enforce the machine-checkable rules of docs/book/STYLE.md.
+# Usage: scripts/check-book-style.sh   (exit 1 on violations; used by docs CI)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+fail=0
+
+note() { echo "STYLE: $1" >&2; fail=1; }
+
+# 1. Unlabeled code fences (openers with no language tag)
+while IFS= read -r hit; do
+  note "unlabeled code fence -> tag it (text for output/ASCII UI): $hit"
+done < <(python3 - <<'PY'
+import glob, re
+for f in sorted(glob.glob('docs/book/*.md') + ['docs/book/index.qmd']):
+    if f.endswith('STYLE.md'):
+        continue
+    fence = False
+    for i, l in enumerate(open(f, encoding='utf-8'), 1):
+        s = l.strip()
+        if s.startswith('```'):
+            if not fence and s == '```':
+                print(f"{f}:{i}")
+            fence = not fence
+PY
+)
+
+# 2. Bold-blockquote admonitions
+if grep -rn '^> \*\*\(Note\|Tip\|Warning\|Important\|Caution\):\*\*' docs/book/*.md >&2; then
+  note "bold-blockquote admonition -> use ::: callout-*"
+fi
+
+# 3. Chapter-number cross references (numbers drift; use titles)
+if grep -rnE '\[(Chapter|Ch\.?) [0-9]' docs/book/*.md docs/book/index.qmd >&2; then
+  note "'Chapter N' in link text -> use the target's H1 title"
+fi
+
+# 4. Banned terminology (prose only — fenced code and inline code spans are
+#    exempt, since command/resource names are what they are)
+if python3 - >&2 <<'PY'
+import glob, re, sys
+BANNED = [r'GameDay', r'\bpreflight\b', r'\bKATES\b']
+bad = False
+for f in sorted(glob.glob('docs/book/*.md') + ['docs/book/index.qmd']):
+    if f.endswith('STYLE.md'):
+        continue
+    fence = False
+    for i, l in enumerate(open(f, encoding='utf-8'), 1):
+        if l.strip().startswith('```'):
+            fence = not fence
+            continue
+        if fence:
+            continue
+        prose = re.sub(r'`[^`]*`', '', l)
+        for pat in BANNED:
+            if re.search(pat, prose):
+                print(f"{f}:{i}: banned term /{pat}/: {l.strip()[:100]}")
+                bad = True
+sys.exit(0 if bad else 1)
+PY
+then
+  note "banned terminology in prose (see STYLE.md terminology table)"
+fi
+
+# 5. Double blank line after callout close
+if python3 - <<'PY'
+import glob, re, sys
+bad = False
+for f in sorted(glob.glob('docs/book/*.md') + ['docs/book/index.qmd']):
+    txt = open(f, encoding='utf-8').read()
+    for m in re.finditer(r':::\n\n\n+', txt):
+        print(f"{f}: double blank line after callout at offset {m.start()}", file=sys.stderr)
+        bad = True
+sys.exit(0 if bad else 1)
+PY
+then
+  note "normalize to exactly one blank line after ':::'"
+fi
+
+if [[ $fail -ne 0 ]]; then
+  echo "" >&2
+  echo "Book style violations found — see docs/book/STYLE.md." >&2
+  exit 1
+fi
+echo "OK: book style checks pass"


### PR DESCRIPTION
## Summary

Phase 4 of the book enhancement plan: codify the style the book already mostly has, conform the outliers, and make CI enforce it — so the consistency survives future contributors.

## What changed

- **[`docs/book/STYLE.md`](docs/book/STYLE.md)** — the one-page style sheet: voice and tense, heading and callout conventions (with semantics for note/tip/important/warning/caution), code-fence rules, title-based cross-references, a terminology table, and the facts policy (no hardcoded counts; versions live in Appendix D).
- **Mechanical conformance across all 27 book files** — 46 unlabeled fences tagged, 70 callout spacing artifacts normalized, the last blockquote admonition converted, `# →` output-as-comment arrows retired, and terminology unified (Game Day, pre-flight, P99-in-prose ×21, the glossary's duplicate Game Day entries merged, security-chapter future tense rewritten to present).
- **[`scripts/check-book-style.sh`](scripts/check-book-style.sh)** — enforces the machine-checkable rules in the docs workflow. It's fence- and inline-code-aware: `kates preflight` (a real CLI alias) stays legal in code blocks while `preflight` in prose gets flagged.

## Notes for review

- The style checker caught its own first false positive during development — it flagged `kates preflight`, which turned out to be a genuine registered alias in `cli/cmd/doctor.go`; the checker was made fence-aware rather than the book changed.
- Verified: style check, version-matrix check, and the full link/anchor validator pass; complete Quarto HTML render succeeds.

Remaining from the plan: the deferred troubleshooting consolidation (phase 3 leftover) and phase 5 (pedagogy: chapter openings, summaries, exercises) — both need the agent fleet, which is rate-limited until this evening.
