### PR TITLE
feat(chaos): scope kates-chaos to the execution plane and make it configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ all: check-prerequisites
 	@echo "🔗 Access points:"
 	@echo "  - Apicurio Registry: http://localhost:30082"
 	@echo "  - Kates:             http://localhost:30083"
-	@echo "  - Litmus UI:         http://localhost:9091  (admin/litmus)"
+	@echo "  - Chaos:             execution plane only (no UI) — 'make chaos-status'"
 	@echo ""
 
 # Check prerequisites — only kubectl and helm are strictly required for generic clusters
@@ -829,9 +829,11 @@ litmus-undeploy:
 	@echo "✅ Kates Chaos removed"
 
 chaos-ui:
-	@echo "🌐 Port-forwarding Litmus UI..."
-	@echo "Access at: http://localhost:9091 (admin/litmus)"
-	kubectl port-forward svc/chaos-litmus-frontend-service 9091:9091 -n kafka
+	@echo "ℹ️  The kates-chaos chart deploys the LitmusChaos execution plane only —"
+	@echo "   there is no web portal to port-forward. Drive chaos via ChaosEngine"
+	@echo "   resources / the 'engines:' values, and inspect state with:"
+	@echo "     make chaos-status"
+	@echo "   To get the ChaosCenter UI, install upstream ChaosCenter separately."
 
 chaos-status:
 	@echo "📊 Chaos Status:"
@@ -1006,7 +1008,7 @@ help:
 	@echo "  ports                              - Start port forwarding"
 	@echo "  logs                               - Stream logs from all services"
 	@echo "  status                             - Check cluster status"
-	@echo "  chaos-ui                           - Port-forward Litmus UI"
+	@echo "  chaos-ui                           - Explain chaos access (no UI in execution-plane chart)"
 	@echo "  chaos-status                       - Show chaos infrastructure status"
 	@echo "  gameday                            - Run automated GameDay validation"
 	@echo "  kyverno-permissive                 - Make Kyverno completely permissive (ignore all)"

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Kates ships its platform as independently versioned Helm charts, composable via 
 | [`kafka-cluster`](charts/kafka-cluster/) | 0.1.1 | 4.2.0 | A Strimzi-managed KRaft Kafka cluster with zone-aware broker pools, SCRAM-SHA-512 authentication, and rack-affinity storage classes. |
 | [`connect-cluster`](charts/connect-cluster/) | 1.2.0 | 4.2.0 | A Strimzi-managed Kafka Connect cluster with a managed KafkaUser, least-privilege ACLs, default-deny NetworkPolicies, and in-chart JMX metrics. |
 | [`kafka-ui`](charts/kafka-ui/) | 0.2.0 | v1.5.0 | A web-based Kafka management interface for topic inspection, consumer group monitoring, and message browsing. |
-| [`kates-chaos`](charts/kates-chaos/) | 1.2.0 | 1.20.0 | A LitmusChaos wrapper that installs Kafka-specific RBAC, ChaosServiceAccounts, and pre-built experiment templates for broker and network faults. |
+| [`kates-chaos`](charts/kates-chaos/) | 2.0.0 | 3.28.0 | A LitmusChaos execution-plane wrapper (operator, exporter, CRDs) with Kafka-specific RBAC, ChaosExperiment/ChaosEngine templating, and monitoring for broker and network faults. |
 | [`kates-monitoring`](charts/monitoring/) | 1.0.0 | 82.4.3 | The Prometheus and Grafana monitoring stack, pre-configured with scrape jobs, recording rules, and auto-provisioned dashboards for Kafka, JVM, and Strimzi metrics. |
 | [`apicurio-registry`](charts/apicurio-registry/) | 0.1.5 | 3.3.0 | Apicurio Schema Registry deployed with KafkaSQL persistence, providing schema validation and compatibility enforcement for Avro, Protobuf, and JSON Schema. |
 | [`kates-platform`](charts/kates-platform/) | 0.2.0 | 1.0.0 | An umbrella chart that composes all sub-charts into a single `helm install` operation for full-platform provisioning. |

--- a/charts/kates-chaos/Chart.yaml
+++ b/charts/kates-chaos/Chart.yaml
@@ -1,16 +1,32 @@
 apiVersion: v2
 name: kates-chaos
-version: 1.2.0
-appVersion: "1.20.0"
-description: Kates Chaos Engineering — wraps LitmusChaos with Kafka-specific RBAC, experiments, and monitoring
+version: 2.0.0
+# Tracks the LitmusChaos execution-plane version this chart deploys.
+appVersion: "3.28.0"
+description: Kates Chaos Engineering — wraps the LitmusChaos execution plane (operator, exporter, CRDs) with Kafka-specific RBAC, experiment/engine templating, and monitoring
 home: https://github.com/bmscomp/kates
+sources:
+  - https://github.com/bmscomp/kates
 keywords:
   - chaos-engineering
   - kafka
   - kates
   - litmus
+maintainers:
+  - name: bmscomp
+    url: https://github.com/bmscomp
 dependencies:
   - name: litmus-core
     version: 3.28.1
     repository: https://litmuschaos.github.io/litmus-helm/
     condition: litmus-core.enabled
+annotations:
+  artifacthub.io/category: skip-prediction
+  artifacthub.io/prerelease: "false"
+  artifacthub.io/changes: |
+    - kind: changed
+      description: Scoped the chart to the LitmusChaos execution plane (operator-only); removed portal (frontend/server/MongoDB) references from NOTES, tests, and GameDay
+    - kind: added
+      description: Configurable images block, service account name, structured NetworkPolicy, ServiceMonitor scrape controls, multi-namespace RBAC/Kyverno, probes and components on ChaosEngines
+    - kind: deprecated
+      description: rbac.kafkaNamespace/rbac.katesNamespace (use rbac.targetNamespaces) and networkPolicies.enabled (use networkPolicy.enabled) — still honored

