### PR TITLE
refactor(cli): rename Go module to github.com/bmscomp/kates/cli, retire klster

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -186,7 +186,7 @@ jobs:
           labels: |
             org.opencontainers.image.title=Kates Backend
             org.opencontainers.image.description=Kafka Advanced Testing & Engineering Suite
-            org.opencontainers.image.vendor=klster
+            org.opencontainers.image.vendor=bmscomp
             org.opencontainers.image.version=${{ needs.meta.outputs.version }}
 
       - name: Collect per-platform image refs

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   GO_VERSION: "1.25"
-  MODULE: "github.com/klster/kates-cli/cmd"
+  MODULE: "github.com/bmscomp/kates/cli/cmd"
 
 jobs:
   build:

--- a/cli/build
+++ b/cli/build
@@ -4,7 +4,7 @@ set -euo pipefail
 VERSION="${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo "dev")}"
 COMMIT="${COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")}"
 BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-MODULE="github.com/klster/kates-cli/cmd"
+MODULE="github.com/bmscomp/kates/cli/cmd"
 OUTPUT_DIR="${OUTPUT_DIR:-dist}"
 
 LDFLAGS="-s -w \

--- a/cli/build.sh
+++ b/cli/build.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 VERSION="${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo "dev")}"
 COMMIT="${COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")}"
 BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-MODULE="github.com/klster/kates-cli/cmd"
+MODULE="github.com/bmscomp/kates/cli/cmd"
 OUTPUT_DIR="${OUTPUT_DIR:-dist}"
 
 LDFLAGS="-s -w \

--- a/cli/cmd/advisor.go
+++ b/cli/cmd/advisor.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/output"
-	"github.com/klster/kates-cli/pkg/theme"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/output"
+	"github.com/bmscomp/kates/cli/pkg/theme"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/apply.go
+++ b/cli/cmd/apply.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )

--- a/cli/cmd/audit.go
+++ b/cli/cmd/audit.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/auto.go
+++ b/cli/cmd/auto.go
@@ -7,9 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/klster/kates-cli/internal/helm"
-	"github.com/klster/kates-cli/output"
-	"github.com/klster/kates-cli/pkg/detect"
+	"github.com/bmscomp/kates/cli/internal/helm"
+	"github.com/bmscomp/kates/cli/output"
+	"github.com/bmscomp/kates/cli/pkg/detect"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/baseline.go
+++ b/cli/cmd/baseline.go
@@ -9,7 +9,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/pkg/theme"
+	"github.com/bmscomp/kates/cli/pkg/theme"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/benchmark.go
+++ b/cli/cmd/benchmark.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/changelog.go
+++ b/cli/cmd/changelog.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/pkg/theme"
+	"github.com/bmscomp/kates/cli/pkg/theme"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/chaos.go
+++ b/cli/cmd/chaos.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/cleanup.go
+++ b/cli/cmd/cleanup.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/cluster_diff.go
+++ b/cli/cmd/cluster_diff.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/cluster_watch.go
+++ b/cli/cmd/cluster_watch.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"sort"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )

--- a/cli/cmd/connect.go
+++ b/cli/cmd/connect.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/klster/kates-cli/internal/kubectl"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/internal/kubectl"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/connect_test_integration.go
+++ b/cli/cmd/connect_test_integration.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )

--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/klster/kates-cli/output"
-	"github.com/klster/kates-cli/pkg/detect"
+	"github.com/bmscomp/kates/cli/output"
+	"github.com/bmscomp/kates/cli/pkg/detect"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/deploy_components.go
+++ b/cli/cmd/deploy_components.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/cli/cmd/deploy_dashboard.go
+++ b/cli/cmd/deploy_dashboard.go
@@ -14,8 +14,8 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/output"
-	"github.com/klster/kates-cli/pkg/theme"
+	"github.com/bmscomp/kates/cli/output"
+	"github.com/bmscomp/kates/cli/pkg/theme"
 )
 
 // ── Controller Interface for deploy.go ─────────────────────────────────────

