### PR TITLE
fix(tui): launch first sweep test and correct lab CSV column mapping

### DIFF
--- a/cli/tui/lab.go
+++ b/cli/tui/lab.go
@@ -274,7 +274,7 @@ func (m LabModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "s":
 			if !m.sweepActive {
 				m.startSweep()
-				return m, nil
+				return m, tea.Batch(m.runTest(), m.tickElapsed())
 			}
 		case "W":
 			if !m.running {
@@ -1208,15 +1208,15 @@ func (m LabModel) exportCSV() string {
 	path := filepath.Join(dir, fmt.Sprintf("kates-lab-%s.csv", time.Now().Format("20060102-150405")))
 
 	var sb strings.Builder
-	sb.WriteString("iteration,throughput_rec_s,p99_ms,avg_latency_ms,delta,test_id")
+	sb.WriteString("iteration,throughput_rec_s,p99_ms,avg_latency_ms,error_rate,delta,test_id")
 	for _, p := range m.params {
 		sb.WriteString("," + p.Key)
 	}
 	sb.WriteString("\n")
 
 	for _, iter := range m.iterations {
-		sb.WriteString(fmt.Sprintf("%d,%.2f,%.2f,%.2f,%s,%s",
-			iter.Number, iter.Throughput, iter.P99Ms, iter.ErrorRate,
+		sb.WriteString(fmt.Sprintf("%d,%.2f,%.2f,%.2f,%.2f,%s,%s",
+			iter.Number, iter.Throughput, iter.P99Ms, iter.AvgMs, iter.ErrorRate,
 			stripAnsi(iter.Delta), iter.TestID))
 		for _, p := range m.params {
 			val := ""


### PR DESCRIPTION
## What changed

Two fixes in the Kates Lab TUI (`cli/tui/lab.go`):

1. **Auto-sweep never launched its first test.** The `'s'` key handler called `startSweep()` and returned `m, nil`, so no `runTest`/`tickElapsed` command was ever dispatched. The UI entered a permanent "running" state and `labTestDoneMsg` never arrived, so `nextSweepStep` never fired. The handler now returns `tea.Batch(m.runTest(), m.tickElapsed())`, mirroring the `enter` and `m` (median mode) handlers.

2. **`exportCSV` wrote the wrong value under `avg_latency_ms`.** The row writer passed `iter.ErrorRate` in the column the header labels `avg_latency_ms`. It now writes `iter.AvgMs` there, and a dedicated `error_rate` column was added after it since that data was already being collected and exported (just mislabeled). New header: `iteration,throughput_rec_s,p99_ms,avg_latency_ms,error_rate,delta,test_id` + param columns.

## Reviewer notes

- `go build ./...` and `go test ./...` in `cli/` pass; the `tui` package has no test files, so these paths were verified by inspection against the reported repro (stuck "running" state on `'s'`; error-rate values in the latency column of exported CSVs).
- The `error_rate` column is a schema addition to the exported CSV — anything parsing these exports by column position will need the new column; parsers keyed by header name are unaffected.