--- a/charts/kates-chaos/README.md
+++ b/charts/kates-chaos/README.md
@@ -1,0 +1,248 @@
+# kates-chaos
+
+Chaos engineering for Kates/Kafka on Kubernetes. Wraps the [LitmusChaos](https://litmuschaos.io/) **execution plane** (`litmus-core` subchart: chaos operator, exporter, CRDs) with Kafka-specific RBAC, ChaosExperiment/ChaosEngine templating, monitoring, network isolation, and admission policy.
+
+> For the full deployment narrative, troubleshooting, and architecture diagram, see the [Kates Chaos Chart — Deployment Guide](../../docs/kates-chaos-chart.md). For chaos-engineering theory, see the [chaos book chapters](../../docs/book/06-chaos-theory.md).
+
+## Overview
+
+This chart deploys the LitmusChaos **execution plane only** — it does **not** deploy the ChaosCenter web portal (frontend / GraphQL / auth-server / MongoDB). Chaos is driven declaratively through the `engines:` values or by applying `ChaosEngine` resources. If you want the UI, install ChaosCenter separately.
+
+What it manages:
+
+- **RBAC** — a `litmus-admin` ServiceAccount + Role in each `target` namespace, a coordinator ClusterRole binding in each `coordinator` namespace, and optional cluster-scoped node-chaos RBAC.
+- **ChaosExperiments** — installed into your target namespaces via a post-install Job.
+- **ChaosEngines** — rendered from `engines:`, with first-class probes and pod components.
+- **Monitoring** — optional ServiceMonitor + Grafana dashboard.
+- **NetworkPolicy / Kyverno / PDB / GameDay** — optional, all off by default.
+
+## Prerequisites
+
+| Requirement | Minimum | Notes |
+|-------------|---------|-------|
+| Kubernetes | 1.25+ | Any managed or self-managed cluster |
+| Helm | 3.12+ | Uses the `litmus-core` subchart dependency |
+| LitmusChaos CRDs | 3.28 | Applied before install (hooks depend on them) |
+| Target namespaces | — | Every `rbac.targetNamespaces` entry must exist |
+
+## Installation
+
+### Quick Start
+
+```bash
+# 1. CRDs (hooks depend on them)
+kubectl apply -f config/litmus/chaos-litmus-chaos-enable.yml
+kubectl wait --for=condition=Established crd/chaosexperiments.litmuschaos.io --timeout=60s
+
+# 2. Dependencies
+helm dependency build charts/kates-chaos
+
+# 3. Install
+helm upgrade --install chaos charts/kates-chaos \
+  -n litmus --create-namespace \
+  -f charts/kates-chaos/values-generic.yaml --wait
+```
+
+### Overlays
+
+| Overlay | Use | Notable defaults |
+|---------|-----|------------------|
+| `values-kind.yaml` | Local Kind / dev | `pullPolicy: IfNotPresent`, NetworkPolicy off |
+| `values-generic.yaml` | Production K8s | `pullPolicy: Always`, NetworkPolicy + Kyverno on |
+
+## Configuration Reference
+
+### Core
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `nameOverride` | Override chart name | `""` |
+| `fullnameOverride` | Override full release name | `""` |
+| `commonLabels` | Labels added to every resource | `{}` |
+| `commonAnnotations` | Annotations added to every resource | `{}` |
+| `serviceAccount.name` | Chaos service account (shared by RBAC + engines) | `litmus-admin` |
+
+### Global & Images
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `global.imageRegistry` | Registry prefix for all chart-managed images | `""` |
+| `global.imagePullPolicy` | Pull policy for chart-managed pods | `IfNotPresent` |
+| `global.imagePullSecrets` | Pull secrets for chart-managed pods | `[]` |
+| `global.clusterDomain` | Cluster DNS domain | `cluster.local` |
+| `images.kubectl.repository` | Image for installer Job / GameDay / tests | `registry.k8s.io/kubectl` |
+| `images.kubectl.tag` | kubectl image tag | `v1.33.0` |
+| `images.kubectl.digest` | Pin by digest (wins over tag) | `""` |
+| `images.goRunner.repository` | Default runtime for experiments | `litmuschaos/go-runner` |
+| `images.goRunner.tag` | go-runner image tag | `3.28.0` |
+
+The `litmus-core` subchart images (operator/runner) are set under the `litmus-core:` key.
+
+### RBAC
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `rbac.enabled` | Render cross-namespace RBAC | `true` |
+| `rbac.targetNamespaces` | List of `{name, role}` — `target` (fault injection) or `coordinator` (create engines/read results) | `[{kafka, target}, {kates, coordinator}]` |
+| `rbac.targetNamespaces[].serviceAccount` | SA bound for a `coordinator` entry | `default` |
+| `rbac.nodeChaos.enabled` | Cluster-scoped RBAC for node-level chaos | `true` |
+| `rbac.kafkaNamespace` | **Deprecated** — use `targetNamespaces` | `""` |
+| `rbac.katesNamespace` | **Deprecated** — use `targetNamespaces` | `""` |
+
+### Experiments
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `experiments.enabled` | Install ChaosExperiment definitions (post-install Job) | `true` |
+| `experiments.targetNamespaces` | Namespaces to install into (empty = every `target` namespace) | `[]` |
+| `experiments.installer.backoffLimit` | Installer Job retries | `3` |
+| `experiments.installer.ttlSecondsAfterFinished` | Installer Job TTL | `300` |
+| `experiments.installer.resources` / `securityContext` / `nodeSelector` / `tolerations` | Installer pod tuning | `{}` / `[]` |
+| `experiments.definitions[].name` | Experiment name | — |
+| `experiments.definitions[].scope` | `Namespaced` or `Cluster` | `Namespaced` |
+| `experiments.definitions[].env` | Default env baked into the ChaosExperiment | — |
+| `experiments.definitions[].permissions` | `spec.definition.permissions` (runner RBAC) | — |
+
+Default definitions: `pod-delete`, `pod-cpu-hog`, `pod-memory-hog`, `pod-network-partition`, `pod-io-stress`, `pod-dns-error`, `node-drain`.
+
+### Engines
+
+Each key under `engines:` renders a `ChaosEngine`. Probes and pod `components` are first-class.
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `engines.<name>.enabled` | Render this engine | `false` |
+| `engines.<name>.appNamespace` | Target namespace | primary `target` ns |
+| `engines.<name>.appLabel` | App selector, e.g. `strimzi.io/kind=Kafka` | — |
+| `engines.<name>.appKind` | `statefulset` / `deployment` / … | `statefulset` |
+| `engines.<name>.experiment` | Experiment name | `<name>` |
+| `engines.<name>.serviceAccount` | Override the chaos SA | `serviceAccount.name` |
+| `engines.<name>.engineState` | `active` / `stop` | `active` |
+| `engines.<name>.annotationCheck` | Require chaos annotation on the target | `false` |
+| `engines.<name>.jobCleanUpPolicy` | `delete` / `retain` | — |
+| `engines.<name>.duration` / `interval` | `TOTAL_CHAOS_DURATION` / `CHAOS_INTERVAL` | `30` / `10` |
+| `engines.<name>.force` | Set `FORCE=true` | `false` |
+| `engines.<name>.targetPods` / `podsAffectedPerc` | Scope the blast radius | — |
+| `engines.<name>.env` | Extra experiment env (map) | `{}` |
+| `engines.<name>.components` | `nodeSelector` / `resources` / `tolerations` for the runner | `{}` |
+| `engines.<name>.probes` | Litmus probes (`cmdProbe`/`httpProbe`/`promProbe`), passed through | `[]` |
+
+### Network Policy
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `networkPolicy.enabled` | Scope chaos-infra traffic | `false` |
+| `networkPolicy.apiServer.enabled` | Egress to the Kubernetes API server (**operator needs it**) | `true` |
+| `networkPolicy.apiServer.ports` / `ipBlock` | API-server ports / CIDR pin | `[443,6443]` / `{}` |
+| `networkPolicy.dns.enabled` | DNS egress | `true` |
+| `networkPolicy.monitoring.enabled` | Prometheus scrape ingress to the exporter | `true` |
+| `networkPolicy.monitoring.namespace` / `port` | Scrape source ns / exporter port | `monitoring` / `8080` |
+| `networkPolicy.targets.enabled` | Egress to `rbac.targetNamespaces` | `true` |
+| `networkPolicy.extraIngress` / `extraEgress` | Raw rules appended verbatim | `[]` |
+| `networkPolicies.enabled` | **Deprecated** alias — OR'd with `networkPolicy.enabled` | `false` |
+
+### Monitoring
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `monitoring.serviceMonitor.enabled` | Create a ServiceMonitor for the exporter | `false` |
+| `monitoring.serviceMonitor.selector` | Exporter Service label selector | `{app: litmus}` |
+| `monitoring.serviceMonitor.port` / `path` / `interval` | Scrape endpoint | `http` / `/metrics` / `30s` |
+| `monitoring.serviceMonitor.scrapeTimeout` / `honorLabels` | Scrape tuning | `""` / `false` |
+| `monitoring.serviceMonitor.relabelings` / `metricRelabelings` | Relabel rules | `[]` |
+| `monitoring.grafanaDashboard.enabled` | Ship the dashboard ConfigMap | `false` |
+| `monitoring.grafanaDashboard.namespace` | Namespace used in dashboard PromQL | release ns |
+| `monitoring.grafanaDashboard.folder` | `grafana_folder` annotation | `""` |
+
+> The `litmus-core` subchart can ship its own exporter ServiceMonitor — leave `monitoring.serviceMonitor.enabled=false` to avoid duplicate scrapes, and enable it only if you manage scraping here.
+
+### Kyverno, PDB & GameDay
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `kyvernoPolicy.enabled` | Pod-security ClusterPolicy (needs Kyverno) | `false` |
+| `kyvernoPolicy.action` | `Audit` / `Enforce` | `Audit` |
+| `kyvernoPolicy.namespaces` | Namespaces the policy applies to (empty = release ns) | `[]` |
+| `kyvernoPolicy.excludeSelector` | Pods skipped (need privileges) | `chaosUID Exists` |
+| `pdb.enabled` | PodDisruptionBudget (requires `selector`) | `false` |
+| `pdb.minAvailable` / `maxUnavailable` / `selector` | PDB config | `1` / `""` / `{}` |
+| `gameday.enabled` | Run the validation Job | `false` |
+| `gameday.checks` | Data-driven `{name, command}` checks (empty = default set) | `[]` |
+
+## Examples
+
+### Kafka leader-kill with an ISR-recovery probe
+
+```yaml
+engines:
+  kafka-leader-kill:
+    enabled: true
+    appLabel: "strimzi.io/kind=Kafka"
+    experiment: pod-delete
+    duration: 60
+    force: true
+    targetPods: "krafter-pool-alpha-0"
+    podsAffectedPerc: "100"
+    jobCleanUpPolicy: retain
+    probes:
+      - name: verify-isr-failover
+        type: cmdProbe
+        mode: PostChaos
+        runProperties: { probeTimeout: "120s", interval: "10s", retry: 6 }
+        cmdProbe/inputs:
+          command: "kubectl exec -n kafka krafter-pool-alpha-1 -- kafka-topics.sh --bootstrap-server localhost:9092 --list"
+          comparator: { type: string, criteria: contains, value: "orders" }
+```
+
+### Multiple target namespaces
+
+```yaml
+rbac:
+  targetNamespaces:
+    - { name: kafka,     role: target }
+    - { name: streaming, role: target }
+    - { name: kates,     role: coordinator }
+experiments:
+  targetNamespaces: [kafka, streaming]   # install experiments into both
+```
+
+### Locked-down cluster (pin the API server, custom GameDay)
+
+```yaml
+networkPolicy:
+  enabled: true
+  apiServer:
+    ipBlock: { cidr: 10.0.0.1/32 }
+gameday:
+  enabled: true
+  checks:
+    - { name: CRDs installed, command: "kubectl get crd chaosengines.litmuschaos.io" }
+    - { name: Brokers Running, command: "kubectl get pods -n kafka -l strimzi.io/kind=Kafka | grep Running" }
+```
+
+## Helm Tests
+
+```bash
+helm test chaos -n litmus
+```
+
+Runs two hooks: the chaos **operator** is `Available`, and the Litmus **CRDs** are established with experiments installed. Both use a scoped, ephemeral test ServiceAccount.
+
+## Upgrading
+
+### 1.x → 2.0.0 (breaking)
+
+2.0.0 rescopes the chart to the execution plane and removes portal assumptions. Renamed keys are **still honored** (deprecated, win when set):
+
+| Old | New |
+|-----|-----|
+| `rbac.kafkaNamespace` / `rbac.katesNamespace` | `rbac.targetNamespaces` (list of `{name, role}`) |
+| `networkPolicies.enabled` | `networkPolicy.enabled` (now structured) |
+| `experiments.image` (string) | `images.kubectl` / `experiments.installer.image` |
+
+Behavioral changes to review:
+
+- **No web portal.** NOTES, Helm tests, and GameDay now validate the operator/CRDs, not a frontend/MongoDB. Install ChaosCenter separately for a UI.
+- **`pdb.enabled` now requires `pdb.selector`** (the chart ships no stateful workload to protect by default).
+- **`kyvernoPolicy.excludeContainers` was removed** — use `kyvernoPolicy.excludeSelector` (a real pod selector).
+- **NetworkPolicy adds Kubernetes API-server egress** — required by the operator; pin `apiServer.ipBlock` on strict clusters.

--- a/charts/kates-chaos/templates/NOTES.txt
+++ b/charts/kates-chaos/templates/NOTES.txt
@@ -1,28 +1,52 @@
-Kates Chaos Engineering v{{ .Chart.Version }}
+Kates Chaos Engineering v{{ .Chart.Version }} (LitmusChaos {{ .Chart.AppVersion }})
 
-Release: {{ .Release.Name }}
+Release:   {{ .Release.Name }}
 Namespace: {{ .Release.Namespace }}
 
-LitmusChaos Portal:
-  UI:      kubectl port-forward svc/{{ .Release.Name }}-litmus-frontend-service -n {{ .Release.Namespace }} 9091:9091
-  Login:   admin / litmus
+This chart deploys the LitmusChaos EXECUTION PLANE (chaos operator, exporter,
+and CRDs). There is no web portal — drive chaos declaratively via the
+`engines:` values or by applying ChaosEngine resources.
+
+Check the operator is up:
+  kubectl rollout status deployment -l app.kubernetes.io/name=litmus -n {{ .Release.Namespace }}
 
 {{- if .Values.rbac.enabled }}
-RBAC:
-  ✓ kafka namespace ({{ .Values.rbac.kafkaNamespace }}) → litmus-admin service account
-  ✓ kates namespace ({{ .Values.rbac.katesNamespace }}) → chaos coordinator role
+
+RBAC (service account: {{ include "kates-chaos.serviceAccountName" . }}):
+{{- range (include "kates-chaos.targetNamespaces" . | fromYamlArray) }}
+  ✓ {{ .name }} namespace → {{ .role | default "target" }}
+{{- end }}
+{{- if .Values.rbac.nodeChaos.enabled }}
+  ✓ cluster-scoped node-chaos RBAC
+{{- end }}
 {{- end }}
 
 {{- if .Values.experiments.enabled }}
+
 Experiments:
   ✓ {{ len .Values.experiments.definitions }} ChaosExperiment definitions (post-install hook)
-  Run: kubectl get chaosexperiments -n {{ .Values.rbac.kafkaNamespace | default "kafka" }}
+  List: kubectl get chaosexperiments -n {{ include "kates-chaos.kafkaNamespace" . }}
+{{- end }}
+
+{{- $engineCount := 0 }}
+{{- range $name, $e := .Values.engines }}{{- if $e.enabled }}{{- $engineCount = add $engineCount 1 }}{{- end }}{{- end }}
+{{- if gt $engineCount 0 }}
+
+Engines:
+  ✓ {{ $engineCount }} ChaosEngine(s) rendered
+  Watch: kubectl get chaosengine,chaosresult -n {{ include "kates-chaos.kafkaNamespace" . }}
 {{- end }}
 
 {{- if .Values.monitoring.serviceMonitor.enabled }}
+
 Monitoring:
-  ✓ ServiceMonitor for chaos-exporter
+  ✓ ServiceMonitor for the chaos exporter
 {{- end }}
 
-Verify:
+Verify the install:
   helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
+{{- if not .Values.gameday.enabled }}
+
+Run a deeper GameDay validation:
+  helm upgrade {{ .Release.Name }} <chart> -n {{ .Release.Namespace }} --reuse-values --set gameday.enabled=true
+{{- end }}

--- a/charts/kates-chaos/templates/_helpers.tpl
+++ b/charts/kates-chaos/templates/_helpers.tpl
@@ -15,11 +15,144 @@
 {{- end }}
 {{- end }}
 
-{{- define "kates-chaos.labels" -}}
+{{- define "kates-chaos.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Selector labels — the stable subset used in matchLabels/selectors.
+Never add version-varying labels here.
+*/}}
+{{- define "kates-chaos.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "kates-chaos.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Common labels applied to every resource, including user-supplied commonLabels.
+*/}}
+{{- define "kates-chaos.labels" -}}
+{{ include "kates-chaos.selectorLabels" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: kates
-helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 }}
+helm.sh/chart: {{ include "kates-chaos.chart" . }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common annotations (empty unless commonAnnotations is set).
+*/}}
+{{- define "kates-chaos.annotations" -}}
+{{- with .Values.commonAnnotations }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve an image reference from an image dict ({repository, tag, digest}) and
+the global block. Prefers digest over tag; prepends global.imageRegistry.
+Usage: include "kates-chaos.image" (dict "img" .Values.images.kubectl "global" .Values.global)
+*/}}
+{{- define "kates-chaos.image" -}}
+{{- $img := .img -}}
+{{- $global := .global | default dict -}}
+{{- $registry := $global.imageRegistry | default "" -}}
+{{- $repo := $img.repository -}}
+{{- if $registry -}}{{- $repo = printf "%s/%s" $registry $repo -}}{{- end -}}
+{{- if $img.digest -}}
+{{- printf "%s@%s" $repo $img.digest -}}
+{{- else -}}
+{{- printf "%s:%s" $repo ($img.tag | toString) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+kubectl image used by the installer Job, gameday, and tests.
+Honors, in order: experiments.installer.image (string), the deprecated
+experiments.image (string), then the images.kubectl dict.
+*/}}
+{{- define "kates-chaos.kubectlImage" -}}
+{{- $override := "" -}}
+{{- if .Values.experiments.installer -}}{{- $override = .Values.experiments.installer.image | default "" -}}{{- end -}}
+{{- if not $override -}}{{- $override = .Values.experiments.image | default "" -}}{{- end -}}
+{{- if $override -}}
+{{- $override -}}
+{{- else -}}
+{{- include "kates-chaos.image" (dict "img" .Values.images.kubectl "global" .Values.global) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+go-runner image used as the default for ChaosExperiment definitions.
+*/}}
+{{- define "kates-chaos.goRunnerImage" -}}
+{{- include "kates-chaos.image" (dict "img" .Values.images.goRunner "global" .Values.global) -}}
+{{- end }}
+
+{{/*
+Chaos service account name (shared by RBAC and ChaosEngines).
+*/}}
+{{- define "kates-chaos.serviceAccountName" -}}
+{{- (.Values.serviceAccount).name | default "litmus-admin" -}}
+{{- end }}
+
+{{/*
+Normalized target-namespace list as a YAML array of {name, role}.
+Prefers rbac.targetNamespaces; falls back to the deprecated
+rbac.kafkaNamespace / rbac.katesNamespace pair.
+Consume with: include "kates-chaos.targetNamespaces" . | fromYamlArray
+*/}}
+{{- define "kates-chaos.targetNamespaces" -}}
+{{- if .Values.rbac.targetNamespaces -}}
+{{- toYaml .Values.rbac.targetNamespaces -}}
+{{- else -}}
+- name: {{ .Values.rbac.kafkaNamespace | default "kafka" }}
+  role: target
+- name: {{ .Values.rbac.katesNamespace | default "kates" }}
+  role: coordinator
+{{- end -}}
+{{- end }}
+
+{{/*
+Primary "target"-role namespace (where experiments install and most faults
+run). Honors the deprecated kafkaNamespace first for backward compatibility.
+*/}}
+{{- define "kates-chaos.kafkaNamespace" -}}
+{{- if .Values.rbac.kafkaNamespace -}}
+{{- .Values.rbac.kafkaNamespace -}}
+{{- else -}}
+{{- $ns := "" -}}
+{{- range (include "kates-chaos.targetNamespaces" . | fromYamlArray) -}}
+{{- if and (eq (.role | default "target") "target") (not $ns) -}}{{- $ns = .name -}}{{- end -}}
+{{- end -}}
+{{- $ns | default "kafka" -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Primary "coordinator"-role namespace. Honors deprecated katesNamespace first.
+*/}}
+{{- define "kates-chaos.katesNamespace" -}}
+{{- if .Values.rbac.katesNamespace -}}
+{{- .Values.rbac.katesNamespace -}}
+{{- else -}}
+{{- $ns := "" -}}
+{{- range (include "kates-chaos.targetNamespaces" . | fromYamlArray) -}}
+{{- if and (eq (.role | default "target") "coordinator") (not $ns) -}}{{- $ns = .name -}}{{- end -}}
+{{- end -}}
+{{- $ns | default "kates" -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Whether the NetworkPolicy is enabled. Enabled if EITHER the new
+networkPolicy.enabled or the deprecated networkPolicies.enabled is true.
+*/}}
+{{- define "kates-chaos.networkPolicyEnabled" -}}
+{{- $new := and (hasKey .Values "networkPolicy") .Values.networkPolicy.enabled -}}
+{{- $old := and (hasKey .Values "networkPolicies") .Values.networkPolicies.enabled -}}
+{{- if or $new $old -}}true{{- else -}}false{{- end -}}
 {{- end }}

--- a/charts/kates-chaos/templates/chaos-rbac.yaml
+++ b/charts/kates-chaos/templates/chaos-rbac.yaml
@@ -1,19 +1,29 @@
 {{- if .Values.rbac.enabled }}
+{{- $sa := include "kates-chaos.serviceAccountName" . }}
+{{- $targets := include "kates-chaos.targetNamespaces" . | fromYamlArray }}
+{{- range $t := $targets }}
+{{- if eq ($t.role | default "target") "target" }}
+---
+# ── Target namespace {{ $t.name }}: fault-injection identity + Role ───────────
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: litmus-admin
-  namespace: {{ .Values.rbac.kafkaNamespace | default "kafka" }}
+  name: {{ $sa }}
+  namespace: {{ $t.name }}
   labels:
-    {{- include "kates-chaos.labels" . | nindent 4 }}
+    {{- include "kates-chaos.labels" $ | nindent 4 }}
+  {{- with include "kates-chaos.annotations" $ }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: litmus-admin
-  namespace: {{ .Values.rbac.kafkaNamespace | default "kafka" }}
+  name: {{ $sa }}
+  namespace: {{ $t.name }}
   labels:
-    {{- include "kates-chaos.labels" . | nindent 4 }}
+    {{- include "kates-chaos.labels" $ | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["pods", "events", "pods/log", "pods/exec", "pods/eviction"]
@@ -37,19 +47,23 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: litmus-admin
-  namespace: {{ .Values.rbac.kafkaNamespace | default "kafka" }}
+  name: {{ $sa }}
+  namespace: {{ $t.name }}
   labels:
-    {{- include "kates-chaos.labels" . | nindent 4 }}
+    {{- include "kates-chaos.labels" $ | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: litmus-admin
+  name: {{ $sa }}
 subjects:
   - kind: ServiceAccount
-    name: litmus-admin
-    namespace: {{ .Values.rbac.kafkaNamespace | default "kafka" }}
+    name: {{ $sa }}
+    namespace: {{ $t.name }}
+{{- end }}
+{{- end }}
+{{- if .Values.rbac.nodeChaos.enabled }}
 ---
+# ── Cluster-scoped RBAC for node-level chaos ─────────────────────────────────
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -78,16 +92,24 @@ roleRef:
   kind: ClusterRole
   name: {{ include "kates-chaos.fullname" . }}-node-chaos
 subjects:
+  {{- range $t := $targets }}
+  {{- if eq ($t.role | default "target") "target" }}
   - kind: ServiceAccount
-    name: litmus-admin
-    namespace: {{ .Values.rbac.kafkaNamespace | default "kafka" }}
+    name: {{ $sa }}
+    namespace: {{ $t.name }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+{{- range $t := $targets }}
+{{- if eq ($t.role | default "target") "coordinator" }}
 ---
+# ── Coordinator namespace {{ $t.name }}: create engines + read results ────────
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kates-chaos.fullname" . }}-kates-coordinator
+  name: {{ include "kates-chaos.fullname" $ }}-coordinator-{{ $t.name }}
   labels:
-    {{- include "kates-chaos.labels" . | nindent 4 }}
+    {{- include "kates-chaos.labels" $ | nindent 4 }}
 rules:
   - apiGroups: ["litmuschaos.io"]
     resources: ["chaosengines", "chaosresults"]
@@ -96,15 +118,17 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "kates-chaos.fullname" . }}-kates-coordinator
+  name: {{ include "kates-chaos.fullname" $ }}-coordinator-{{ $t.name }}
   labels:
-    {{- include "kates-chaos.labels" . | nindent 4 }}
+    {{- include "kates-chaos.labels" $ | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "kates-chaos.fullname" . }}-kates-coordinator
+  name: {{ include "kates-chaos.fullname" $ }}-coordinator-{{ $t.name }}
 subjects:
   - kind: ServiceAccount
-    name: default
-    namespace: {{ .Values.rbac.katesNamespace | default "kates" }}
+    name: {{ $t.serviceAccount | default "default" }}
+    namespace: {{ $t.name }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/kates-chaos/templates/chaosengines.yaml
+++ b/charts/kates-chaos/templates/chaosengines.yaml
@@ -1,4 +1,5 @@
-{{- $kafkaNamespace := .Values.rbac.kafkaNamespace | default "kafka" }}
+{{- $kafkaNamespace := include "kates-chaos.kafkaNamespace" . }}
+{{- $defaultSA := include "kates-chaos.serviceAccountName" . }}
 {{- range $name, $engine := .Values.engines }}
 {{- if $engine.enabled }}
 ---
@@ -8,19 +9,43 @@ metadata:
   name: {{ $name }}
   namespace: {{ $engine.appNamespace | default $kafkaNamespace }}
   labels:
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: kates-chaos
+    {{- include "kates-chaos.labels" $ | nindent 4 }}
+    {{- with $engine.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $engine.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  engineState: active
+  engineState: {{ $engine.engineState | default "active" }}
+  annotationCheck: {{ $engine.annotationCheck | default false | quote }}
+  {{- with $engine.jobCleanUpPolicy }}
+  jobCleanUpPolicy: {{ . }}
+  {{- end }}
   appinfo:
     appns: {{ $engine.appNamespace | default $kafkaNamespace }}
     applabel: {{ $engine.appLabel | quote }}
     appkind: {{ $engine.appKind | default "statefulset" }}
-  chaosServiceAccount: litmus-admin
+  chaosServiceAccount: {{ $engine.serviceAccount | default $defaultSA }}
   experiments:
     - name: {{ $engine.experiment | default $name }}
       spec:
         components:
+          {{- with $engine.components }}
+          {{- if .nodeSelector }}
+          nodeSelector:
+            {{- toYaml .nodeSelector | nindent 12 }}
+          {{- end }}
+          {{- if .resources }}
+          resources:
+            {{- toYaml .resources | nindent 12 }}
+          {{- end }}
+          {{- if .tolerations }}
+          tolerations:
+            {{- toYaml .tolerations | nindent 12 }}
+          {{- end }}
+          {{- end }}
           env:
             - name: TOTAL_CHAOS_DURATION
               value: {{ $engine.duration | default 30 | quote }}
@@ -30,9 +55,21 @@ spec:
             - name: FORCE
               value: "true"
             {{- end }}
+            {{- with $engine.targetPods }}
+            - name: TARGET_PODS
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with $engine.podsAffectedPerc }}
+            - name: PODS_AFFECTED_PERC
+              value: {{ . | quote }}
+            {{- end }}
             {{- range $key, $val := $engine.env }}
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
+        {{- with $engine.probes }}
+        probe:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kates-chaos/templates/experiments.yaml
+++ b/charts/kates-chaos/templates/experiments.yaml
@@ -1,5 +1,16 @@
 {{- if .Values.experiments.enabled }}
-{{- $kafkaNamespace := .Values.rbac.kafkaNamespace | default "kafka" }}
+{{- $kubectl := include "kates-chaos.kubectlImage" . }}
+{{- $goRunner := include "kates-chaos.goRunnerImage" . }}
+{{- $pullPolicy := .Values.global.imagePullPolicy | default "IfNotPresent" }}
+{{- $installer := .Values.experiments.installer | default dict }}
+{{- /* Namespaces to install ChaosExperiment definitions into */ -}}
+{{- $installNs := .Values.experiments.targetNamespaces }}
+{{- if not $installNs }}
+{{- $installNs = list }}
+{{- range (include "kates-chaos.targetNamespaces" . | fromYamlArray) }}
+{{- if eq (.role | default "target") "target" }}{{- $installNs = append $installNs .name }}{{- end }}
+{{- end }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,34 +22,50 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "5"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- with include "kates-chaos.annotations" . }}
+    {{- . | nindent 4 }}
+    {{- end }}
 data:
   experiments.yaml: |
-    {{- range .Values.experiments.definitions }}
+    {{- range $ns := $installNs }}
+    {{- range $def := $.Values.experiments.definitions }}
     ---
     apiVersion: litmuschaos.io/v1alpha1
     kind: ChaosExperiment
     metadata:
-      name: {{ .name }}
-      namespace: {{ $kafkaNamespace }}
+      name: {{ $def.name }}
+      namespace: {{ $ns }}
       labels:
-        name: {{ .name }}
+        name: {{ $def.name }}
         app.kubernetes.io/part-of: litmus
     spec:
       definition:
-        scope: {{ .scope | default "Namespaced" }}
-        image: {{ .image | default "litmuschaos/go-runner:3.28.0" }}
-        imagePullPolicy: IfNotPresent
-        # NOTE(Backend-Upgrade): The Litmus Chaos Engine orchestrator explicitly validates 
-        # the ChaosExperiment definition and fails with "nil command" if the command field is omitted. 
-        # Additionally, since `litmuschaos/go-runner:3.x` uses a distroless container architecture 
+        scope: {{ $def.scope | default "Namespaced" }}
+        {{- with $def.permissions }}
+        permissions:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        image: {{ $def.image | default $goRunner }}
+        imagePullPolicy: {{ $pullPolicy }}
+        # NOTE(Backend-Upgrade): The Litmus Chaos Engine orchestrator explicitly validates
+        # the ChaosExperiment definition and fails with "nil command" if the command field is omitted.
+        # Additionally, since `litmuschaos/go-runner:3.x` uses a distroless container architecture
         # without standard shells like `/bin/bash`, we cannot use standard `/bin/bash -c` wrappers.
         # Instead, we directly invoke the `experiments` binary at its absolute path `/litmus/experiments`
         # and pass the experiment name argument to execute the targeted chaos fault natively.
         command: ["/litmus/experiments"]
-        args: ["-name", "{{ .name }}"]
+        args: ["-name", "{{ $def.name }}"]
+        {{- with $def.env }}
+        env:
+          {{- range $k, $v := . }}
+          - name: {{ $k }}
+            value: {{ $v | quote }}
+          {{- end }}
+        {{- end }}
         labels:
-          name: {{ .name }}
-          experiment: {{ .name }}
+          name: {{ $def.name }}
+          experiment: {{ $def.name }}
+    {{- end }}
     {{- end }}
 ---
 apiVersion: batch/v1
@@ -52,25 +79,53 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "10"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- with include "kates-chaos.annotations" . }}
+    {{- . | nindent 4 }}
+    {{- end }}
 spec:
-  backoffLimit: 3
-  ttlSecondsAfterFinished: 300
+  backoffLimit: {{ $installer.backoffLimit | default 3 }}
+  ttlSecondsAfterFinished: {{ $installer.ttlSecondsAfterFinished | default 300 }}
   template:
     metadata:
       labels:
         app: experiment-installer
+        {{- include "kates-chaos.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ include "kates-chaos.fullname" . }}-experiment-installer
       automountServiceAccountToken: true
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $installer.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $installer.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $installer.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $installer.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: experiments-data
           configMap:
             name: {{ include "kates-chaos.fullname" . }}-experiments-data
       initContainers:
         - name: wait-for-operator
-          image: {{ .Values.experiments.image | default "registry.k8s.io/kubectl:v1.33.0" }}
-          imagePullPolicy: IfNotPresent
+          image: {{ $kubectl }}
+          imagePullPolicy: {{ $pullPolicy }}
+          {{- with $installer.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - "kubectl"
             - "wait"
@@ -82,8 +137,12 @@ spec:
             - "{{ .Release.Namespace }}"
             - "--timeout=300s"
         - name: wait-for-crd
-          image: {{ .Values.experiments.image | default "registry.k8s.io/kubectl:v1.33.0" }}
-          imagePullPolicy: IfNotPresent
+          image: {{ $kubectl }}
+          imagePullPolicy: {{ $pullPolicy }}
+          {{- with $installer.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - "kubectl"
             - "wait"
@@ -92,8 +151,16 @@ spec:
             - "--timeout=300s"
       containers:
         - name: install
-          image: {{ .Values.experiments.image | default "registry.k8s.io/kubectl:v1.33.0" }}
-          imagePullPolicy: IfNotPresent
+          image: {{ $kubectl }}
+          imagePullPolicy: {{ $pullPolicy }}
+          {{- with $installer.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $installer.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - "kubectl"
             - "apply"

--- a/charts/kates-chaos/templates/gameday.yaml
+++ b/charts/kates-chaos/templates/gameday.yaml
@@ -1,5 +1,71 @@
-{{- if .Values.gameday.enabled | default false }}
-{{- $kafkaNamespace := .Values.rbac.kafkaNamespace | default "kafka" }}
+{{- if .Values.gameday.enabled }}
+{{- $ns := .Release.Namespace }}
+{{- $kafkaNamespace := include "kates-chaos.kafkaNamespace" . }}
+{{- $image := .Values.gameday.image | default (include "kates-chaos.kubectlImage" .) }}
+{{- $pullPolicy := .Values.global.imagePullPolicy | default "IfNotPresent" }}
+{{- $checks := .Values.gameday.checks }}
+{{- if not $checks }}
+{{- $checks = list
+      (dict "name" "CRDs installed" "command" "kubectl get crd chaosengines.litmuschaos.io")
+      (dict "name" "Chaos operator running" "command" (printf "kubectl get pods -n %s -l app.kubernetes.io/name=litmus --no-headers | grep Running" $ns))
+      (dict "name" "Experiments installed" "command" (printf "[ $(kubectl get chaosexperiments -n %s --no-headers 2>/dev/null | wc -l) -gt 0 ]" $kafkaNamespace))
+      (dict "name" "Target namespace accessible" "command" (printf "kubectl get namespace %s" $kafkaNamespace)) }}
+{{- end }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kates-chaos.fullname" . }}-gameday
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kates-chaos.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "15"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kates-chaos.fullname" . }}-gameday
+  labels:
+    {{- include "kates-chaos.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "15"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces"]
+    verbs: ["get", "list"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list"]
+  - apiGroups: ["litmuschaos.io"]
+    resources: ["chaosexperiments", "chaosengines", "chaosresults"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kates-chaos.fullname" . }}-gameday
+  labels:
+    {{- include "kates-chaos.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "15"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kates-chaos.fullname" . }}-gameday
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kates-chaos.fullname" . }}-gameday
+    namespace: {{ .Release.Namespace }}
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -12,19 +78,24 @@ metadata:
     "helm.sh/hook-weight": "20"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  backoffLimit: 1
-  ttlSecondsAfterFinished: 600
+  backoffLimit: {{ .Values.gameday.backoffLimit | default 1 }}
+  ttlSecondsAfterFinished: {{ .Values.gameday.ttlSecondsAfterFinished | default 600 }}
   template:
     metadata:
       labels:
         app: gameday-runner
+        {{- include "kates-chaos.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: Never
-      serviceAccountName: {{ include "kates-chaos.fullname" . }}-experiment-installer
+      serviceAccountName: {{ include "kates-chaos.fullname" . }}-gameday
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: gameday
-          image: {{ .Values.gameday.image | default "bitnami/kubectl:1.33" }}
-          imagePullPolicy: IfNotPresent
+          image: {{ $image }}
+          imagePullPolicy: {{ $pullPolicy }}
           command: ["/bin/sh"]
           args:
             - -c
@@ -48,23 +119,9 @@ spec:
                 fi
               }
 
-              run_check "CRDs installed" \
-                "kubectl get crd chaosengines.litmuschaos.io"
-
-              run_check "Chaos operator running" \
-                "kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/component=chaos-operator --no-headers | grep Running"
-
-              run_check "MongoDB responsive" \
-                "kubectl exec {{ .Release.Name }}-mongodb-0 -n {{ .Release.Namespace }} -- mongosh --quiet --eval 'db.adminCommand(\"ping\")' | grep ok"
-
-              run_check "Experiments installed" \
-                "[ $(kubectl get chaosexperiments -n {{ $kafkaNamespace }} --no-headers 2>/dev/null | wc -l) -gt 0 ]"
-
-              run_check "Subscriber connected" \
-                "kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/component=subscriber --no-headers | grep Running"
-
-              run_check "Kafka namespace accessible" \
-                "kubectl get namespace {{ $kafkaNamespace }}"
+              {{ range $checks }}
+              run_check {{ .name | quote }} {{ .command | quote }}
+              {{ end }}
 
               echo ""
               echo "================================"

--- a/charts/kates-chaos/templates/grafana-dashboard.yaml
+++ b/charts/kates-chaos/templates/grafana-dashboard.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.monitoring.grafanaDashboard.enabled }}
+{{- $gd := .Values.monitoring.grafanaDashboard }}
+{{- $ns := $gd.namespace | default .Release.Namespace }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,9 +8,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kates-chaos.labels" . | nindent 4 }}
-    {{- range $key, $val := .Values.monitoring.grafanaDashboard.labels }}
+    {{- range $key, $val := $gd.labels }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
+  {{- if $gd.folder }}
+  annotations:
+    grafana_folder: {{ $gd.folder | quote }}
+  {{- end }}
 data:
   kates-chaos-dashboard.json: |
     {
@@ -91,7 +97,7 @@ data:
           "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
           "targets": [
             {
-              "expr": "kube_pod_status_phase{namespace=\"litmus\", phase=\"Running\"} == 1",
+              "expr": "kube_pod_status_phase{namespace=\"{{ $ns }}\", phase=\"Running\"} == 1",
               "legendFormat": "{{`{{`}} pod {{`}}`}}",
               "instant": true,
               "format": "table"
@@ -99,20 +105,24 @@ data:
           ]
         },
         {
-          "title": "MongoDB Status",
+          "title": "Chaos Operator Up",
           "type": "stat",
           "gridPos": { "h": 6, "w": 6, "x": 0, "y": 14 },
           "targets": [
             {
-              "expr": "up{job=~\".*mongodb.*\", namespace=\"litmus\"}",
-              "legendFormat": "MongoDB"
+              "expr": "count(kube_pod_status_phase{namespace=\"{{ $ns }}\", pod=~\".*chaos-operator.*\", phase=\"Running\"} == 1) or vector(0)",
+              "legendFormat": "Operator"
             }
           ],
           "fieldConfig": {
             "defaults": {
-              "mappings": [
-                { "type": "value", "options": { "1": { "text": "UP", "color": "green" }, "0": { "text": "DOWN", "color": "red" } } }
-              ]
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "steps": [
+                  { "color": "red", "value": null },
+                  { "color": "green", "value": 1 }
+                ]
+              }
             }
           }
         }

--- a/charts/kates-chaos/templates/kyverno-policies.yaml
+++ b/charts/kates-chaos/templates/kyverno-policies.yaml
@@ -1,4 +1,7 @@
 {{- if and .Values.kyvernoPolicy.enabled (.Capabilities.APIVersions.Has "kyverno.io/v1") }}
+{{- $kp := .Values.kyvernoPolicy }}
+{{- $namespaces := $kp.namespaces | default (list .Release.Namespace) }}
+{{- $excludeSelector := $kp.excludeSelector | default (dict "matchExpressions" (list (dict "key" "chaosUID" "operator" "Exists"))) }}
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -11,30 +14,29 @@ metadata:
     policies.kyverno.io/severity: high
     policies.kyverno.io/description: >-
       Enforces and auto-patches restricted pod security standards for all
-      LitmusChaos and MongoDB pods: non-root containers, dropped capabilities,
-      seccomp profiles, and no privilege escalation. Chaos-runner and experiment
-      pods are excluded because they require elevated privileges for fault injection.
+      chaos-infra pods: non-root containers, dropped capabilities, seccomp
+      profiles, and no privilege escalation. Chaos experiment/runner pods
+      (matched by excludeSelector) are skipped because they require elevated
+      privileges for fault injection.
 spec:
-  validationFailureAction: {{ .Values.kyvernoPolicy.action | default "Audit" }}
+  validationFailureAction: {{ $kp.action | default "Audit" }}
   background: true
   rules:
-    {{- if .Values.kyvernoPolicy.mutate }}
+    {{- if $kp.mutate }}
     # ── Mutate: auto-inject pod-level security context ────────────────────────
     - name: mutate-run-as-non-root
       match:
         any:
           - resources:
               kinds: ["Pod"]
-              namespaces: [{{ .Release.Namespace | quote }}]
+              namespaces: {{ toYaml $namespaces | nindent 16 }}
       exclude:
         any:
           - resources:
               kinds: ["Pod"]
-              namespaces: [{{ .Release.Namespace | quote }}]
+              namespaces: {{ toYaml $namespaces | nindent 16 }}
               selector:
-                matchExpressions:
-                  - key: chaosUID
-                    operator: Exists
+                {{- toYaml $excludeSelector | nindent 16 }}
       mutate:
         patchStrategicMerge:
           spec:
@@ -43,22 +45,19 @@ spec:
               +(runAsUser): 1001
               +(fsGroup): 1001
 
-    # ── Mutate: auto-inject container-level security context ──────────────────
     - name: mutate-drop-capabilities
       match:
         any:
           - resources:
               kinds: ["Pod"]
-              namespaces: [{{ .Release.Namespace | quote }}]
+              namespaces: {{ toYaml $namespaces | nindent 16 }}
       exclude:
         any:
           - resources:
               kinds: ["Pod"]
-              namespaces: [{{ .Release.Namespace | quote }}]
+              namespaces: {{ toYaml $namespaces | nindent 16 }}
               selector:
-                matchExpressions:
-                  - key: chaosUID
-                    operator: Exists
+                {{- toYaml $excludeSelector | nindent 16 }}
       mutate:
         patchStrategicMerge:
           spec:
@@ -74,16 +73,14 @@ spec:
         any:
           - resources:
               kinds: ["Pod"]
-              namespaces: [{{ .Release.Namespace | quote }}]
+              namespaces: {{ toYaml $namespaces | nindent 16 }}
       exclude:
         any:
           - resources:
               kinds: ["Pod"]
-              namespaces: [{{ .Release.Namespace | quote }}]
+              namespaces: {{ toYaml $namespaces | nindent 16 }}
               selector:
-                matchExpressions:
-                  - key: chaosUID
-                    operator: Exists
+                {{- toYaml $excludeSelector | nindent 16 }}
       mutate:
         patchStrategicMerge:
           spec:
@@ -96,16 +93,14 @@ spec:
         any:
           - resources:
               kinds: ["Pod"]
-              namespaces: [{{ .Release.Namespace | quote }}]
+              namespaces: {{ toYaml $namespaces | nindent 16 }}
       exclude:
         any:
           - resources:
               kinds: ["Pod"]
-              namespaces: [{{ .Release.Namespace | quote }}]
+              namespaces: {{ toYaml $namespaces | nindent 16 }}
               selector:
-                matchExpressions:
-                  - key: chaosUID
-                    operator: Exists
+                {{- toYaml $excludeSelector | nindent 16 }}
       mutate:
         patchStrategicMerge:
           spec:
@@ -116,23 +111,19 @@ spec:
     {{- end }}
 
     # ── Validate: enforce standards ───────────────────────────────────────────
-    # Chaos experiment pods (labeled with chaosUID) are excluded from validation
-    # because they inherently need elevated privileges for fault injection.
     - name: validate-non-root
       match:
         any:
           - resources:
               kinds: ["Pod"]
-              namespaces: [{{ .Release.Namespace | quote }}]
+              namespaces: {{ toYaml $namespaces | nindent 16 }}
       exclude:
         any:
           - resources:
               kinds: ["Pod"]
-              namespaces: [{{ .Release.Namespace | quote }}]
+              namespaces: {{ toYaml $namespaces | nindent 16 }}
               selector:
-                matchExpressions:
-                  - key: chaosUID
-                    operator: Exists
+                {{- toYaml $excludeSelector | nindent 16 }}
       validate:
         message: "Chaos pods must run as non-root (spec.securityContext.runAsNonRoot: true)."
         pattern:
@@ -145,16 +136,14 @@ spec:
         any:
           - resources:
               kinds: ["Pod"]
-              namespaces: [{{ .Release.Namespace | quote }}]
+              namespaces: {{ toYaml $namespaces | nindent 16 }}
       exclude:
         any:
           - resources:
               kinds: ["Pod"]
-              namespaces: [{{ .Release.Namespace | quote }}]
+              namespaces: {{ toYaml $namespaces | nindent 16 }}
               selector:
-                matchExpressions:
-                  - key: chaosUID
-                    operator: Exists
+                {{- toYaml $excludeSelector | nindent 16 }}
       validate:
         message: "Containers must drop ALL capabilities."
         pattern:
@@ -169,16 +158,14 @@ spec:
         any:
           - resources:
               kinds: ["Pod"]
-              namespaces: [{{ .Release.Namespace | quote }}]
+              namespaces: {{ toYaml $namespaces | nindent 16 }}
       exclude:
         any:
           - resources:
               kinds: ["Pod"]
-              namespaces: [{{ .Release.Namespace | quote }}]
+              namespaces: {{ toYaml $namespaces | nindent 16 }}
               selector:
-                matchExpressions:
-                  - key: chaosUID
-                    operator: Exists
+                {{- toYaml $excludeSelector | nindent 16 }}
       validate:
         message: "Containers must not allow privilege escalation."
         pattern:

--- a/charts/kates-chaos/templates/networkpolicy.yaml
+++ b/charts/kates-chaos/templates/networkpolicy.yaml
@@ -1,10 +1,10 @@
-{{- if .Values.networkPolicies.enabled }}
-{{- $kafkaNamespace := .Values.rbac.kafkaNamespace | default "kafka" }}
-{{- $katesNamespace := .Values.rbac.katesNamespace | default "kates" }}
+{{- if eq (include "kates-chaos.networkPolicyEnabled" .) "true" }}
+{{- $np := .Values.networkPolicy | default dict }}
+{{- $targets := include "kates-chaos.targetNamespaces" . | fromYamlArray }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "kates-chaos.fullname" . }}-allow-internal
+  name: {{ include "kates-chaos.fullname" . }}-chaos-infra
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kates-chaos.labels" . | nindent 4 }}
@@ -16,32 +16,65 @@ spec:
     - Ingress
     - Egress
   ingress:
+    # Intra-release traffic (operator ↔ exporter, etc.)
     - from:
-        - namespaceSelector: {}
-          podSelector:
+        - podSelector:
             matchLabels:
               app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if (($np.monitoring).enabled | default true) }}
+    # Prometheus scrape of the chaos exporter
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $np.monitoring.namespace | default "monitoring" }}
+      ports:
+        - protocol: TCP
+          port: {{ $np.monitoring.port | default 8080 }}
+    {{- end }}
+    {{- with $np.extraIngress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   egress:
+    # Intra-release traffic
     - to:
-        - namespaceSelector: {}
-          podSelector:
+        - podSelector:
             matchLabels:
               app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if (($np.apiServer).enabled | default true) }}
+    # Kubernetes API server (required by the chaos operator)
     - to:
-        - namespaceSelector: {}
-          podSelector:
-            matchLabels:
-              strimzi.io/kind: Kafka
+        {{- with ($np.apiServer).ipBlock }}
+        - ipBlock:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+      ports:
+        {{- range ($np.apiServer).ports | default (list 443 6443) }}
+        - protocol: TCP
+          port: {{ . }}
+        {{- end }}
+    {{- end }}
+    {{- if (($np.targets).enabled | default true) }}
+    # Fault injection / coordination into chaos target namespaces
+    {{- range $t := $targets }}
     - to:
-        - namespaceSelector: {}
-          podSelector:
+        - namespaceSelector:
             matchLabels:
-              app.kubernetes.io/name: kates
+              kubernetes.io/metadata.name: {{ $t.name }}
+    {{- end }}
+    {{- end }}
+    {{- if (($np.dns).enabled | default true) }}
+    # DNS resolution
     - to:
         - namespaceSelector: {}
       ports:
+        {{- range ($np.dns).ports | default (list 53) }}
         - protocol: UDP
-          port: 53
+          port: {{ . }}
         - protocol: TCP
-          port: 53
+          port: {{ . }}
+        {{- end }}
+    {{- end }}
+    {{- with $np.extraEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/kates-chaos/templates/pdb.yaml
+++ b/charts/kates-chaos/templates/pdb.yaml
@@ -1,15 +1,21 @@
 {{- if .Values.pdb.enabled }}
+{{- if not .Values.pdb.selector }}
+{{- fail "pdb.enabled=true requires pdb.selector (this chart ships no stateful workload to protect by default)" }}
+{{- end }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "kates-chaos.fullname" . }}-mongodb
+  name: {{ include "kates-chaos.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kates-chaos.labels" . | nindent 4 }}
 spec:
-  minAvailable: 1
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  {{- end }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: mongodb
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- toYaml .Values.pdb.selector | nindent 6 }}
 {{- end }}

--- a/charts/kates-chaos/templates/servicemonitor.yaml
+++ b/charts/kates-chaos/templates/servicemonitor.yaml
@@ -1,4 +1,9 @@
 {{- if and .Values.monitoring.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+{{- $sm := .Values.monitoring.serviceMonitor }}
+# NOTE: the litmus-core subchart can create its own exporter ServiceMonitor.
+# Enable this only when you want the chaos infra scraped via a ServiceMonitor
+# managed by THIS chart, and make sure `selector`/`port` match the exporter
+# Service (litmus-core labels it `app: litmus`, port name `http`).
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -6,19 +11,30 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kates-chaos.labels" . | nindent 4 }}
-    app: chaos-exporter
-    {{- with .Values.monitoring.serviceMonitor.labels }}
+    {{- with $sm.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   selector:
     matchLabels:
-      app: chaos-exporter
+      {{- toYaml ($sm.selector | default (dict "app" "litmus")) | nindent 6 }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
   endpoints:
-    - port: tcp-metrics
-      path: /metrics
-      interval: {{ .Values.monitoring.serviceMonitor.interval | default "30s" }}
+    - port: {{ $sm.port | default "http" }}
+      path: {{ $sm.path | default "/metrics" }}
+      interval: {{ $sm.interval | default "30s" }}
+      {{- with $sm.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      honorLabels: {{ $sm.honorLabels | default false }}
+      {{- with $sm.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $sm.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/kates-chaos/templates/tests/test-connectivity.yaml
+++ b/charts/kates-chaos/templates/tests/test-connectivity.yaml
@@ -1,37 +1,66 @@
+{{- $kubectl := include "kates-chaos.kubectlImage" . }}
+{{- $pullPolicy := .Values.global.imagePullPolicy | default "IfNotPresent" }}
+{{- $kafkaNamespace := include "kates-chaos.kafkaNamespace" . }}
+{{- $testSA := printf "%s-test" (include "kates-chaos.fullname" .) }}
 apiVersion: v1
-kind: Pod
+kind: ServiceAccount
 metadata:
-  name: {{ include "kates-chaos.fullname" . }}-test-portal
+  name: {{ $testSA }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kates-chaos.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  restartPolicy: Never
-  containers:
-    - name: test
-      image: busybox:1.36
-      command: ['sh', '-c']
-      args:
-        - |
-          echo "Testing Litmus portal server..."
-          for i in $(seq 1 10); do
-            if wget -q --spider --timeout=5 "http://{{ .Release.Name }}-litmus-server-service:9002/status" 2>/dev/null; then
-              echo "✅ Portal server reachable"
-              exit 0
-            fi
-            echo "Attempt $i/10..."
-            sleep 3
-          done
-          echo "❌ Portal server unreachable"
-          exit 1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $testSA }}
+  labels:
+    {{- include "kates-chaos.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list"]
+  - apiGroups: ["litmuschaos.io"]
+    resources: ["chaosexperiments", "chaosengines", "chaosresults"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $testSA }}
+  labels:
+    {{- include "kates-chaos.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $testSA }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $testSA }}
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: v1
 kind: Pod
 metadata:
-  name: {{ include "kates-chaos.fullname" . }}-test-frontend
+  name: {{ include "kates-chaos.fullname" . }}-test-operator
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kates-chaos.labels" . | nindent 4 }}
@@ -40,53 +69,22 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   restartPolicy: Never
+  serviceAccountName: {{ $testSA }}
   containers:
     - name: test
-      image: busybox:1.36
+      image: {{ $kubectl }}
+      imagePullPolicy: {{ $pullPolicy }}
       command: ['sh', '-c']
       args:
         - |
-          echo "Testing Litmus frontend..."
-          for i in $(seq 1 10); do
-            if wget -q --spider --timeout=5 "http://{{ .Release.Name }}-litmus-frontend-service:9091" 2>/dev/null; then
-              echo "✅ Frontend reachable"
-              exit 0
-            fi
-            echo "Attempt $i/10..."
-            sleep 3
-          done
-          echo "❌ Frontend unreachable"
-          exit 1
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: {{ include "kates-chaos.fullname" . }}-test-mongodb
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "kates-chaos.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  restartPolicy: Never
-  containers:
-    - name: test
-      image: {{ .Values.experiments.image | default "registry.k8s.io/kubectl:v1.33.0" }}
-      command: ['sh', '-c']
-      args:
-        - |
-          echo "Testing MongoDB connectivity..."
-          for i in $(seq 1 15); do
-            if kubectl exec {{ .Release.Name }}-mongodb-0 -n {{ .Release.Namespace }} -- \
-              mongosh --quiet --eval "db.adminCommand('ping')" 2>/dev/null | grep -q "ok"; then
-              echo "✅ MongoDB responsive"
-              exit 0
-            fi
-            echo "Attempt $i/15..."
-            sleep 5
-          done
-          echo "❌ MongoDB not responsive"
+          echo "Waiting for the chaos operator to become Available..."
+          if kubectl wait --for=condition=Available deployment \
+            -l app.kubernetes.io/name=litmus -n {{ .Release.Namespace }} --timeout=120s; then
+            echo "✅ Chaos operator Available"
+            exit 0
+          fi
+          echo "❌ Chaos operator not Available"
+          kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/name=litmus
           exit 1
 ---
 apiVersion: v1
@@ -101,10 +99,11 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   restartPolicy: Never
-  serviceAccountName: {{ include "kates-chaos.fullname" . }}-experiment-installer
+  serviceAccountName: {{ $testSA }}
   containers:
     - name: test
-      image: {{ .Values.experiments.image | default "registry.k8s.io/kubectl:v1.33.0" }}
+      image: {{ $kubectl }}
+      imagePullPolicy: {{ $pullPolicy }}
       command: ['sh', '-c']
       args:
         - |
@@ -122,8 +121,8 @@ spec:
             fi
           done
           echo ""
-          echo "Verifying ChaosExperiments in {{ .Values.rbac.kafkaNamespace }}..."
-          COUNT=$(kubectl get chaosexperiments -n {{ .Values.rbac.kafkaNamespace }} --no-headers 2>/dev/null | wc -l | tr -d ' ')
+          echo "Verifying ChaosExperiments in {{ $kafkaNamespace }}..."
+          COUNT=$(kubectl get chaosexperiments -n {{ $kafkaNamespace }} --no-headers 2>/dev/null | wc -l | tr -d ' ')
           if [ "$COUNT" -gt "0" ]; then
             echo "  ✅ $COUNT experiments found"
             PASS=$((PASS + 1))

--- a/charts/kates-chaos/values-generic.yaml
+++ b/charts/kates-chaos/values-generic.yaml
@@ -1,5 +1,5 @@
 # Kates Chaos — Generic Kubernetes Cluster Overlay
-# Cloud-native defaults for any standard Kubernetes environment
+# Cloud-native defaults for any standard Kubernetes environment.
 
 litmus-core:
   enabled: true
@@ -10,14 +10,24 @@ litmus-core:
     image:
       pullPolicy: Always
 
+global:
+  imagePullPolicy: Always
+
 rbac:
   enabled: true
-  kafkaNamespace: kafka
-  katesNamespace: kates
+  targetNamespaces:
+    - name: kafka
+      role: target
+    - name: kates
+      role: coordinator
+  nodeChaos:
+    enabled: true
 
 monitoring:
   serviceMonitor:
-    enabled: true
+    # Off by default to avoid duplicating the litmus-core exporter
+    # ServiceMonitor. Enable if you scrape via this chart instead.
+    enabled: false
     interval: 15s
     labels:
       release: monitoring
@@ -26,7 +36,7 @@ monitoring:
     labels:
       grafana_dashboard: "1"
 
-pdb:
+networkPolicy:
   enabled: true
 
 kyvernoPolicy:
@@ -34,9 +44,10 @@ kyvernoPolicy:
   action: Audit
   mutate: true
 
-networkPolicies:
-  enabled: true
+# No stateful workload ships with this chart; leave the PDB off unless you
+# point pdb.selector at a workload you run in the release namespace.
+pdb:
+  enabled: false
 
 experiments:
   enabled: true
-  image: registry.k8s.io/kubectl:v1.33.0

--- a/charts/kates-chaos/values-kind.yaml
+++ b/charts/kates-chaos/values-kind.yaml
@@ -1,5 +1,5 @@
 # Kates Chaos — Kind Cluster Overlay
-# Optimized for single-node Kind with pre-loaded images
+# Optimized for single-node Kind with pre-loaded images.
 
 litmus-core:
   enabled: true
@@ -10,14 +10,22 @@ litmus-core:
     image:
       pullPolicy: IfNotPresent
 
+global:
+  imagePullPolicy: IfNotPresent
+
 rbac:
   enabled: true
-  kafkaNamespace: kafka
-  katesNamespace: kates
+  targetNamespaces:
+    - name: kafka
+      role: target
+    - name: kates
+      role: coordinator
+  nodeChaos:
+    enabled: true
 
 monitoring:
   serviceMonitor:
-    enabled: true
+    enabled: false
     interval: 30s
     labels:
       release: monitoring
@@ -26,13 +34,11 @@ monitoring:
     labels:
       grafana_dashboard: "1"
 
-pdb:
+networkPolicy:
   enabled: false
 
-networkPolicies:
+pdb:
   enabled: false
 
 experiments:
   enabled: true
-  # FIX #8: pin to the exact same kubectl version used everywhere else in the stack
-  image: registry.k8s.io/kubectl:v1.33.0

--- a/charts/kates-chaos/values.schema.json
+++ b/charts/kates-chaos/values.schema.json
@@ -1,46 +1,67 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
+  "additionalProperties": true,
+  "definitions": {
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string", "minLength": 1 },
+        "tag": { "type": "string" },
+        "digest": { "type": "string" }
+      }
+    }
+  },
   "properties": {
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "commonLabels": { "type": "object" },
+    "commonAnnotations": { "type": "object" },
     "global": {
       "type": "object",
       "properties": {
-        "imagePullPolicy": {
-          "type": "string",
-          "enum": ["Always", "IfNotPresent", "Never"]
-        }
+        "imageRegistry": { "type": "string" },
+        "imagePullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
+        "imagePullSecrets": { "type": "array" },
+        "clusterDomain": { "type": "string" },
+        "storageClass": { "type": "string" }
       }
     },
-    "litmus": {
+    "images": {
       "type": "object",
       "properties": {
-        "enabled": { "type": "boolean" }
+        "kubectl": { "$ref": "#/definitions/image" },
+        "goRunner": { "$ref": "#/definitions/image" }
       }
     },
-    "auth": {
+    "serviceAccount": {
       "type": "object",
       "properties": {
-        "adminPassword": { "type": "string", "description": "Litmus admin portal password (auto-generated if empty)" },
-        "dbRootPassword": { "type": "string", "description": "MongoDB root password (auto-generated if empty)" },
-        "jwtSecret": { "type": "string", "description": "JWT signing secret (auto-generated if empty)" },
-        "existingSecret": { "type": "string", "description": "Name of pre-existing K8s Secret to use instead" }
+        "name": { "type": "string", "minLength": 1 }
       }
     },
     "rbac": {
       "type": "object",
-      "required": ["kafkaNamespace", "katesNamespace"],
       "properties": {
         "enabled": { "type": "boolean" },
-        "kafkaNamespace": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Target namespace where Kafka is deployed"
+        "targetNamespaces": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "role": { "type": "string", "enum": ["target", "coordinator"] },
+              "serviceAccount": { "type": "string" }
+            }
+          }
         },
-        "katesNamespace": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Target namespace where Kates is deployed"
-        }
+        "nodeChaos": {
+          "type": "object",
+          "properties": { "enabled": { "type": "boolean" } }
+        },
+        "kafkaNamespace": { "type": "string", "description": "DEPRECATED: use targetNamespaces" },
+        "katesNamespace": { "type": "string", "description": "DEPRECATED: use targetNamespaces" }
       }
     },
     "monitoring": {
@@ -50,7 +71,14 @@
           "type": "object",
           "properties": {
             "enabled": { "type": "boolean" },
+            "selector": { "type": "object" },
+            "port": { "type": "string" },
+            "path": { "type": "string" },
             "interval": { "type": "string", "pattern": "^[0-9]+[smh]$" },
+            "scrapeTimeout": { "type": "string" },
+            "honorLabels": { "type": "boolean" },
+            "relabelings": { "type": "array" },
+            "metricRelabelings": { "type": "array" },
             "labels": { "type": "object" }
           }
         },
@@ -58,6 +86,8 @@
           "type": "object",
           "properties": {
             "enabled": { "type": "boolean" },
+            "namespace": { "type": "string" },
+            "folder": { "type": "string" },
             "labels": { "type": "object" }
           }
         }
@@ -67,35 +97,119 @@
       "type": "object",
       "properties": {
         "enabled": { "type": "boolean" },
-        "image": { "type": "string" },
+        "image": { "type": "string", "description": "DEPRECATED: use experiments.installer.image or images.kubectl" },
+        "installer": {
+          "type": "object",
+          "properties": {
+            "image": { "type": "string" },
+            "backoffLimit": { "type": "integer", "minimum": 0 },
+            "ttlSecondsAfterFinished": { "type": "integer", "minimum": 0 },
+            "resources": { "type": "object" },
+            "podSecurityContext": { "type": "object" },
+            "securityContext": { "type": "object" },
+            "nodeSelector": { "type": "object" },
+            "tolerations": { "type": "array" },
+            "affinity": { "type": "object" }
+          }
+        },
+        "targetNamespaces": { "type": "array", "items": { "type": "string" } },
         "definitions": {
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["name", "scope"],
+            "required": ["name"],
             "properties": {
               "name": { "type": "string" },
-              "scope": {
-                "type": "string",
-                "enum": ["Namespaced", "Cluster"]
-              },
-              "image": { "type": "string" }
+              "scope": { "type": "string", "enum": ["Namespaced", "Cluster"] },
+              "image": { "type": "string" },
+              "env": { "type": "object" },
+              "permissions": { "type": "array" }
             }
           }
         }
       }
     },
-    "engines": { "type": "object" },
-    "pdb": {
+    "engines": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "enabled": { "type": "boolean" },
+          "appNamespace": { "type": "string" },
+          "appLabel": { "type": "string" },
+          "appKind": { "type": "string" },
+          "experiment": { "type": "string" },
+          "serviceAccount": { "type": "string" },
+          "engineState": { "type": "string", "enum": ["active", "stop"] },
+          "annotationCheck": { "type": "boolean" },
+          "jobCleanUpPolicy": { "type": "string", "enum": ["delete", "retain"] },
+          "duration": { "type": ["integer", "string"] },
+          "interval": { "type": ["integer", "string"] },
+          "force": { "type": "boolean" },
+          "targetPods": { "type": "string" },
+          "podsAffectedPerc": { "type": ["integer", "string"] },
+          "env": { "type": "object" },
+          "components": { "type": "object" },
+          "probes": { "type": "array" },
+          "labels": { "type": "object" },
+          "annotations": { "type": "object" }
+        }
+      }
+    },
+    "networkPolicy": {
       "type": "object",
       "properties": {
-        "enabled": { "type": "boolean" }
+        "enabled": { "type": "boolean" },
+        "apiServer": { "type": "object" },
+        "dns": { "type": "object" },
+        "monitoring": { "type": "object" },
+        "targets": { "type": "object" },
+        "extraIngress": { "type": "array" },
+        "extraEgress": { "type": "array" }
       }
     },
     "networkPolicies": {
       "type": "object",
+      "description": "DEPRECATED alias for networkPolicy",
+      "properties": { "enabled": { "type": "boolean" } }
+    },
+    "pdb": {
+      "type": "object",
       "properties": {
-        "enabled": { "type": "boolean" }
+        "enabled": { "type": "boolean" },
+        "minAvailable": { "type": ["integer", "string"] },
+        "maxUnavailable": { "type": ["integer", "string"] },
+        "selector": { "type": "object" }
+      }
+    },
+    "kyvernoPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "action": { "type": "string", "enum": ["Audit", "Enforce"] },
+        "mutate": { "type": "boolean" },
+        "namespaces": { "type": "array", "items": { "type": "string" } },
+        "excludeSelector": { "type": "object" }
+      }
+    },
+    "gameday": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "image": { "type": "string" },
+        "backoffLimit": { "type": "integer", "minimum": 0 },
+        "ttlSecondsAfterFinished": { "type": "integer", "minimum": 0 },
+        "checks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "command"],
+            "properties": {
+              "name": { "type": "string" },
+              "command": { "type": "string" }
+            }
+          }
+        }
       }
     }
   }

--- a/charts/kates-chaos/values.yaml
+++ b/charts/kates-chaos/values.yaml
@@ -1,18 +1,52 @@
-
 # Kates Chaos Engineering — Default Values
-# Wraps LitmusChaos with Kafka/Kates-specific chaos infrastructure
+#
+# Wraps LitmusChaos with Kafka/Kates-specific chaos infrastructure:
+# cross-namespace RBAC, ChaosExperiment/ChaosEngine templating, monitoring,
+# network isolation, and admission policy.
+#
+# SCOPE: this chart deploys the LitmusChaos EXECUTION PLANE only — the chaos
+# operator, the chaos exporter, and the CRDs (via the litmus-core subchart).
+# It does NOT deploy the ChaosCenter web portal (frontend / GraphQL server /
+# auth-server / MongoDB). If you want the UI, install ChaosCenter separately.
 
 nameOverride: ""
 fullnameOverride: ""
 
-# Global settings
+# -- Extra labels added to every resource this chart renders
+commonLabels: {}
+# -- Extra annotations added to every resource this chart renders
+commonAnnotations: {}
+
+# ── Global settings ──────────────────────────────────────────────────────────
 global:
+  # -- Registry prefix applied to every chart-managed image (e.g. "myregistry.io").
+  # Empty = pull from the upstream registry in each image's repository.
+  imageRegistry: ""
+  # -- Default image pull policy for chart-managed pods
   imagePullPolicy: IfNotPresent
-  # Standardize DNS/Storage variables (even if not explicitly used by Litmus)
+  # -- Image pull secrets applied to chart-managed pods
+  imagePullSecrets: []
+  # -- Cluster DNS domain
   clusterDomain: "cluster.local"
+  # -- Default storage class (reserved for future stateful components)
   storageClass: ""
 
-# Upstream Litmus execution plane (Chaos Operator + CRDs)
+# ── Image sources ────────────────────────────────────────────────────────────
+# Single source of truth for the images this chart manages directly. Set
+# `digest` to pin by content (takes precedence over `tag`).
+images:
+  # kubectl — used by the experiment installer Job, GameDay, and Helm tests
+  kubectl:
+    repository: registry.k8s.io/kubectl
+    tag: "v1.33.0"
+    digest: ""
+  # go-runner — default runtime for ChaosExperiment definitions
+  goRunner:
+    repository: litmuschaos/go-runner
+    tag: "3.28.0"
+    digest: ""
+
+# ── Upstream Litmus execution plane (Chaos Operator + exporter + CRDs) ───────
 litmus-core:
   enabled: true
   operator:
@@ -24,27 +58,84 @@ litmus-core:
       repository: docker.io/litmuschaos/chaos-runner
       tag: "3.28.0"
 
-# RBAC for chaos experiments in target namespaces
+# ── Chaos service account ────────────────────────────────────────────────────
+# The identity ChaosEngines and experiment pods run as. Created by the RBAC
+# block in each "target"-role namespace, and referenced by ChaosEngines.
+serviceAccount:
+  name: litmus-admin
+
+# ── RBAC for chaos experiments in target namespaces ──────────────────────────
+# Each target namespace gets RBAC by role:
+#   target      → litmus-admin ServiceAccount + Role + RoleBinding (fault injection)
+#   coordinator → ClusterRole binding letting its default SA create ChaosEngines
+#                 and read ChaosResults (used by an app that orchestrates chaos)
 rbac:
   enabled: true
-  kafkaNamespace: kafka
-  katesNamespace: kates
+  targetNamespaces:
+    - name: kafka
+      role: target
+    - name: kates
+      role: coordinator
+  # -- Cluster-scoped RBAC for node-level chaos (node-drain, node-restart, …)
+  nodeChaos:
+    enabled: true
 
-# Prometheus monitoring integration
+  # -- DEPRECATED: use `targetNamespaces`. When set, these win over the list
+  # above and are honored for backward compatibility.
+  kafkaNamespace: ""
+  katesNamespace: ""
+
+# ── Prometheus monitoring integration ────────────────────────────────────────
 monitoring:
   serviceMonitor:
+    # -- Create a ServiceMonitor for the chaos exporter. NOTE: the litmus-core
+    # subchart can ship its own exporter ServiceMonitor; leave this disabled to
+    # avoid duplicate scrapes and enable it only if you manage scraping here.
     enabled: false
+    # -- Label selector matching the exporter Service (litmus-core labels its
+    # exporter Service `app: litmus`).
+    selector:
+      app: litmus
+    # -- Exporter Service port name to scrape
+    port: http
+    path: /metrics
     interval: 30s
+    scrapeTimeout: ""
+    honorLabels: false
+    relabelings: []
+    metricRelabelings: []
     labels: {}
   grafanaDashboard:
     enabled: false
+    # -- Namespace used in dashboard PromQL queries (defaults to the release
+    # namespace where the chaos infra runs)
+    namespace: ""
+    # -- Grafana folder annotation (empty = General)
+    folder: ""
     labels:
       grafana_dashboard: "1"
 
-# ChaosExperiment definitions (deployed via post-install Job)
+# ── ChaosExperiment definitions (installed via post-install Job) ─────────────
 experiments:
   enabled: true
-  image: registry.k8s.io/kubectl:v1.33.0
+  # Installer Job (applies the ChaosExperiment CRs once the operator + CRDs
+  # are ready).
+  installer:
+    # -- Override the kubectl image as a plain string; empty = images.kubectl
+    image: ""
+    backoffLimit: 3
+    ttlSecondsAfterFinished: 300
+    resources: {}
+    podSecurityContext: {}
+    securityContext: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+  # -- Namespaces to install ChaosExperiment definitions into. Empty = every
+  # "target"-role namespace from rbac.targetNamespaces.
+  targetNamespaces: []
+  # -- ChaosExperiment definitions. `env` becomes the experiment's default env;
+  # `permissions` maps to spec.definition.permissions (RBAC the runner needs).
   definitions:
     - name: pod-delete
       scope: Namespaced
@@ -61,29 +152,86 @@ experiments:
     - name: node-drain
       scope: Cluster
 
-# ChaosEngine automation (Phase 3)
+# ── ChaosEngine automation ───────────────────────────────────────────────────
+# Each entry renders a ChaosEngine. Minimal example:
+#   engines:
+#     kafka-pod-delete:
+#       enabled: true
+#       appLabel: "strimzi.io/kind=Kafka"
+#       experiment: pod-delete
+#       duration: 30
+#       interval: 10
+#       force: true
+#       podsAffectedPerc: "50"
+# See values-generic.yaml and docs for probes/components.
 engines: {}
 
-# PodDisruptionBudgets
-pdb:
+# ── Network policy ───────────────────────────────────────────────────────────
+# Default-deny is NOT imposed; this policy scopes what the chaos infra pods in
+# the release namespace may talk to. Egress must include the Kubernetes API
+# server (the operator needs it) and DNS.
+networkPolicy:
   enabled: false
+  # -- Egress to the Kubernetes API server (required by the chaos operator)
+  apiServer:
+    enabled: true
+    ports: [443, 6443]
+    # -- Restrict to the control-plane CIDR on locked-down clusters, e.g.
+    # ipBlock: {cidr: 10.0.0.1/32}
+    ipBlock: {}
+  # -- DNS egress
+  dns:
+    enabled: true
+    ports: [53]
+  # -- Prometheus scrape ingress to the exporter
+  monitoring:
+    enabled: true
+    namespace: monitoring
+    port: 8080
+  # -- Egress to the chaos target namespaces (fault injection / coordination)
+  targets:
+    enabled: true
+  # -- Extra raw ingress/egress rules appended verbatim
+  extraIngress: []
+  extraEgress: []
 
-# Kyverno pod security policies (requires Kyverno controller in cluster)
-kyvernoPolicy:
-  enabled: false          # opt-in by default
-  action: Audit           # Audit | Enforce
-  mutate: true            # auto-inject security contexts on pod admission
-  excludeContainers:       # container names to skip during mutation
-    - chaos-runner
-    - go-runner
-    - experiment
-
-# Network policies
+# -- DEPRECATED alias for networkPolicy.enabled (honored for compatibility)
 networkPolicies:
   enabled: false
 
-# GameDay validation (trigger: --set gameday.enabled=true)
+# ── PodDisruptionBudget ──────────────────────────────────────────────────────
+# Off by default in the operator-only topology (there is no stateful workload
+# shipped by this chart to protect). Enable and point `selector` at a workload
+# you run in the release namespace if you need one.
+pdb:
+  enabled: false
+  minAvailable: 1
+  maxUnavailable: ""
+  # -- Pod selector for the PDB (required when enabled)
+  selector: {}
+
+# ── Kyverno pod security policies (requires Kyverno controller in cluster) ───
+kyvernoPolicy:
+  enabled: false          # opt-in
+  action: Audit           # Audit | Enforce
+  mutate: true            # auto-inject security contexts on pod admission
+  # -- Namespaces the policy applies to (empty = release namespace only)
+  namespaces: []
+  # -- Pods excluded from validation/mutation. Chaos experiment pods carry the
+  # `chaosUID` label and must be excluded (they need elevated privileges).
+  excludeSelector:
+    matchExpressions:
+      - key: chaosUID
+        operator: Exists
+
+# ── GameDay validation ───────────────────────────────────────────────────────
+# Runs a Job of read-only checks against the chaos infra. Checks are
+# data-driven: each has a name and a shell command that must exit 0 to pass.
+# Empty `checks` uses the operator-only default set below (rendered by the
+# template). Override to add your own.
 gameday:
   enabled: false
-
-
+  image: ""               # empty = images.kubectl
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 600
+  checks: []

--- a/charts/kates/Chart.yaml
+++ b/charts/kates/Chart.yaml
@@ -20,9 +20,7 @@ icon: https://raw.githubusercontent.com/bmscomp/kates/main/docs/icon.png
 annotations:
   artifacthub.io/category: integration-delivery
   artifacthub.io/license: Apache-2.0
-dependencies:
-  - name: postgresql
-    version: "16.x.x"
-    repository: https://charts.bitnami.com/bitnami
-    condition: postgresql.useSubchart
-    alias: postgresqlHA
+# No subchart dependencies: the bundled database is a self-contained
+# StatefulSet on the official `postgres` image (templates/postgresql.yaml).
+# For production HA, set postgresql.enabled=false and point externalDatabase
+# at a managed cluster — CloudNativePG is the recommended non-Bitnami option.

--- a/charts/kates/templates/_helpers.tpl
+++ b/charts/kates/templates/_helpers.tpl
@@ -43,9 +43,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{- define "kates.postgresql.jdbcUrl" -}}
-{{- if .Values.postgresql.useSubchart -}}
-jdbc:postgresql://{{ .Release.Name }}-postgresqlha-postgresql.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:5432/{{ .Values.postgresql.auth.database }}
-{{- else if .Values.postgresql.enabled -}}
+{{- if .Values.postgresql.enabled -}}
 jdbc:postgresql://{{ include "kates.postgresql.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:5432/{{ .Values.postgresql.auth.database }}
 {{- else -}}
 jdbc:postgresql://{{ .Values.externalDatabase.host }}:{{ .Values.externalDatabase.port | default 5432 }}/{{ .Values.externalDatabase.database }}

--- a/charts/kates/templates/networkpolicy.yaml
+++ b/charts/kates/templates/networkpolicy.yaml
@@ -74,7 +74,7 @@ spec:
     {{- end }}
 {{- end }}
 
-{{- if and .Values.networkPolicy.enabled .Values.postgresql.enabled (not .Values.postgresql.useSubchart) }}
+{{- if and .Values.networkPolicy.enabled .Values.postgresql.enabled }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/charts/kates/templates/postgresql.yaml
+++ b/charts/kates/templates/postgresql.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.postgresql.enabled (not .Values.postgresql.useSubchart) }}
+{{- if .Values.postgresql.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/kates/values.schema.json
+++ b/charts/kates/values.schema.json
@@ -481,7 +481,6 @@
             "type": "object",
             "properties": {
                 "enabled": { "type": "boolean" },
-                "useSubchart": { "type": "boolean" },
                 "image": {
                     "type": "object",
                     "properties": {
@@ -529,22 +528,6 @@
                 "password": { "type": "string" },
                 "existingSecret": { "type": "string" },
                 "passwordKey": { "type": "string" }
-            }
-        },
-        "postgresqlHA": {
-            "type": "object",
-            "properties": {
-                "auth": {
-                    "type": "object",
-                    "properties": {
-                        "database": { "type": "string" },
-                        "username": { "type": "string" },
-                        "password": { "type": "string" }
-                    }
-                },
-                "architecture": { "type": "string", "enum": [ "standalone", "replication" ] },
-                "primary": { "type": "object" },
-                "readReplicas": { "type": "object" }
             }
         },
         "defaults": {

--- a/charts/kates/values.yaml
+++ b/charts/kates/values.yaml
@@ -416,13 +416,14 @@ metrics:
     labels:
       grafana_dashboard: "1"
 
-# -- Bundled PostgreSQL configuration
+# -- Bundled PostgreSQL configuration.
+# A self-contained single-instance StatefulSet on the official `postgres`
+# image (no Bitnami). For production HA, set enabled=false and point
+# externalDatabase at a managed cluster (CloudNativePG recommended).
 postgresql:
   # -- Deploy bundled PostgreSQL
   enabled: true
-  # -- Use Bitnami PostgreSQL subchart instead
-  useSubchart: false
-  # -- PostgreSQL image
+  # -- PostgreSQL image (official library image; Alpine variants also work)
   image:
     repository: postgres
     tag: "16"
@@ -470,7 +471,10 @@ postgresql:
     # -- Minimum pool size
     minSize: "5"
 
-# -- External database configuration (when postgresql.enabled=false)
+# -- External database configuration (when postgresql.enabled=false).
+# Recommended for production HA: run a CloudNativePG `Cluster` (official
+# postgres images, streaming replication, backups) and point host/port at its
+# `-rw` service, e.g. host: kates-db-rw.database.svc — no Bitnami involved.
 externalDatabase:
   # -- Enable external database
   enabled: false
@@ -488,21 +492,6 @@ externalDatabase:
   existingSecret: ""
   # -- Key in the existing Secret
   passwordKey: "password"
-
-# -- Bitnami PostgreSQL HA subchart values (when postgresql.useSubchart=true)
-postgresqlHA:
-  auth:
-    database: kates
-    username: kates
-    password: kates
-  architecture: replication
-  primary:
-    persistence:
-      size: 10Gi
-  readReplicas:
-    replicaCount: 2
-    persistence:
-      size: 10Gi
 
 # -- Default benchmark parameters (fallback for all test types)
 defaults:

--- a/docs/book/appendix-d-versions.md
+++ b/docs/book/appendix-d-versions.md
@@ -19,7 +19,7 @@ Every version the platform pins, in one place. This table is generated from the 
 | `headlamp` chart | 0.1.0 (app 0.40.1) | `charts/headlamp/Chart.yaml` |
 | `kafka-cluster` chart | 0.1.1 (app 4.2.0) | `charts/kafka-cluster/Chart.yaml` |
 | `kafka-ui` chart | 0.2.0 (app v1.5.0) | `charts/kafka-ui/Chart.yaml` |
-| `kates-chaos` chart | 1.2.0 (app 1.20.0) | `charts/kates-chaos/Chart.yaml` |
+| `kates-chaos` chart | 2.0.0 (app 3.28.0) | `charts/kates-chaos/Chart.yaml` |
 | `kates-platform` chart | 0.2.0 (app 1.0.0) | `charts/kates-platform/Chart.yaml` |
 | `kates` chart | 0.4.4 (app 1.20.0) | `charts/kates/Chart.yaml` |
 | `minio` chart | 17.0.21 (app 2025.7.23) | `charts/minio/Chart.yaml` |

--- a/docs/kates-chaos-chart.md
+++ b/docs/kates-chaos-chart.md
@@ -1,63 +1,47 @@
 # Kates Chaos Chart — Deployment Guide
 
-> **This document covers the `kates-chaos` Helm chart deployment and configuration.** For chaos engineering theory and methodology, see [Chaos Engineering Theory](book/06-chaos-theory.md) and [Chaos Engineering in Practice](book/07-chaos-practice.md).
+> **This document covers the `kates-chaos` Helm chart deployment and configuration.** For a condensed values reference, examples, and upgrade notes, see the [chart README](../charts/kates-chaos/README.md). For chaos engineering theory and methodology, see [Chaos Engineering Theory](book/06-chaos-theory.md) and [Chaos Engineering in Practice](book/07-chaos-practice.md).
 
-Comprehensive guide for deploying the **kates-chaos** Helm chart on any Kubernetes cluster. This chart wraps [LitmusChaos 3.28](https://litmuschaos.io/) with Kafka-specific RBAC, experiment definitions, monitoring, and secrets management.
+Guide for deploying the **kates-chaos** Helm chart on any Kubernetes cluster. This chart wraps the [LitmusChaos](https://litmuschaos.io/) **execution plane** with Kafka/Kates-specific RBAC, ChaosExperiment/ChaosEngine templating, monitoring, network isolation, and admission policy.
+
+> **Scope — execution plane only.** This chart deploys the LitmusChaos chaos **operator**, the chaos **exporter**, and the **CRDs** (via the `litmus-core` subchart). It does **not** deploy the ChaosCenter web portal (frontend / GraphQL server / auth-server / MongoDB). Drive chaos declaratively through the `engines:` values or by applying `ChaosEngine` resources. If you want the UI, install ChaosCenter separately.
 
 ## Prerequisites
 
 | Requirement | Minimum Version | Notes |
 |-------------|----------------|-------|
 | Kubernetes | 1.25+ | Any managed (EKS, GKE, AKS) or self-managed cluster |
-| Helm | 3.12+ | Chart uses OCI and subchart dependencies |
+| Helm | 3.12+ | Chart uses a subchart dependency (`litmus-core`) |
 | kubectl | 1.25+ | Must be configured for your target cluster |
-| Storage class | Any | Dynamic provisioning for MongoDB PVCs |
-| Kafka | Deployed | In the `kafka` namespace (configurable) |
+| Kafka | Deployed | In the `kafka` namespace (configurable via `rbac.targetNamespaces`) |
 
 ### Namespace Requirements
 
-The chart expects these namespaces to exist (or creates them):
-
-- **`litmus`** — Created automatically by `--create-namespace`
-- **`kafka`** — Must exist if RBAC is enabled (chaos target)
-- **`kates`** — Must exist if RBAC is enabled (chaos coordinator)
+- **release namespace** (e.g. `litmus`) — where the operator/exporter run; created by `--create-namespace`
+- **target namespaces** — every entry in `rbac.targetNamespaces` must exist. `role: target` namespaces receive the chaos ServiceAccount + Role (fault injection); `role: coordinator` namespaces get a ClusterRole binding to create engines and read results.
 
 ## Architecture Overview
 
 ```mermaid
 graph TB
-    subgraph litmus["litmus namespace"]
-        direction TB
-        frontend["Frontend UI :9091"]
-        auth["Auth Server"]
-        graphql["GraphQL Server API :9002"]
-        mongo["MongoDB 3-node ReplicaSet"]
+    subgraph release["release namespace (e.g. litmus)"]
         operator["Chaos Operator"]
-        workflow["Workflow Controller Argo"]
         exporter["Chaos Exporter :8080"]
-        tracker["Event Tracker"]
-        subscriber["Subscriber"]
-
-        frontend --> graphql
-        frontend --> auth
-        graphql --> mongo
-        auth --> mongo
-        operator --> subscriber
-        subscriber --> graphql
-        tracker --> graphql
+        crds["Litmus CRDs"]
     end
 
-    subgraph kafka["kafka namespace"]
+    subgraph kafka["kafka namespace (role: target)"]
         brokers["Kafka Brokers"]
+        sa["litmus-admin SA + Role"]
+        experiments["ChaosExperiments"]
     end
 
-    subgraph kates["kates namespace"]
+    subgraph kates["kates namespace (role: coordinator)"]
         app["Kates Application"]
     end
 
-    operator -- "chaos injection" --> kafka
-    subscriber -- "experiment status" --> kafka
-    graphql -- "coordination" --> kates
+    operator -- "reconciles ChaosEngine → injects faults" --> kafka
+    app -- "creates ChaosEngine / reads ChaosResult" --> operator
     exporter -- "metrics" --> prometheus["Prometheus"]
 ```
 
@@ -72,7 +56,7 @@ helm repo update
 
 ### Step 2 — Install CRDs
 
-CRDs must be applied before Helm install (the chart's post-install hooks depend on them):
+CRDs must be applied before Helm install (the post-install hooks depend on them):
 
 ```bash
 kubectl apply -f config/litmus/chaos-litmus-chaos-enable.yml
@@ -100,369 +84,295 @@ helm upgrade --install chaos charts/kates-chaos \
   --timeout 10m --wait
 ```
 
-Or use the Makefile shorthand:
-
-```bash
-# Note: installs into the kafka namespace (helm ... -n kafka --create-namespace),
-# unlike the manual commands above which use the litmus namespace
-make litmus-generic
-```
+Or use the Makefile shorthand (`make litmus-generic` — note it installs into the `kafka` namespace).
 
 ### Step 5 — Verify Deployment
 
 ```bash
-# Check pod status
-kubectl get pods -n litmus
-
-# Run Helm test suite (portal, frontend, MongoDB, CRDs)
+kubectl rollout status deployment -l app.kubernetes.io/name=litmus -n litmus
 helm test chaos -n litmus
-
-# Or via Makefile — note: the litmus-* targets install and test in the
-# kafka namespace, not litmus
-make litmus-test
 ```
 
-Expected output — all pods `Running`:
+Expected pods — operator + exporter only:
 
 ```
-NAME                                        READY   STATUS
-chaos-litmus-auth-server-xxx                1/1     Running
-chaos-litmus-frontend-xxx                   1/1     Running
-chaos-litmus-server-xxx                     1/1     Running
-chaos-mongodb-0                             1/1     Running
-chaos-mongodb-1                             1/1     Running
-chaos-mongodb-2                             1/1     Running
-chaos-operator-ce-xxx                       1/1     Running
-chaos-exporter-xxx                          1/1     Running
-subscriber-xxx                              1/1     Running
-workflow-controller-xxx                     1/1     Running
-event-tracker-xxx                           1/1     Running
+NAME                          READY   STATUS
+chaos-operator-ce-xxx         1/1     Running
+chaos-exporter-xxx            1/1     Running
 ```
 
 ## Configuration Reference
 
-### Secrets Management
+### Images
 
-The chart auto-generates credentials on first install and persists them in a Kubernetes Secret with `helm.sh/resource-policy: keep` (survives `helm upgrade`).
-
-| Credential | Secret Key | Behavior |
-|-----------|-----------|----------|
-| Portal admin password | `admin-password` | Auto-generated if `auth.adminPassword` is empty |
-| MongoDB root password | `db-root-password` | Auto-generated (16-char random) |
-| JWT signing secret | `jwt-secret` | Auto-generated (32-char random) |
-
-**Option A — Auto-generated (recommended for production)**
+All chart-managed images resolve from a single `images` block, with an optional global registry prefix and digest pinning:
 
 ```yaml
-auth:
-  adminPassword: ""    # auto-generated
-  dbRootPassword: ""   # auto-generated
-  jwtSecret: ""        # auto-generated
+global:
+  imageRegistry: ""          # prefix applied to every chart-managed image
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+images:
+  kubectl:                   # installer Job, GameDay, Helm tests
+    repository: registry.k8s.io/kubectl
+    tag: "v1.33.0"
+    digest: ""               # takes precedence over tag when set
+  goRunner:                  # default runtime for ChaosExperiment definitions
+    repository: litmuschaos/go-runner
+    tag: "3.28.0"
 ```
 
-**Option B — Explicit passwords**
+The `litmus-core` subchart images (operator/runner) are configured under the `litmus-core:` key.
 
-```bash
-helm upgrade --install chaos charts/kates-chaos \
-  -n litmus --create-namespace \
-  -f charts/kates-chaos/values-generic.yaml \
-  --set auth.adminPassword=MySecureP@ss \
-  --set auth.dbRootPassword=MongoR00t! \
-  --timeout 10m --wait
-```
-
-**Option C — External Secrets Operator**
+### Service Account
 
 ```yaml
-auth:
-  existingSecret: my-external-secret
+serviceAccount:
+  name: litmus-admin         # created in each target namespace; used by ChaosEngines
 ```
 
-The existing Secret must have keys: `admin-password`, `db-root-password`, `jwt-secret`.
-
-**Retrieve auto-generated credentials:**
-
-```bash
-kubectl get secret chaos-auth -n litmus -o jsonpath='{.data.admin-password}' | base64 -d
-kubectl get secret chaos-auth -n litmus -o jsonpath='{.data.db-root-password}' | base64 -d
-```
-
-### MongoDB Configuration
-
-The generic overlay deploys a 3-node MongoDB ReplicaSet with arbiter:
-
-```yaml
-litmus:
-  mongodb:
-    architecture: replicaset
-    replicaCount: 3
-    arbiter:
-      enabled: true
-    auth:
-      enabled: true
-    persistence:
-      enabled: true
-      size: 10Gi
-      storageClass: ""   # uses cluster default
-    resources:
-      requests:
-        cpu: 500m
-        memory: 1Gi
-      limits:
-        cpu: 2
-        memory: 2Gi
-```
-
-> **Storage Class**: Set `storageClass` to your cluster's provisioner (e.g., `gp3`, `standard-rwo`, `longhorn`). Leave empty (`""`) to use the cluster default.
-
-### RBAC (Cross-Namespace Chaos)
-
-The chart creates RBAC resources allowing the chaos operator to inject faults into target namespaces:
+### RBAC (cross-namespace chaos)
 
 ```yaml
 rbac:
   enabled: true
-  kafkaNamespace: kafka    # where Kafka brokers run
-  katesNamespace: kates    # where Kates application runs
+  targetNamespaces:
+    - name: kafka
+      role: target           # litmus-admin SA + Role + RoleBinding (fault injection)
+    - name: kates
+      role: coordinator      # ClusterRole binding: create engines, read results
+  nodeChaos:
+    enabled: true            # cluster-scoped RBAC for node-drain and node-level faults
 ```
 
-This creates:
-- `ClusterRole` + `ClusterRoleBinding` for `litmus-admin` → `kafka` namespace
-- `Role` + `RoleBinding` for chaos coordinator → `kates` namespace
+Each `coordinator` entry may set `serviceAccount:` (defaults to `default`) to bind a specific SA.
 
-### Network Policies
+> **Deprecated:** `rbac.kafkaNamespace` / `rbac.katesNamespace` still work and win over `targetNamespaces` when set, but `targetNamespaces` is preferred and supports any number of namespaces.
 
-Enabled by default in the generic overlay. Controls traffic to/from the litmus namespace:
+### ChaosExperiment Definitions
+
+Installed via a post-install/post-upgrade Job. Definitions carry optional default `env` and `permissions` (mapped to `spec.definition`):
 
 ```yaml
-networkPolicies:
+experiments:
   enabled: true
+  installer:                 # the kubectl Job that applies the definitions
+    backoffLimit: 3
+    ttlSecondsAfterFinished: 300
+    resources: {}
+    securityContext: {}
+    nodeSelector: {}
+    tolerations: []
+  targetNamespaces: []       # empty = every role:target namespace
+  definitions:
+    - name: pod-delete
+      scope: Namespaced
+      env:                   # baked into the ChaosExperiment as defaults
+        PODS_AFFECTED_PERC: "50"
+      permissions: []        # extra RBAC the runner needs (spec.definition.permissions)
 ```
 
-**Allowed traffic:**
-- Litmus ↔ Litmus (inter-component communication)
-- Litmus → Kafka namespace (chaos injection)
-- Litmus → Kates namespace (chaos coordination)
-- Litmus → kube-system (DNS resolution, TCP/UDP port 53)
+Default set: `pod-delete`, `pod-cpu-hog`, `pod-memory-hog`, `pod-network-partition`, `pod-io-stress`, `pod-dns-error` (Namespaced) and `node-drain` (Cluster).
 
-**All other ingress/egress is denied.**
+Verify: `kubectl get chaosexperiments -n kafka`
 
-### PodDisruptionBudgets
+### ChaosEngine Automation
 
-Protects MongoDB from accidental disruptions:
+Each `engines:` entry renders a `ChaosEngine`. Probes and pod `components` are first-class:
 
 ```yaml
-pdb:
-  enabled: true      # default in generic overlay
+engines:
+  kafka-leader-kill:
+    enabled: true
+    appNamespace: kafka                 # defaults to the primary target namespace
+    appLabel: "strimzi.io/kind=Kafka"
+    appKind: statefulset
+    experiment: pod-delete
+    serviceAccount: ""                  # defaults to serviceAccount.name
+    engineState: active                 # active | stop
+    annotationCheck: false
+    jobCleanUpPolicy: retain            # delete | retain
+    duration: 60                        # TOTAL_CHAOS_DURATION
+    interval: 60                        # CHAOS_INTERVAL
+    force: true                         # FORCE=true
+    targetPods: "krafter-pool-alpha-0"  # TARGET_PODS
+    podsAffectedPerc: "100"             # PODS_AFFECTED_PERC
+    env:                                # any additional experiment env
+      APP_NS: kafka
+    components:
+      nodeSelector: {}
+      resources: {}
+      tolerations: []
+    probes:                             # passed through verbatim to spec…probe
+      - name: verify-isr-failover
+        type: cmdProbe
+        mode: PostChaos
+        runProperties: { probeTimeout: "120s", interval: "10s", retry: 6 }
+        cmdProbe/inputs:
+          command: "kubectl exec -n kafka krafter-pool-alpha-1 -- kafka-topics.sh --bootstrap-server localhost:9092 --list"
+          comparator: { type: string, criteria: contains, value: "orders" }
+    labels: {}
+    annotations: {}
 ```
 
-Creates a PDB with `minAvailable: 1` for MongoDB.
+This model expresses the scenarios in `config/litmus/experiments/` (leader-kill, network-latency, ISR-health probe, multi-broker-kill) directly as values.
+
+### Network Policy
+
+Scopes what the chaos-infra pods in the release namespace may talk to. Egress **must** include the Kubernetes API server (the operator needs it) and DNS:
+
+```yaml
+networkPolicy:
+  enabled: true
+  apiServer:
+    enabled: true
+    ports: [443, 6443]
+    ipBlock: {}              # e.g. {cidr: 10.0.0.1/32} to pin the control plane
+  dns:
+    enabled: true
+    ports: [53]
+  monitoring:
+    enabled: true            # ingress for Prometheus to scrape the exporter
+    namespace: monitoring
+    port: 8080
+  targets:
+    enabled: true            # egress to every rbac.targetNamespaces entry
+  extraIngress: []           # raw rules appended verbatim
+  extraEgress: []
+```
+
+> **Deprecated:** `networkPolicies.enabled` is honored as an alias — the policy renders if **either** key is true.
 
 ### Monitoring
-
-#### Prometheus ServiceMonitor
 
 ```yaml
 monitoring:
   serviceMonitor:
-    enabled: true
+    enabled: false           # litmus-core ships its own exporter ServiceMonitor;
+                             # enable this only if you scrape via THIS chart
+    selector: { app: litmus }  # must match the exporter Service
+    port: http
+    path: /metrics
     interval: 15s
-    labels:
-      release: monitoring   # match your Prometheus operator selector
-```
-
-#### Grafana Dashboard
-
-Auto-discovered via the `grafana_dashboard: "1"` label:
-
-```yaml
-monitoring:
+    scrapeTimeout: ""
+    honorLabels: false
+    relabelings: []
+    metricRelabelings: []
+    labels: { release: monitoring }
   grafanaDashboard:
     enabled: true
-    labels:
-      grafana_dashboard: "1"
+    namespace: ""            # namespace used in dashboard PromQL (default: release ns)
+    folder: ""               # grafana_folder annotation
+    labels: { grafana_dashboard: "1" }
 ```
 
-Dashboard panels:
-- Experiment pass/fail counts
-- Engine duration time series
-- Experiment run count over time
-- Chaos infrastructure pod status table
-- MongoDB health indicator
+Dashboard panels: experiment pass/fail counts, engine duration, run-count over time, chaos-infra pod status, chaos operator up.
 
-### ChaosExperiment Definitions
-
-7 experiments are installed via a post-install/post-upgrade Job:
-
-| Experiment | Scope | Description |
-|-----------|-------|-------------|
-| `pod-delete` | Namespaced | Kill a random pod |
-| `pod-cpu-hog` | Namespaced | CPU stress on target pod |
-| `pod-memory-hog` | Namespaced | Memory stress on target pod |
-| `pod-network-partition` | Namespaced | Network isolation |
-| `pod-io-stress` | Namespaced | Disk I/O stress |
-| `pod-dns-error` | Namespaced | DNS resolution failure |
-| `node-drain` | Cluster | Drain a Kubernetes node |
-
-Verify experiments are installed:
-
-```bash
-kubectl get chaosexperiments -n kafka
-```
-
-### ChaosEngine Automation
-
-Create `ChaosEngine` resources declaratively via values:
+### Kyverno Pod Security Policies
 
 ```yaml
-engines:
-  kafkaPodDelete:
-    enabled: true
-    appNamespace: kafka
-    appLabel: "strimzi.io/cluster=krafter"
-    appKind: statefulset
-    experiment: pod-delete
-    duration: 30
-    interval: 10
-    force: false
-    env:
-      PODS_AFFECTED_PERC: "50"
+kyvernoPolicy:
+  enabled: false
+  action: Audit              # Audit | Enforce
+  mutate: true               # auto-inject restricted security contexts on admission
+  namespaces: []             # empty = release namespace only
+  excludeSelector:           # pods skipped from validate/mutate (need privileges)
+    matchExpressions:
+      - key: chaosUID
+        operator: Exists
 ```
 
-This creates a `ChaosEngine` resource that runs the `pod-delete` experiment against the Kafka StatefulSet.
+Only rendered when the cluster has the `kyverno.io/v1` API.
+
+### PodDisruptionBudget
+
+Off by default — the chart ships no stateful workload to protect. To guard a workload you run in the release namespace, enable it and **provide a selector** (required):
+
+```yaml
+pdb:
+  enabled: true
+  minAvailable: 1            # or set maxUnavailable
+  selector:
+    app.kubernetes.io/name: my-workload
+```
 
 ### GameDay Validation
 
-Trigger a 6-point infrastructure validation:
-
-```bash
-# Via Makefile
-make litmus-gameday
-
-# Via Helm
-helm upgrade chaos charts/kates-chaos \
-  -n litmus \
-  -f charts/kates-chaos/values-generic.yaml \
-  --set gameday.enabled=true \
-  --timeout 5m --wait
-```
-
-Checks performed:
-1. CRDs installed
-2. Chaos operator running
-3. MongoDB responsive
-4. Experiments installed in kafka namespace
-5. Subscriber connected
-6. Kafka namespace accessible
-
-## Accessing the Portal
-
-### ClusterIP (generic default)
-
-```bash
-kubectl port-forward svc/chaos-litmus-frontend-service 9091:9091 -n litmus
-```
-
-Then open http://localhost:9091
-
-### Ingress (production)
-
-Create an Ingress via Helm values:
+A Job of read-only checks. Checks are data-driven; leave `checks` empty for the operator-only default set, or override:
 
 ```yaml
-litmus:
-  ingress:
-    enabled: true
-    ingressClassName: nginx
-    host:
-      name: chaos.example.com
+gameday:
+  enabled: true
+  checks:
+    - name: CRDs installed
+      command: "kubectl get crd chaosengines.litmuschaos.io"
+    - name: Custom broker check
+      command: "kubectl get pods -n kafka -l strimzi.io/kind=Kafka | grep Running"
+```
+
+```bash
+# Enable on an existing release
+helm upgrade chaos charts/kates-chaos -n litmus --reuse-values --set gameday.enabled=true
 ```
 
 ## Uninstalling
 
 ```bash
-# Full teardown (Helm release + PVCs + namespace)
-make litmus-undeploy
-
-# Or manually
 helm uninstall chaos -n litmus
-kubectl delete pvc --all -n litmus
-kubectl delete all --all -n litmus
 kubectl delete namespace litmus
 ```
 
 ## Troubleshooting
 
-### MongoDB pods stuck in `Pending`
+### Experiments not appearing in the target namespace
 
-**Cause**: No StorageClass available or PVC cannot bind.
+**Cause**: post-install Job failed or the CRDs weren't established first.
 
 ```bash
-kubectl describe pvc -n litmus
+kubectl get jobs -n litmus | grep experiments
+kubectl logs job/chaos-kates-chaos-experiments -n litmus
 ```
 
-**Fix**: Set `litmus.mongodb.persistence.storageClass` to a valid provisioner name.
+### Operator not reconciling ChaosEngines
 
-### Auth-server/server stuck in `Init:0/1`
+**Cause**: with `networkPolicy.enabled=true` and a strict CNI, the operator may be unable to reach the Kubernetes API server.
 
-**Cause**: Init container `wait-for-mongodb` cannot connect. MongoDB must be a StatefulSet (not Deployment).
+**Fix**: ensure `networkPolicy.apiServer.enabled=true` (default) and, on locked-down clusters, set `networkPolicy.apiServer.ipBlock.cidr` to the control-plane CIDR.
 
-**Fix**: Ensure `litmus.mongodb.architecture: replicaset` (not `standalone`). The init container connects via StatefulSet DNS (`chaos-mongodb-0.chaos-mongodb-headless`).
+### `helm test` fails on the operator check
 
-### ImagePullBackOff on MongoDB
-
-**Cause**: The upstream Litmus chart defaults to a deprecated `bitnamilegacy/mongodb` image.
-
-**Fix**: The stack pins MongoDB to `mongo:6.0` (see `images.env`); on Kind the external MongoDB StatefulSet is used because `bitnamilegacy/mongodb` is amd64-only. If issues persist, verify image availability:
+**Cause**: the operator Deployment is not `Available` yet.
 
 ```bash
-docker pull mongo:6.0
-```
-
-### Subscriber CrashLoopBackOff
-
-**Cause**: Transient — subscriber starts before the Litmus server is fully ready.
-
-**Fix**: Generally self-resolving within 2-3 restart cycles. If persistent, check server logs:
-
-```bash
-kubectl logs -n litmus -l app.kubernetes.io/component=litmus-server
-```
-
-### Experiments not appearing in kafka namespace
-
-**Cause**: Post-install Job failed or RBAC insufficient.
-
-```bash
-# Check the installer job
-kubectl get jobs -n litmus | grep experiment
-kubectl logs job/chaos-experiments -n litmus
+kubectl rollout status deployment -l app.kubernetes.io/name=litmus -n litmus
+kubectl get pods -n litmus -l app.kubernetes.io/name=litmus
 ```
 
 ## Chart Files Reference
 
 ```
 charts/kates-chaos/
-├── Chart.yaml                              # v1.2.0, depends on litmus-core 3.28.1
+├── Chart.yaml                              # v2.0.0, depends on litmus-core 3.28.1
+├── README.md                               # Chart reference (values tables, examples, upgrade notes)
 ├── values.yaml                             # Base defaults
 ├── values-kind.yaml                        # Kind cluster overlay (dev)
 ├── values-generic.yaml                     # Generic Kubernetes overlay (prod)
 ├── values.schema.json                      # Helm install-time validation
 ├── .helmignore
 └── templates/
-    ├── _helpers.tpl                        # Template helpers
+    ├── _helpers.tpl                        # Image/label/namespace helpers
     ├── NOTES.txt                           # Post-install instructions
-    ├── secrets.yaml                        # Auto-generated auth secrets
-    ├── chaos-rbac.yaml                     # Cross-namespace RBAC
-    ├── experiments.yaml                    # Post-install ChaosExperiment Job
-    ├── chaosengines.yaml                   # Templated ChaosEngine resources
+    ├── chaos-rbac.yaml                     # Cross-namespace RBAC (per target namespace)
+    ├── experiments.yaml                    # Post-install ChaosExperiment installer Job
+    ├── chaosengines.yaml                   # Templated ChaosEngine resources (probes/components)
     ├── servicemonitor.yaml                 # Prometheus integration
     ├── grafana-dashboard.yaml              # Grafana dashboard ConfigMap
-    ├── pdb.yaml                            # MongoDB PodDisruptionBudget
-    ├── networkpolicy.yaml                  # Namespace isolation
-    ├── gameday.yaml                        # Infrastructure validation Job
+    ├── kyverno-policies.yaml               # Pod security ClusterPolicy
+    ├── networkpolicy.yaml                  # Chaos-infra network isolation
+    ├── pdb.yaml                            # Optional PodDisruptionBudget
+    ├── gameday.yaml                        # Data-driven validation Job
     └── tests/
-        └── test-connectivity.yaml          # 4-tier Helm test suite
+        └── test-connectivity.yaml          # Helm test suite (operator + CRDs)
 ```
 
 ## Makefile Targets
@@ -471,8 +381,13 @@ charts/kates-chaos/
 |--------|-------------|
 | `make litmus` | Deploy with Kind overlay (development) |
 | `make litmus-generic` | Deploy with generic Kubernetes overlay (production) |
-| `make litmus-undeploy` | Full teardown (release + PVCs + namespace) |
+| `make litmus-undeploy` | Full teardown (release + namespace) |
 | `make litmus-test` | Run Helm test suite |
-| `make litmus-gameday` | Trigger GameDay infrastructure validation |
-| `make chaos-ui` | Port-forward Litmus UI to localhost:9091 |
+| `make litmus-gameday` | Trigger GameDay validation |
 | `make chaos-status` | Show release, pods, experiments, engines, results |
+
+## See Also
+
+- [Chaos Engineering Theory](book/06-chaos-theory.md)
+- [Chaos Engineering in Practice](book/07-chaos-practice.md)
+- [Tutorial 3: Chaos Engineering](tutorials/03-chaos-engineering.md)


### PR DESCRIPTION
## Why

The `kates-chaos` chart *documented, tested, and monitored* a full ChaosCenter portal (frontend / GraphQL server / auth-server / MongoDB / subscriber) but only ever deployed the `litmus-core` **execution plane** (operator + exporter + CRDs). Every portal reference was dead:

- `helm test` probed `litmus-server-service:9002`, `litmus-frontend-service:9091`, and `mongodb-0` — none of which exist → **tests always failed**.
- GameDay pinged a MongoDB and subscriber that were never installed → **always failed**.
- The PDB selected `app.kubernetes.io/name: mongodb` → **selected nothing**.
- `values.schema.json` + the docs described `auth.*`, `litmus.mongodb.*`, `litmus.ingress.*`, and a `secrets.yaml` that **no template consumed**.

On top of that, the chart was heavily hardcoded (four different "kubectl" image pins, the `litmus-admin` SA name repeated as a magic string, single fixed target namespaces, a NetworkPolicy with no API-server egress, dead `global.*` and `kyvernoPolicy.excludeContainers` values).

This PR rescopes the chart honestly to the execution plane and turns the hardcoding into real configuration.

## What changed

**Correctness / drift (Phase 1)**
- Rewrote NOTES, Helm tests, and GameDay to check what actually deploys (operator `Available`, CRDs `Established`, experiments present) instead of the portal. Tests get their own scoped SA/RBAC as `test` hooks.
- GameDay is data-driven (`gameday.checks`) with an operator-only default set and its own read RBAC.
- Grafana dashboard: templated the namespace in PromQL (was hardcoded `litmus`); replaced the bogus MongoDB panel with operator-up.
- Reconciled the ServiceMonitor with litmus-core's own exporter SM (off by default; correct `app: litmus` selector / `http` port).
- Makefile: `chaos-ui` no longer port-forwards a non-existent frontend service.

**Configurability (Phases 2–4)**
- `images` block (kubectl, goRunner) as a single source of truth, with `global.imageRegistry` prefix and digest pinning; `global.imagePullPolicy` / `imagePullSecrets` now actually consumed.
- `serviceAccount.name` shared by RBAC and ChaosEngines.
- `rbac.targetNamespaces` list (any number, per-namespace `target`/`coordinator` role) replaces the fixed `kafkaNamespace`/`katesNamespace` pair; `rbac.nodeChaos` gate.
- ChaosEngines gain probes, `components` (nodeSelector/resources/tolerations), `annotationCheck`, `jobCleanUpPolicy`, SA override, and promoted `targetPods`/`podsAffectedPerc` — enough to express the `config/litmus/experiments/` scenarios as values.
- ChaosExperiment definitions carry `env` defaults + `permissions`; installer Job knobs (backoffLimit, ttl, resources, securityContext, scheduling) exposed; multi-namespace install.
- **Structured NetworkPolicy that adds the Kubernetes API-server egress the operator needs (previously omitted)**, plus Prometheus scrape ingress, per-target egress, and `extraIngress`/`extraEgress`.
- ServiceMonitor scrape controls (scrapeTimeout, relabelings, honorLabels).
- Kyverno policy: multi-namespace + a real, configurable pod exclusion (`excludeSelector`) replacing the dead `excludeContainers`.
- PDB: honest default off; requires a `selector` when enabled.

**Meta (Phase 5)**
- `values.schema.json` rewritten to match and constrain the real structure (enums, engine shape, deprecations).
- Chart `1.2.0 → 2.0.0`; `appVersion` aligned to LitmusChaos `3.28.0`; added maintainers/sources/artifacthub metadata.
- Overlays and `docs/kates-chaos-chart.md` rewritten for the execution-plane reality and the new keys.

## Notes for reviewers

- **Breaking change (2.0.0), but with compatibility shims.** `rbac.kafkaNamespace`/`rbac.katesNamespace` and `networkPolicies.enabled` are still honored (deprecated keys win / OR-in), mirroring the connect-cluster chart's convention. The visible behavior change is that the chart no longer implies a web UI — install upstream ChaosCenter separately for that.
- **Decision taken:** the plan offered (A) add the real portal vs (B) scope honestly to operator-only. This PR implements **B** (recommended in the plan) — smaller surface, declarative-first, correct fast.
- **Verification:** `helm lint` and `helm template` pass on `values.yaml`, `values-kind.yaml`, and `values-generic.yaml` with the subchart both enabled and disabled; rendered manifests parse as valid YAML with no duplicate `(kind, namespace, name)` tuples; the schema rejects bad enums; deprecated keys still render; a 3-namespace config fans RBAC + experiments out correctly.
- Not exercised on a live cluster (no runtime observation of an actual chaos run) — validation is render/lint/schema-level.

---

## Also in this PR: drop Bitnami PostgreSQL from the `kates` chart (38d27cb)

Unrelated to the chaos chart but bundled here at the author's request. The `kates` app chart declared a Bitnami `postgresql` subchart (optional HA path); because Helm fetches every declared dependency at `dependency build` time regardless of its `condition`, it broke deploys with `missing in charts/ directory: postgresql`, and Bitnami archived its free images to `bitnamilegacy/` in 2025.

- Removed the Bitnami subchart dependency + the `useSubchart`/`postgresqlHA` machinery.
- The chart already bundles a self-contained StatefulSet on the **official `postgres:16`** image — now the only in-chart DB.
- Production HA path documented via `externalDatabase` → **CloudNativePG** (official images, replication), the recommended non-Bitnami option.
- `helm lint`/`helm template` pass on bundled + external-DB paths; schema validates.