--- a/cli/cmd/deploy_plan.go
+++ b/cli/cmd/deploy_plan.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/huh"
-	"github.com/klster/kates-cli/pkg/detect"
+	"github.com/bmscomp/kates/cli/pkg/detect"
 )
 
 // runInteractiveForms runs the interactive huh forms (Form 1: component selection,

--- a/cli/cmd/deploy_preview.go
+++ b/cli/cmd/deploy_preview.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 )
 
 // renderDeployPreview displays a dry-run preview of what would be deployed.

--- a/cli/cmd/deploy_recovery.go
+++ b/cli/cmd/deploy_recovery.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"golang.org/x/term"
 )
 

--- a/cli/cmd/deploy_view.go
+++ b/cli/cmd/deploy_view.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/pkg/theme"
+	"github.com/bmscomp/kates/cli/pkg/theme"
 	"github.com/mattn/go-runewidth"
 	"golang.org/x/term"
 )

--- a/cli/cmd/detect.go
+++ b/cli/cmd/detect.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/klster/kates-cli/output"
-	"github.com/klster/kates-cli/pkg/detect"
+	"github.com/bmscomp/kates/cli/output"
+	"github.com/bmscomp/kates/cli/pkg/detect"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/diff.go
+++ b/cli/cmd/diff.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/disruption.go
+++ b/cli/cmd/disruption.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/disruption_watch.go
+++ b/cli/cmd/disruption_watch.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/klster/kates-cli/client"
+	"github.com/bmscomp/kates/cli/client"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/doc.go
+++ b/cli/cmd/doc.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/doctor.go
+++ b/cli/cmd/doctor.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/klster/kates-cli/internal/kubectl"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/internal/kubectl"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/doctor_dns.go
+++ b/cli/cmd/doctor_dns.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/internal/kubectl"
+	"github.com/bmscomp/kates/cli/internal/kubectl"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/doctor_test.go
+++ b/cli/cmd/doctor_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 )
 
 func TestDoctorRenderChecks(t *testing.T) {

--- a/cli/cmd/dryrun.go
+++ b/cli/cmd/dryrun.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 )
 
 func printDryRun(label string, payload interface{}) {

--- a/cli/cmd/explain.go
+++ b/cli/cmd/explain.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/export.go
+++ b/cli/cmd/export.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/flow.go
+++ b/cli/cmd/flow.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )

--- a/cli/cmd/gate.go
+++ b/cli/cmd/gate.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/groups.go
+++ b/cli/cmd/groups.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/health.go
+++ b/cli/cmd/health.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/helm_test_cmd.go
+++ b/cli/cmd/helm_test_cmd.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/go-pdf/fpdf"
-	"github.com/klster/kates-cli/internal/helm"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/internal/helm"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/helpers.go
+++ b/cli/cmd/helpers.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"golang.org/x/term"
 )
 

--- a/cli/cmd/helpers_test.go
+++ b/cli/cmd/helpers_test.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"testing"
 
-	"github.com/klster/kates-cli/client"
+	"github.com/bmscomp/kates/cli/client"
 )
 
 func TestMapStr(t *testing.T) {

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 
@@ -148,7 +148,7 @@ echo ""
 
 if ! command -v kates &>/dev/null; then
   echo "ERROR: kates CLI not found in PATH"
-  echo "Install: go install github.com/klster/kates-cli@latest"
+  echo "Install: go install github.com/bmscomp/kates/cli@latest"
   exit 1
 fi
 

--- a/cli/cmd/junit.go
+++ b/cli/cmd/junit.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/klster/kates-cli/client"
+	"github.com/bmscomp/kates/cli/client"
 )
 
 type junitTestSuites struct {

--- a/cli/cmd/kafka.go
+++ b/cli/cmd/kafka.go
@@ -8,9 +8,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/output"
-	"github.com/klster/kates-cli/tui"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/output"
+	"github.com/bmscomp/kates/cli/tui"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/kyverno.go
+++ b/cli/cmd/kyverno.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/klster/kates-cli/internal/kubectl"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/internal/kubectl"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/kyverno_apply.go
+++ b/cli/cmd/kyverno_apply.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/klster/kates-cli/internal/helm"
-	"github.com/klster/kates-cli/internal/kubectl"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/internal/helm"
+	"github.com/bmscomp/kates/cli/internal/kubectl"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/kyverno_detect.go
+++ b/cli/cmd/kyverno_detect.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/klster/kates-cli/internal/kubectl"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/internal/kubectl"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/kyverno_test.go
+++ b/cli/cmd/kyverno_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 )
 
 func TestKyvernoDetectRecommendations(t *testing.T) {

--- a/cli/cmd/lab.go
+++ b/cli/cmd/lab.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/klster/kates-cli/tui"
+	"github.com/bmscomp/kates/cli/tui"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/operator.go
+++ b/cli/cmd/operator.go
@@ -6,7 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/klster/kates-cli/pkg/operator"
+	"github.com/bmscomp/kates/cli/pkg/operator"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/plugin.go
+++ b/cli/cmd/plugin.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/portforward.go
+++ b/cli/cmd/portforward.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/output"
-	"github.com/klster/kates-cli/pkg/theme"
+	"github.com/bmscomp/kates/cli/output"
+	"github.com/bmscomp/kates/cli/pkg/theme"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/replay.go
+++ b/cli/cmd/replay.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/report.go
+++ b/cli/cmd/report.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/report_brokers.go
+++ b/cli/cmd/report_brokers.go
@@ -6,8 +6,8 @@ import (
 	"math"
 	"strings"
 
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/report_heatmap.go
+++ b/cli/cmd/report_heatmap.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/report_html.go
+++ b/cli/cmd/report_html.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/klster/kates-cli/client"
+	"github.com/bmscomp/kates/cli/client"
 )
 
 func renderHTMLReport(id string, r *client.Report) string {

--- a/cli/cmd/report_html_test.go
+++ b/cli/cmd/report_html_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/klster/kates-cli/client"
+	"github.com/bmscomp/kates/cli/client"
 )
 
 func TestRenderHTMLReport_Basic(t *testing.T) {

--- a/cli/cmd/report_markdown.go
+++ b/cli/cmd/report_markdown.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/klster/kates-cli/client"
+	"github.com/bmscomp/kates/cli/client"
 )
 
 func renderMarkdownReport(id string, r *client.Report) string {

--- a/cli/cmd/report_markdown_test.go
+++ b/cli/cmd/report_markdown_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/klster/kates-cli/client"
+	"github.com/bmscomp/kates/cli/client"
 )
 
 func TestRenderMarkdownReport_Basic(t *testing.T) {

--- a/cli/cmd/resilience.go
+++ b/cli/cmd/resilience.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )

--- a/cli/cmd/scaffold.go
+++ b/cli/cmd/scaffold.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )

--- a/cli/cmd/scenario_diff.go
+++ b/cli/cmd/scenario_diff.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )

--- a/cli/cmd/schedule.go
+++ b/cli/cmd/schedule.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/security.go
+++ b/cli/cmd/security.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"

--- a/cli/cmd/security_auth.go
+++ b/cli/cmd/security_auth.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/security_compliance.go
+++ b/cli/cmd/security_compliance.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/security_drift.go
+++ b/cli/cmd/security_drift.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/security_tls.go
+++ b/cli/cmd/security_tls.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/snapshot.go
+++ b/cli/cmd/snapshot.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 )

--- a/cli/cmd/test.go
+++ b/cli/cmd/test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/huh"
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )

--- a/cli/cmd/test_extras.go
+++ b/cli/cmd/test_extras.go
@@ -6,8 +6,8 @@ import (
 	"math"
 	"strings"
 
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/testutil_test.go
+++ b/cli/cmd/testutil_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/output"
 )
 
 // setupTest creates an httptest.Server that returns the given statusCode and body.

--- a/cli/cmd/theme.go
+++ b/cli/cmd/theme.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )

--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/trend.go
+++ b/cli/cmd/trend.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/tune.go
+++ b/cli/cmd/tune.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/client"
+	"github.com/bmscomp/kates/cli/client"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/types.go
+++ b/cli/cmd/types.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"strings"
 
-	"github.com/klster/kates-cli/client"
+	"github.com/bmscomp/kates/cli/client"
 )
 
 // TestCounts holds aggregated test status counts.

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -95,7 +95,7 @@ func runUpgrade() error {
 
 	// ── 6. Build ─────────────────────────────────────────────────────────────
 	buildDate := time.Now().UTC().Format(time.RFC3339)
-	ldflags := fmt.Sprintf("-s -w -X github.com/klster/kates-cli/cmd.Version=%s -X github.com/klster/kates-cli/cmd.Commit=%s -X github.com/klster/kates-cli/cmd.BuildDate=%s",
+	ldflags := fmt.Sprintf("-s -w -X github.com/bmscomp/kates/cli/cmd.Version=%s -X github.com/bmscomp/kates/cli/cmd.Commit=%s -X github.com/bmscomp/kates/cli/cmd.BuildDate=%s",
 		gitBranch+"-"+gitCommit, gitCommit, buildDate)
 
 	tmpBin := filepath.Join(srcDir, "dist", "kates")

--- a/cli/cmd/validate_test.go
+++ b/cli/cmd/validate_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/klster/kates-cli/client"
+	"github.com/bmscomp/kates/cli/client"
 )
 
 func TestValidateSLAs_AllPass(t *testing.T) {

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/watch.go
+++ b/cli/cmd/watch.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/charmbracelet/bubbles/progress"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/webhook.go
+++ b/cli/cmd/webhook.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,4 +1,4 @@
-module github.com/klster/kates-cli
+module github.com/bmscomp/kates/cli
 
 go 1.25.7
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/klster/kates-cli/cmd"
+	"github.com/bmscomp/kates/cli/cmd"
 )
 
 func main() {

--- a/cli/output/output.go
+++ b/cli/output/output.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/pkg/theme"
+	"github.com/bmscomp/kates/cli/pkg/theme"
 	"github.com/mattn/go-runewidth"
 	"github.com/muesli/termenv"
 	"golang.org/x/term"

--- a/cli/pkg/detect/renderer_json.go
+++ b/cli/pkg/detect/renderer_json.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"io"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 )
 
 func RenderJSON(report *DetectReport) {

--- a/cli/pkg/detect/renderer_tui.go
+++ b/cli/pkg/detect/renderer_tui.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 )
 
 func RenderTUI(report *DetectReport) {

--- a/cli/pkg/detect/spinner.go
+++ b/cli/pkg/detect/spinner.go
@@ -6,7 +6,7 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/output"
+	"github.com/bmscomp/kates/cli/output"
 )
 
 type ProgressMsg string

--- a/cli/pkg/theme/tokens.go
+++ b/cli/pkg/theme/tokens.go
@@ -4,7 +4,7 @@
 //
 // Usage:
 //
-//	import "github.com/klster/kates-cli/pkg/theme"
+//	import "github.com/bmscomp/kates/cli/pkg/theme"
 //
 //	style := lipgloss.NewStyle().Foreground(theme.Accent)
 package theme

--- a/cli/tui/brokers.go
+++ b/cli/tui/brokers.go
@@ -7,7 +7,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/client"
+	"github.com/bmscomp/kates/cli/client"
 )
 
 type brokersModel struct {

--- a/cli/tui/groups.go
+++ b/cli/tui/groups.go
@@ -7,7 +7,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/client"
+	"github.com/bmscomp/kates/cli/client"
 )
 
 type groupsView int

--- a/cli/tui/lab.go
+++ b/cli/tui/lab.go
@@ -11,8 +11,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/client"
-	"github.com/klster/kates-cli/pkg/theme"
+	"github.com/bmscomp/kates/cli/client"
+	"github.com/bmscomp/kates/cli/pkg/theme"
 )
 
 type labParam struct {

--- a/cli/tui/produce.go
+++ b/cli/tui/produce.go
@@ -7,7 +7,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/client"
+	"github.com/bmscomp/kates/cli/client"
 )
 
 type produceView int

--- a/cli/tui/styles.go
+++ b/cli/tui/styles.go
@@ -2,7 +2,7 @@ package tui
 
 import (
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/pkg/theme"
+	"github.com/bmscomp/kates/cli/pkg/theme"
 )
 
 // Adaptive palette for the TUI — all values flip between light/dark terminal modes.

--- a/cli/tui/topics.go
+++ b/cli/tui/topics.go
@@ -8,7 +8,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/client"
+	"github.com/bmscomp/kates/cli/client"
 )
 
 type topicsView int

--- a/cli/tui/tui.go
+++ b/cli/tui/tui.go
@@ -7,7 +7,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/klster/kates-cli/client"
+	"github.com/bmscomp/kates/cli/client"
 )
 
 type tab int

--- a/config/litmus/experiments/kafka-disk-stress.yaml
+++ b/config/litmus/experiments/kafka-disk-stress.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kafka
   labels:
     app.kubernetes.io/managed-by: kates
-    kates.klster.com/scenario: disk-stress
+    kates.bmscomp.github.io/scenario: disk-stress
 spec:
   annotationCheck: 'false'
   engineState: active

--- a/config/litmus/experiments/kafka-leader-kill.yaml
+++ b/config/litmus/experiments/kafka-leader-kill.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kafka
   labels:
     app.kubernetes.io/managed-by: kates
-    kates.klster.com/scenario: leader-kill
+    kates.bmscomp.github.io/scenario: leader-kill
 spec:
   annotationCheck: 'false'
   engineState: active

--- a/config/litmus/experiments/kafka-multi-broker-kill.yaml
+++ b/config/litmus/experiments/kafka-multi-broker-kill.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kafka
   labels:
     app.kubernetes.io/managed-by: kates
-    kates.klster.com/scenario: multi-broker-kill
+    kates.bmscomp.github.io/scenario: multi-broker-kill
 spec:
   annotationCheck: 'false'
   engineState: active

--- a/config/litmus/experiments/kafka-network-partition.yaml
+++ b/config/litmus/experiments/kafka-network-partition.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kafka
   labels:
     app.kubernetes.io/managed-by: kates
-    kates.klster.com/scenario: network-partition
+    kates.bmscomp.github.io/scenario: network-partition
 spec:
   annotationCheck: 'false'
   engineState: active

--- a/config/litmus/experiments/kafka-rolling-restart.yaml
+++ b/config/litmus/experiments/kafka-rolling-restart.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kafka
   labels:
     app.kubernetes.io/managed-by: kates
-    kates.klster.com/scenario: rolling-restart
+    kates.bmscomp.github.io/scenario: rolling-restart
 spec:
   annotationCheck: 'false'
   engineState: active

--- a/config/litmus/experiments/kates-chaos-integration-job.yaml
+++ b/config/litmus/experiments/kates-chaos-integration-job.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kafka
   labels:
     app.kubernetes.io/managed-by: kates
-    kates.klster.com/component: chaos-integration
+    kates.bmscomp.github.io/component: chaos-integration
 spec:
   backoffLimit: 0
   ttlSecondsAfterFinished: 86400

--- a/config/litmus/experiments/probe-rto-assertion.yaml
+++ b/config/litmus/experiments/probe-rto-assertion.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kafka
   labels:
     app.kubernetes.io/managed-by: kates
-    kates.klster.com/component: chaos-probe
+    kates.bmscomp.github.io/component: chaos-probe
 data:
   rto-probe.sh: |
     #!/bin/bash

--- a/images.env
+++ b/images.env
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Single source of truth for all container images used by klster.
+# Single source of truth for all container images used by Kates.
 # Sourced by pull-images.sh and load-images-to-kind.sh.
 
 # Strimzi Kafka

--- a/kates-ci.sh
+++ b/kates-ci.sh
@@ -15,7 +15,7 @@ echo ""
 
 if ! command -v kates &>/dev/null; then
   echo "ERROR: kates CLI not found in PATH"
-  echo "Install: go install github.com/klster/kates-cli@latest"
+  echo "Install: brew install bmscomp/tap/kates — or download a binary from https://github.com/bmscomp/kates/releases/latest"
   exit 1
 fi
 

--- a/kates/Dockerfile
+++ b/kates/Dockerfile
@@ -9,8 +9,8 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
   -trimpath \
   -ldflags="-s -w \
-  -X github.com/klster/kates-cli/cmd.Version=1.0.0 \
-  -X github.com/klster/kates-cli/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  -X github.com/bmscomp/kates/cli/cmd.Version=1.0.0 \
+  -X github.com/bmscomp/kates/cli/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   -o /kates .
 
 # Stage 2: Build the Java application

--- a/kates/Dockerfile.native
+++ b/kates/Dockerfile.native
@@ -9,8 +9,8 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
   -trimpath \
   -ldflags="-s -w \
-  -X github.com/klster/kates-cli/cmd.Version=1.0.0 \
-  -X github.com/klster/kates-cli/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  -X github.com/bmscomp/kates/cli/cmd.Version=1.0.0 \
+  -X github.com/bmscomp/kates/cli/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   -o /kates-cli .
 
 # Stage 2: Build the native executable (Mandrel)

--- a/kates/README.md
+++ b/kates/README.md
@@ -15,7 +15,7 @@ Quarkus-based REST API that orchestrates Kafka performance tests, chaos engineer
 ## Package Structure
 
 ```
-src/main/java/com/klster/kates/
+src/main/java/com/bmscomp/kates/
 ├── api/            REST endpoints (JAX-RS resources)
 ├── chaos/          Chaos provider implementations (Litmus, K8s, NoOp)
 ├── config/         Application configuration beans

--- a/kates/docs/architecture.md
+++ b/kates/docs/architecture.md
@@ -19,7 +19,7 @@ Three core principles shaped the architecture:
 The codebase is organized into packages that correspond directly to the major subsystems of the application. Each package has a clear boundary and a well-defined set of responsibilities. This is not an accident — the package structure is the architecture, made visible in the file system.
 
 ```
-com.klster.kates
+com.bmscomp.kates
 ├── api/                  REST endpoints (JAX-RS resources)
 │   ├── TestResource      POST/GET/DELETE /api/tests, GET /api/tests/backends
 │   ├── ClusterResource   GET /api/cluster/* (brokers, topics, consumer groups)

--- a/kates/docs/book/extending-kates.md
+++ b/kates/docs/book/extending-kates.md
@@ -8,9 +8,9 @@ This chapter explains the three extension points, the contracts each SPI defines
 
 | SPI | Package | Purpose | Existing Implementations |
 |-----|---------|---------|--------------------------|
-| `BenchmarkBackend` | `com.klster.kates.engine` | Executes performance benchmarks | `NativeBenchmarkBackend`, `TrogdorBenchmarkBackend` |
-| `ChaosProvider` | `com.klster.kates.chaos` | Injects and cleans up faults | `KubernetesChaosProvider`, `LitmusChaosProvider`, `HybridChaosProvider`, `NoOpChaosProvider` |
-| `ExportStrategy` | `com.klster.kates.export` | Transforms results into output formats | `CsvExporter`, `JunitXmlExporter`, `HeatmapExporter` |
+| `BenchmarkBackend` | `com.bmscomp.kates.engine` | Executes performance benchmarks | `NativeBenchmarkBackend`, `TrogdorBenchmarkBackend` |
+| `ChaosProvider` | `com.bmscomp.kates.chaos` | Injects and cleans up faults | `KubernetesChaosProvider`, `LitmusChaosProvider`, `HybridChaosProvider`, `NoOpChaosProvider` |
+| `ExportStrategy` | `com.bmscomp.kates.export` | Transforms results into output formats | `CsvExporter`, `JunitXmlExporter`, `HeatmapExporter` |
 
 Each SPI is a Java interface with CDI qualifiers. Implementations are discovered automatically by Quarkus's CDI container at startup. Adding a new implementation is as simple as creating a class that implements the interface and annotating it with the appropriate CDI qualifier.
 

--- a/kates/k8s/configmap.yaml
+++ b/kates/k8s/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: kates
     app.kubernetes.io/name: kates
-    app.kubernetes.io/part-of: klster
+    app.kubernetes.io/part-of: kates
 data:
   # Kafka cluster
   KATES_KAFKA_BOOTSTRAP_SERVERS: "krafter-kafka-bootstrap.kafka.svc:9092"

--- a/kates/k8s/deployment.yaml
+++ b/kates/k8s/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: kates
     app.kubernetes.io/name: kates
-    app.kubernetes.io/part-of: klster
+    app.kubernetes.io/part-of: kates
 spec:
   replicas: 1
   selector:

--- a/kates/k8s/namespace.yaml
+++ b/kates/k8s/namespace.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: kates
   labels:
-    app.kubernetes.io/part-of: klster
+    app.kubernetes.io/part-of: kates

--- a/kates/k8s/postgres.yaml
+++ b/kates/k8s/postgres.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: postgres
     app.kubernetes.io/name: postgres
-    app.kubernetes.io/part-of: klster
+    app.kubernetes.io/part-of: kates
     app.kubernetes.io/component: database
 spec:
   serviceName: postgres
@@ -73,7 +73,7 @@ metadata:
   labels:
     app: postgres
     app.kubernetes.io/name: postgres
-    app.kubernetes.io/part-of: klster
+    app.kubernetes.io/part-of: kates
     app.kubernetes.io/component: database
 spec:
   type: ClusterIP

--- a/kates/k8s/rbac.yaml
+++ b/kates/k8s/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: kates
     app.kubernetes.io/name: kates
-    app.kubernetes.io/part-of: klster
+    app.kubernetes.io/part-of: kates
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -15,7 +15,7 @@ metadata:
   labels:
     app: kates
     app.kubernetes.io/name: kates
-    app.kubernetes.io/part-of: klster
+    app.kubernetes.io/part-of: kates
 rules:
   - apiGroups: ["litmuschaos.io"]
     resources: ["chaosengines", "chaosexperiments", "chaosresults"]
@@ -46,7 +46,7 @@ metadata:
   labels:
     app: kates
     app.kubernetes.io/name: kates
-    app.kubernetes.io/part-of: klster
+    app.kubernetes.io/part-of: kates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/kates/k8s/service.yaml
+++ b/kates/k8s/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: kates
     app.kubernetes.io/name: kates
-    app.kubernetes.io/part-of: klster
+    app.kubernetes.io/part-of: kates
 spec:
   type: ClusterIP
   selector:

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Shared constants, colors, and utility functions for all klster scripts.
+# Shared constants, colors, and utility functions for all Kates scripts.
 # Source this file at the top of every script:
 #   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 #   source "${SCRIPT_DIR}/common.sh"

--- a/scripts/install-kates.sh
+++ b/scripts/install-kates.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 BINARY="kates"
-REPO_BASE_URL="${KATES_DOWNLOAD_URL:-https://github.com/klster/kates-cli/releases/latest/download}"
+REPO_BASE_URL="${KATES_DOWNLOAD_URL:-https://github.com/bmscomp/kates/releases/latest/download}"
 
 detect_platform() {
   local os arch


### PR DESCRIPTION
## Summary

Retires the last `klster` references in the codebase — the Go module rename that was deliberately deferred during the earlier URL/chart cleanup because it touches every import in the CLI.

## What changed

- **Module path**: `github.com/klster/kates-cli` → `github.com/bmscomp/kates/cli` (the canonical path for a module in the `cli/` subdirectory of this repo — the old path pointed at a repository that has never existed, so the advertised `go install` could never work)
- All ~100 import statements across `cli/`
- Version-injection ldflags in `cli/build.sh`, `cli/build`, `.github/workflows/release-cli.yml`, and `kates/Dockerfile.native` — all four injected `-X` vars at the old path and would have shipped binaries with empty version fields after a naive rename
- `kates-ci.sh` now points at brew/releases instead of the never-functional `go install` instruction
- The `kates.klster.com/*` label domain in the chaos experiment manifests → `kates.bmscomp.github.io/*` (verified nothing selects on these labels)

## Verification

- `go build ./...` and `go test ./...` pass across all packages under the new path
- ldflags version injection verified end to end: a test build with `-X github.com/bmscomp/kates/cli/cmd.Version=rename-test` shows `rename-test` in `kates version` output
- `grep -r klster` across the codebase returns nothing — a second exhaustive unfiltered sweep caught six more files the first pass missed (JVM Dockerfile ldflags, the install script pointing at a nonexistent repo for release downloads, OCI vendor label, k8s part-of labels, backend docs package paths)

## Note for review

Anyone with a local clone needs no action (module path is internal); anything vendoring the CLI as a library would need the new import path — nothing in this repo does.

