### PR TITLE
feat(kafka-ui): fix TLS/secret bugs, harden, and add observability + HA

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Kates ships its platform as independently versioned Helm charts, composable via 
 | [`kates`](charts/kates/) | 0.4.4 | 1.20.0 | The Kates backend (Quarkus REST/gRPC) and frontend, deployed as a single Kubernetes Deployment with ConfigMap-driven configuration. |
 | [`kafka-cluster`](charts/kafka-cluster/) | 0.1.1 | 4.2.0 | A Strimzi-managed KRaft Kafka cluster with zone-aware broker pools, SCRAM-SHA-512 authentication, and rack-affinity storage classes. |
 | [`connect-cluster`](charts/connect-cluster/) | 1.2.0 | 4.2.0 | A Strimzi-managed Kafka Connect cluster with a managed KafkaUser, least-privilege ACLs, default-deny NetworkPolicies, and in-chart JMX metrics. |
-| [`kafka-ui`](charts/kafka-ui/) | 0.2.0 | v1.5.0 | A web-based Kafka management interface for topic inspection, consumer group monitoring, and message browsing. |
+| [`kafka-ui`](charts/kafka-ui/) | 0.3.0 | v1.5.0 | A web-based Kafka management interface for topic inspection, consumer group monitoring, and message browsing. |
 | [`kates-chaos`](charts/kates-chaos/) | 2.0.0 | 3.28.0 | A LitmusChaos execution-plane wrapper (operator, exporter, CRDs) with Kafka-specific RBAC, ChaosExperiment/ChaosEngine templating, and monitoring for broker and network faults. |
 | [`kates-monitoring`](charts/monitoring/) | 1.0.0 | 82.4.3 | The Prometheus and Grafana monitoring stack, pre-configured with scrape jobs, recording rules, and auto-provisioned dashboards for Kafka, JVM, and Strimzi metrics. |
 | [`apicurio-registry`](charts/apicurio-registry/) | 0.1.5 | 3.3.0 | Apicurio Schema Registry deployed with KafkaSQL persistence, providing schema validation and compatibility enforcement for Avro, Protobuf, and JSON Schema. |

--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for deploying Kafka UI (Kafbat) with Strimzi SCRAM-SHA-512 authentication
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "v1.5.0"
 kubeVersion: ">=1.27.0-0"
 home: https://github.com/bmscomp/kates
@@ -19,3 +19,15 @@ keywords:
   - monitoring
   - strimzi
   - dashboard
+annotations:
+  artifacthub.io/category: streaming-messaging
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/changes: |
+    - kind: fixed
+      description: Wire the Kafka TLS truststore (mount trustedCertificateSecret + set ssl.truststore.location) so SASL_SSL actually works
+    - kind: fixed
+      description: Source Schema Registry / Kafka Connect auth passwords from Secrets instead of rendering them into the ConfigMap
+    - kind: fixed
+      description: Derive NetworkPolicy egress ports from the Schema Registry / Connect URLs; generate a random web password instead of admin
+    - kind: added
+      description: ServiceAccount (token not mounted), ServiceMonitor, PodDisruptionBudget, HorizontalPodAutoscaler, Helm test, topologySpreadConstraints, extraVolumes, values.schema.json, read-only root filesystem

--- a/charts/kafka-ui/README.md
+++ b/charts/kafka-ui/README.md
@@ -4,6 +4,8 @@ A Helm chart for deploying [Kafbat Kafka UI](https://github.com/kafbat/kafka-ui)
 
 > **Note** — This chart uses the actively maintained **Kafbat** fork (`ghcr.io/kafbat/kafka-ui`), which is the community continuation of the original Provectus Kafka UI. The old `provectuslabs/kafka-ui` image is deprecated and contains known security vulnerabilities.
 
+> **📚 Task-oriented guides** live in [`docs/`](docs/): [Setup & Access](docs/01-setup.md) · [Kafka Connection & ACLs](docs/02-kafka-and-acls.md) · [Schema Registry](docs/03-schema-registry.md) · [Kafka Connect](docs/04-kafka-connect.md). This README is the parameter reference.
+
 ## Architecture
 
 Kafka UI serves as the central observability and management dashboard for the entire Kates streaming platform. Rather than requiring operators to interact with each component individually through CLI tools or raw API calls, Kafka UI provides a single web interface that aggregates information from three core backend services — the Kafka brokers, the Apicurio Schema Registry, and the Kafka Connect cluster — into one unified view.
@@ -216,6 +218,24 @@ kafka:
     enabled: true
 ```
 
+### TLS to Kafka (SASL_SSL)
+
+When `kafka.tls.enabled=true` the chart uses `SASL_SSL` and **mounts the CA
+certificate** so the broker cert can be verified. You must provide the Secret
+holding the PEM CA (the Strimzi cluster CA, named `<clusterName>-cluster-ca-cert`):
+
+```yaml
+kafka:
+  tls:
+    enabled: true
+    trustedCertificateSecret: krafter-cluster-ca-cert   # required when enabled
+    certificateKey: ca.crt                              # key inside the Secret
+```
+
+The Secret is mounted at `/etc/kafka-ui/certs/<certificateKey>` and referenced
+via `ssl.truststore.location`. Enabling TLS without `trustedCertificateSecret`
+fails the render with a clear error.
+
 ### Authentication
 
 Kafka UI authenticates to the Kafka cluster using SCRAM-SHA-512. The chart creates a Strimzi `KafkaUser` resource, and the Strimzi Entity Operator generates a Kubernetes Secret containing the password. The Deployment mounts this Secret as an environment variable.
@@ -257,7 +277,9 @@ schemaRegistry:
 
 If `url` is left empty, the chart auto-computes it as `http://apicurio-apicurio-registry.<namespace>.svc.cluster.local:8080/apis/ccompat/v7`.
 
-For registries that require authentication:
+For registries that require authentication. The password is **stored in a
+Secret and injected as an environment variable** — it is never rendered into
+the ConfigMap:
 
 ```yaml
 schemaRegistry:
@@ -266,7 +288,9 @@ schemaRegistry:
   auth:
     enabled: true
     username: "admin"
-    password: "secret"
+    password: "secret"          # the chart creates a Secret from this
+    # existingSecret: my-sr-secret   # …or bring your own (key: password)
+    # passwordKey: password
 ```
 
 ## Integrating Kafka Connect
@@ -279,9 +303,15 @@ kafkaConnect:
   name: "connect-cluster"     # display name in the UI
   # Explicit URL to the Kafka Connect REST API
   url: "http://connect-cluster-connect-api.kafka.svc:8083"
+  # Optional basic auth (password sourced from a Secret, like Schema Registry)
+  auth:
+    enabled: false
+    username: ""
+    password: ""
+    # existingSecret: my-connect-secret
 ```
 
-If `url` is left empty, the chart auto-computes it as `http://connect-cluster-connect-api.<namespace>.svc.cluster.local:8083`.
+If `url` is left empty, the chart auto-computes it as `http://connect-cluster-connect-api.<namespace>.svc.cluster.local:8083`. The NetworkPolicy egress port is derived automatically from the URL.
 
 ## Securing Kafka UI (Web UI Auth & RBAC)
 
@@ -394,6 +424,59 @@ echo "http://localhost:8080"
 echo "https://kafka-ui.mycompany.com"
 ```
 
+## Observability
+
+Kafka UI exposes Prometheus metrics at `/actuator/prometheus`. Create a
+`ServiceMonitor` (requires the Prometheus Operator CRDs):
+
+```yaml
+metrics:
+  serviceMonitor:
+    enabled: true
+    interval: 30s
+    labels:
+      release: monitoring     # match your Prometheus selector
+```
+
+## High Availability
+
+```yaml
+replicas: 2
+pdb:
+  enabled: true
+  minAvailable: 1
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app: kafka-ui
+autoscaling:            # optional — CPU/memory HPA (omit static replicas)
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+```
+
+## Security Hardening
+
+The chart runs hardened by default:
+
+- Dedicated `ServiceAccount` with `automountServiceAccountToken: false` — Kafka UI does not call the Kubernetes API.
+- `readOnlyRootFilesystem: true` with an `emptyDir` mounted at `/tmp`.
+- Non-root, all capabilities dropped, no privilege escalation.
+- A default-scoped `NetworkPolicy` (no Kubernetes API-server egress unless `networkPolicy.apiServerEgress=true`).
+- The web login password is randomly generated on first install and preserved across upgrades (never a well-known default).
+
+```yaml
+serviceAccount:
+  create: true
+  automountServiceAccountToken: false
+extraVolumes: []          # e.g. mount custom truststores / serde descriptors
+extraVolumeMounts: []
+```
+
 ## Parameters Reference
 
 ### Image
@@ -415,6 +498,8 @@ echo "https://kafka-ui.mycompany.com"
 | `kafka.bootstrapServers` | `""` (auto-computed) | Bootstrap servers override |
 | `kafka.clusterDomain` | `cluster.local` | Kubernetes cluster domain |
 | `kafka.tls.enabled` | `false` | Enable TLS (port 9093) |
+| `kafka.tls.trustedCertificateSecret` | `""` | Secret holding the PEM CA (**required** when TLS enabled) |
+| `kafka.tls.certificateKey` | `ca.crt` | Key inside the Secret |
 
 ### Schema Registry
 
@@ -424,7 +509,9 @@ echo "https://kafka-ui.mycompany.com"
 | `schemaRegistry.url` | `""` (auto-computed) | Schema Registry URL |
 | `schemaRegistry.auth.enabled` | `false` | Enable authentication |
 | `schemaRegistry.auth.username` | `""` | Auth username |
-| `schemaRegistry.auth.password` | `""` | Auth password |
+| `schemaRegistry.auth.password` | `""` | Password (creates a Secret; not in the ConfigMap) |
+| `schemaRegistry.auth.existingSecret` | `""` | Use a pre-existing Secret instead |
+| `schemaRegistry.auth.passwordKey` | `password` | Key in the Secret |
 
 ### Web UI Authentication & RBAC
 
@@ -433,7 +520,9 @@ echo "https://kafka-ui.mycompany.com"
 | `auth.enabled` | `false` | Enable Web UI authentication |
 | `auth.type` | `DISABLED` | Authentication type (`DISABLED` or `LOGIN_FORM`) |
 | `auth.username` | `admin` | Username for Basic Auth |
-| `auth.passwordSecret` | `""` | Name of Kubernetes Secret containing the password |
+| `auth.passwordSecret` | `kafka-ui-web-password` | Secret the chart creates/looks up for the password |
+| `auth.password` | `""` | Explicit password (else a random one is generated + preserved) |
+| `auth.existingSecret` | `""` | Use a pre-existing Secret instead of managing one |
 | `auth.rbac.enabled` | `false` | Enable Role-Based Access Control |
 | `auth.rbac.roles` | `[]` | List of RBAC roles and permissions |
 
@@ -444,6 +533,41 @@ echo "https://kafka-ui.mycompany.com"
 | `kafkaConnect.enabled` | `false` | Enable Kafka Connect integration |
 | `kafkaConnect.name` | `connect-cluster` | Display name in the UI |
 | `kafkaConnect.url` | `""` (auto-computed) | Connect REST API URL |
+| `kafkaConnect.auth.enabled` | `false` | Enable basic auth to the Connect REST API |
+| `kafkaConnect.auth.username` / `password` / `existingSecret` | `""` | Connect credentials (password via Secret) |
+
+### ServiceAccount & Security
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `serviceAccount.create` | `true` | Create a dedicated ServiceAccount |
+| `serviceAccount.name` | `""` (fullname) | ServiceAccount name |
+| `serviceAccount.automountServiceAccountToken` | `false` | Mount the API token (not needed) |
+| `securityContext.readOnlyRootFilesystem` | `true` | Read-only root FS (chart mounts `/tmp` emptyDir) |
+| `extraVolumes` / `extraVolumeMounts` | `[]` | Extra volumes/mounts (custom truststores, serdes) |
+
+### NetworkPolicy
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `networkPolicy.enabled` | `true` | Create a NetworkPolicy |
+| `networkPolicy.ingressNamespace` | `ingress-nginx` | Namespace allowed to reach the UI |
+| `networkPolicy.monitoringNamespace` | `monitoring` | Namespace allowed to scrape metrics |
+| `networkPolicy.apiServerEgress` | `false` | Allow egress to the Kubernetes API server |
+| `networkPolicy.extraIngress` / `extraEgress` | `[]` | Extra rules appended verbatim |
+
+### Observability & HA
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `metrics.serviceMonitor.enabled` | `false` | Create a ServiceMonitor (needs Prometheus Operator) |
+| `metrics.serviceMonitor.path` | `/actuator/prometheus` | Metrics path |
+| `metrics.serviceMonitor.interval` | `30s` | Scrape interval |
+| `pdb.enabled` | `false` | Create a PodDisruptionBudget |
+| `pdb.minAvailable` / `maxUnavailable` | `1` / `""` | PDB thresholds |
+| `autoscaling.enabled` | `false` | Enable the HorizontalPodAutoscaler |
+| `autoscaling.minReplicas` / `maxReplicas` | `1` / `5` | HPA bounds |
+| `topologySpreadConstraints` | `[]` | Spread replicas across nodes/zones |
 
 ### Service
 

--- a/charts/kafka-ui/docs/01-setup.md
+++ b/charts/kafka-ui/docs/01-setup.md
@@ -1,0 +1,213 @@
+# 01 — Setup & Access
+
+End-to-end install of Kafka UI against a Strimzi Kafka cluster.
+
+## Prerequisites
+
+- A Kubernetes cluster (1.27+) with the **Strimzi** operator and a running
+  `Kafka` custom resource. Verify:
+
+  ```bash
+  kubectl get kafka -A
+  # NAMESPACE   NAME      READY
+  # kafka       krafter   True
+  ```
+
+- The Kafka cluster must expose a **SCRAM-SHA-512** listener (Kafka UI
+  authenticates with SCRAM). Check its listeners:
+
+  ```bash
+  kubectl get kafka krafter -n kafka \
+    -o jsonpath='{range .spec.kafka.listeners[*]}{.name}{" :"}{.port}{" auth="}{.authentication.type}{"\n"}{end}'
+  # plain :9092 auth=scram-sha-512
+  # tls   :9093 auth=tls
+  ```
+
+- Optional integrations: an Apicurio **Schema Registry** and a **Kafka Connect**
+  cluster (see guides [03](03-schema-registry.md) and [04](04-kafka-connect.md)).
+
+## Where to install it
+
+Kafka UI needs a SCRAM `KafkaUser` and its generated Secret. There are two
+patterns:
+
+1. **Chart-managed user (default).** Deploy Kafka UI **in the same namespace as
+   Kafka** and leave `kafkaUser.enabled=true`. The chart creates a `KafkaUser`
+   and Strimzi's User Operator generates the credential Secret. See
+   [02 — Kafka Connection & ACLs](02-kafka-and-acls.md).
+
+2. **Externally-managed user.** If the `KafkaUser` is owned by another release
+   (e.g. a platform chart), set `kafkaUser.enabled=false` and Kafka UI consumes
+   the existing Secret named after `kafkaUser.name`. Trying to adopt a
+   `KafkaUser` owned by another Helm release fails with an ownership error.
+
+## Install
+
+```bash
+helm upgrade --install kafka-ui charts/kafka-ui \
+  --namespace kafka \
+  --set kafka.clusterName=krafter \
+  --set service.type=NodePort --set service.nodePort=30081 \
+  --set auth.enabled=true --set auth.type=LOGIN_FORM \
+  --wait --timeout 3m
+```
+
+### Environment overlays
+
+Pre-built value files ship with the chart:
+
+| Overlay | Use |
+|---------|-----|
+| `values-kind.yaml` | Local Kind (NodePort 30081, `kafkaUser.enabled=false`, SR/Connect on) |
+| `values-dev.yaml` | Dev (SR + Connect integration) |
+| `values-prod.yaml` | Production (2 replicas, PDB, topology spread, ServiceMonitor, TLS, Ingress) |
+
+```bash
+helm upgrade --install kafka-ui charts/kafka-ui -n kafka -f charts/kafka-ui/values-prod.yaml --wait
+```
+
+## Web login
+
+When `auth.enabled=true` and `auth.type=LOGIN_FORM`, the UI requires a login.
+The password is **generated randomly on first install and preserved across
+upgrades** — it is never a well-known default.
+
+- **Username:** `auth.username` (defaults to `admin`).
+- **Password:** stored in the Secret named by `auth.passwordSecret` (defaults to
+  `kafka-ui-web-password`), under the key `password`.
+
+### Get the password
+
+The same one-liner works whether the password was auto-generated, set via
+`auth.password`, or later rotated — always read it back from the Secret rather
+than assuming a value:
+
+```bash
+kubectl get secret kafka-ui-web-password -n kafka \
+  -o jsonpath='{.data.password}' | base64 -d; echo
+```
+
+Adjust the Secret name if you changed `auth.passwordSecret`, or the namespace if
+you installed elsewhere. Print username and password together:
+
+```bash
+NS=kafka
+echo "user: $(helm get values kafka-ui -n $NS -o json | \
+  python3 -c 'import sys,json;print(json.load(sys.stdin).get("auth",{}).get("username","admin"))')"
+echo "pass: $(kubectl get secret kafka-ui-web-password -n $NS -o jsonpath='{.data.password}' | base64 -d)"
+```
+
+If you use your own Secret (`auth.existingSecret`), read the password from that
+Secret instead (key `password`).
+
+### Rotate the password, then read the new one
+
+Delete the Secret so the chart mints a fresh random password, upgrade, restart
+the pod to load it, then read it back:
+
+```bash
+# 1. Remove the current Secret (it carries helm.sh/resource-policy: keep,
+#    so a plain `helm upgrade` will NOT rotate it on its own)
+kubectl delete secret kafka-ui-web-password -n kafka
+
+# 2. Regenerate (a new random password is created because none exists now)
+helm upgrade kafka-ui charts/kafka-ui -n kafka --reuse-values --wait
+
+# 3. Restart so the pod picks up the new value (env is read at startup)
+kubectl rollout restart deploy/kafka-ui -n kafka
+kubectl rollout status  deploy/kafka-ui -n kafka
+
+# 4. Read the rotated password
+kubectl get secret kafka-ui-web-password -n kafka \
+  -o jsonpath='{.data.password}' | base64 -d; echo
+```
+
+To rotate to a **specific** value instead of a random one, skip the delete and
+set it explicitly:
+
+```bash
+helm upgrade kafka-ui charts/kafka-ui -n kafka --reuse-values \
+  --set auth.password='my-new-password' --wait
+kubectl rollout restart deploy/kafka-ui -n kafka
+```
+
+### Manage the password yourself
+
+```yaml
+auth:
+  enabled: true
+  type: LOGIN_FORM
+  username: admin
+  password: "my-password"          # chart creates the Secret from this
+  # existingSecret: my-ui-secret   # …or bring your own (key: password)
+```
+
+## Access the UI
+
+```bash
+# NodePort
+echo "http://$(kubectl get node -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'):30081"
+
+# Port-forward (works anywhere)
+kubectl port-forward svc/kafka-ui 8080:8080 -n kafka
+#   → http://localhost:8080
+```
+
+For production, use an Ingress:
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: kafka-ui.example.com
+      paths: [{ path: /, pathType: Prefix }]
+  tls:
+    - secretName: kafka-ui-tls
+      hosts: [kafka-ui.example.com]
+```
+
+## Verify
+
+```bash
+# Health endpoint
+kubectl exec deploy/kafka-ui -n kafka -- wget -qO- http://localhost:8080/actuator/health
+# {"status":"UP","groups":["liveness","readiness"]}
+
+# Chart test suite (probes /actuator/health)
+helm test kafka-ui -n kafka
+
+# Logs — confirm the cluster is being scraped
+kubectl logs deploy/kafka-ui -n kafka | grep -i "Metrics updated for cluster"
+```
+
+## Security hardening (defaults)
+
+The chart runs hardened out of the box:
+
+- Dedicated `ServiceAccount` with `automountServiceAccountToken: false` (Kafka UI does not call the Kubernetes API).
+- `readOnlyRootFilesystem: true` with an `emptyDir` mounted at `/tmp`.
+- Non-root (`runAsUser: 1001`), all capabilities dropped, no privilege escalation.
+- A scoped `NetworkPolicy` (browser via the ingress controller, Prometheus scrape, egress only to Kafka + enabled integrations + DNS; **no** Kubernetes API-server egress unless `networkPolicy.apiServerEgress=true`).
+
+## Observability
+
+Kafka UI exposes Prometheus metrics at `/actuator/prometheus`.
+
+```yaml
+metrics:
+  serviceMonitor:
+    enabled: true          # requires the Prometheus Operator CRDs
+    labels:
+      release: monitoring  # match your Prometheus selector
+```
+
+## Uninstall
+
+```bash
+helm uninstall kafka-ui -n kafka
+```
+
+A chart-managed `KafkaUser` carries `helm.sh/resource-policy: keep`, so the
+Strimzi Secret survives uninstall to avoid disrupting other consumers. Delete it
+manually if you truly want it gone.

--- a/charts/kafka-ui/docs/02-kafka-and-acls.md
+++ b/charts/kafka-ui/docs/02-kafka-and-acls.md
@@ -1,0 +1,187 @@
+# 02 — Kafka Connection & ACLs
+
+How Kafka UI connects to the brokers, authenticates with SCRAM, and what
+**authorization (ACLs)** it needs.
+
+## Connection
+
+### Auto-discovery (default)
+
+The chart computes the bootstrap address from `kafka.clusterName` and the
+namespace:
+
+```yaml
+kafka:
+  clusterName: krafter          # the Strimzi Kafka CR name
+  namespace: ""                 # defaults to the release namespace
+  clusterDomain: cluster.local
+```
+
+Resolves to `krafter-kafka-bootstrap.<namespace>.svc.cluster.local:9092`
+(`:9092` for plaintext SCRAM, `:9093` when `kafka.tls.enabled=true`).
+
+### Explicit bootstrap
+
+```yaml
+kafka:
+  bootstrapServers: "my-kafka-bootstrap.prod.svc:9092"
+```
+
+## Authentication (SCRAM-SHA-512)
+
+Kafka UI authenticates as a Strimzi `KafkaUser` using SCRAM-SHA-512. The User
+Operator generates a Secret (named after the user) containing the password; the
+chart injects it into the pod as `KAFKA_UI_PASSWORD` and references it in the
+client `sasl.jaas.config`. The password is **never** written to the ConfigMap.
+
+The rendered client config (plaintext SCRAM listener):
+
+```yaml
+security.protocol: SASL_PLAINTEXT     # SASL_SSL when kafka.tls.enabled
+sasl.mechanism: SCRAM-SHA-512
+sasl.jaas.config: >-
+  org.apache.kafka.common.security.scram.ScramLoginModule required
+  username="kafka-ui" password="${KAFKA_UI_PASSWORD}";
+```
+
+### TLS to Kafka (SASL_SSL)
+
+Only if your cluster exposes a **SASL_SSL** listener (SCRAM over TLS). Note: a
+Strimzi `tls` listener with `authentication.type: tls` is **mutual TLS**, not
+SASL — do not point Kafka UI at it with SCRAM.
+
+```yaml
+kafka:
+  tls:
+    enabled: true
+    trustedCertificateSecret: krafter-cluster-ca-cert   # required when enabled
+    certificateKey: ca.crt
+```
+
+The chart mounts the CA at `/etc/kafka-ui/certs/<certificateKey>` and sets
+`ssl.truststore.location`. Enabling TLS without the Secret fails the render.
+
+## The KafkaUser
+
+### Chart-managed (same namespace as Kafka)
+
+With `kafkaUser.enabled=true` and Kafka UI deployed in the Kafka namespace, the
+chart renders a `KafkaUser`:
+
+```yaml
+kafkaUser:
+  enabled: true
+  name: kafka-ui
+  quotas:
+    producerByteRate: 1048576       # 1 MiB/s
+    consumerByteRate: 52428800      # 50 MiB/s
+    requestPercentage: 10           # cap broker request-handler usage
+  acls: [ ... ]                     # see below
+```
+
+### Externally-managed
+
+If another release owns the `KafkaUser` (e.g. a platform chart), set
+`kafkaUser.enabled=false`. Kafka UI then consumes the pre-existing Secret named
+`kafkaUser.name`. (Helm refuses to adopt a resource owned by another release.)
+
+## ACLs
+
+When the Kafka cluster has `authorization.type: simple` (or `opa`/`keycloak`),
+every operation is checked against the user's ACLs. Strimzi maps chart ACL
+entries to `AclRule`s. Grant **least privilege** for what you use Kafka UI for.
+
+### Read-only monitor (chart default)
+
+Enough to list/describe topics and consumer groups and to browse messages:
+
+```yaml
+kafkaUser:
+  acls:
+    - resource: { type: topic,   name: "*", patternType: literal }
+      operations: ["Describe", "Read"]
+    - resource: { type: group,   name: "*", patternType: literal }
+      operations: ["Describe", "Read"]
+    - resource: { type: cluster }
+      operations: ["Describe"]
+```
+
+| UI capability | Required operations |
+|---------------|---------------------|
+| List / describe topics, view configs | `topic:Describe`, `topic:DescribeConfigs` |
+| Browse messages (consume) | `topic:Read` + `group:Read` |
+| List / describe consumer groups | `group:Describe`, `group:Read` |
+| Cluster overview (brokers, controller) | `cluster:Describe` |
+
+> `Read` on a topic implies `Describe`; the explicit entries above are harmless
+> and make intent clear.
+
+### Read-write operator
+
+Add topic management and produce access. Prefer **prefix** patterns to scope by
+team/domain rather than `*`:
+
+```yaml
+kafkaUser:
+  acls:
+    - resource: { type: topic, name: "team-a.", patternType: prefix }
+      operations: ["Describe", "DescribeConfigs", "Read", "Write", "Create", "Delete", "Alter", "AlterConfigs"]
+    - resource: { type: group, name: "*", patternType: literal }
+      operations: ["Describe", "Read"]
+    - resource: { type: cluster }
+      operations: ["Describe"]
+```
+
+### Admin (create topics cluster-wide)
+
+Creating brand-new topics from the UI needs a cluster-level `Create` (or a
+topic `Create` on the target pattern):
+
+```yaml
+kafkaUser:
+  acls:
+    - resource: { type: cluster }
+      operations: ["Describe", "Create", "Alter", "AlterConfigs", "DescribeConfigs"]
+    - resource: { type: topic, name: "*", patternType: literal }
+      operations: ["Describe", "DescribeConfigs", "Read", "Write", "Create", "Delete", "Alter", "AlterConfigs"]
+    - resource: { type: group, name: "*", patternType: literal }
+      operations: ["Describe", "Read"]
+```
+
+### Supported operations & resource types
+
+- **Operations:** `Read`, `Write`, `Create`, `Delete`, `Alter`, `Describe`,
+  `AlterConfigs`, `DescribeConfigs`, `ClusterAction`, `IdempotentWrite`, `All`.
+- **Resource types:** `topic`, `group`, `cluster`, `transactionalId`.
+- **patternType:** `literal` (exact / `*`) or `prefix`.
+
+### Viewing the effective ACLs
+
+```bash
+# From the KafkaUser CR
+kubectl get kafkauser kafka-ui -n kafka \
+  -o jsonpath='{range .spec.authorization.acls[*]}{.resource.type}{" "}{.resource.name}{" -> "}{.operations}{"\n"}{end}'
+
+# From the broker (authoritative)
+kubectl exec krafter-<pool>-0 -n kafka -c kafka -- \
+  bin/kafka-acls.sh --bootstrap-server localhost:9092 \
+  --command-config /tmp/admin.properties \
+  --list --principal 'User:kafka-ui'
+```
+
+### Web-UI RBAC vs. Kafka ACLs — don't confuse them
+
+- **Kafka ACLs** (this page) authorize the *service account* Kafka UI uses to
+  talk to the brokers. They apply to everyone using the UI.
+- **Web-UI RBAC** (`auth.rbac`) authorizes *human logins* inside the UI
+  (who may view vs. edit). It needs multiple identities — a single Basic-Auth
+  user cannot exercise multiple RBAC roles. Use OAuth/LDAP for real RBAC.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| UI shows the cluster but no topics/messages | Missing `topic:Read` / `group:Read` ACLs |
+| `TopicAuthorizationException` in logs | ACL too narrow for the topic pattern in use |
+| `SaslAuthenticationException` | Wrong `kafkaUser.name`, missing Secret, or no SCRAM listener |
+| `disconnected` / timeouts | `NetworkPolicy` blocking egress, or wrong bootstrap port (9092 vs 9093) |

--- a/charts/kafka-ui/docs/03-schema-registry.md
+++ b/charts/kafka-ui/docs/03-schema-registry.md
@@ -1,0 +1,80 @@
+# 03 — Schema Registry (Apicurio)
+
+Integrate an Apicurio Registry so Kafka UI can resolve and display Avro / JSON
+Schema / Protobuf schemas for messages.
+
+Kafka UI talks to the registry through its **Confluent-compatible** API
+(`/apis/ccompat/v7`), so any Confluent-compatible registry works.
+
+## Enable
+
+```yaml
+schemaRegistry:
+  enabled: true
+  # Explicit URL (recommended)
+  url: "http://apicurio-apicurio-registry.kafka.svc:80/apis/ccompat/v7"
+```
+
+If `url` is empty, the chart auto-computes:
+`http://apicurio-apicurio-registry.<kafkaNamespace>.svc.<clusterDomain>:8080/apis/ccompat/v7`.
+
+> **Watch the port.** Apicurio's Service in this stack listens on **`:80`**, but
+> the auto-computed URL assumes `:8080`. Set `url` explicitly (with the correct
+> port) whenever your Service differs — the NetworkPolicy egress port is derived
+> from this URL, so a wrong port both breaks resolution *and* the egress rule.
+
+## Authentication
+
+For a registry that requires credentials. The password is **stored in a Secret
+and injected as an environment variable** (`SCHEMA_REGISTRY_PASSWORD`) — it is
+never rendered into the ConfigMap.
+
+```yaml
+schemaRegistry:
+  enabled: true
+  url: "https://registry.example.com/apis/ccompat/v7"
+  auth:
+    enabled: true
+    username: "kafka-ui"
+    password: "s3cr3t"              # chart creates <fullname>-schema-registry Secret
+    # existingSecret: my-sr-secret  # …or reference your own
+    # passwordKey: password
+```
+
+## Network policy
+
+When `networkPolicy.enabled=true`, the chart adds an egress rule to the Kafka
+namespace on the **port parsed from `schemaRegistry.url`**. If your registry
+lives in a *different* namespace, add an explicit rule:
+
+```yaml
+networkPolicy:
+  extraEgress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: registry-ns
+      ports:
+        - port: 8080
+          protocol: TCP
+```
+
+## Verify
+
+```bash
+# Registry reachable from the pod
+kubectl exec deploy/kafka-ui -n kafka -- \
+  wget -qO- http://apicurio-apicurio-registry.kafka.svc:80/apis/ccompat/v7/subjects
+# [] or a JSON list of subjects
+
+# In the UI: a topic carrying schematized messages shows a "Schema" tab with the
+# resolved value/key schema.
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| Messages show as raw bytes, no schema | `schemaRegistry.enabled=false`, wrong `url`, or unreachable registry |
+| Registry connection refused | Wrong port (Apicurio `:80` vs `:8080`), or NetworkPolicy egress blocked |
+| 401/403 from the registry | `schemaRegistry.auth` not set or wrong credentials |

--- a/charts/kafka-ui/docs/04-kafka-connect.md
+++ b/charts/kafka-ui/docs/04-kafka-connect.md
@@ -1,0 +1,95 @@
+# 04 — Kafka Connect
+
+Integrate a Kafka Connect cluster so Kafka UI can list connectors, inspect their
+status/tasks/config, and create or restart connectors from the browser.
+
+## Enable
+
+```yaml
+kafkaConnect:
+  enabled: true
+  name: "connect-cluster"        # display name in the UI
+  # Explicit REST API URL (recommended)
+  url: "http://connect-cluster-rest-api.connect.svc:8083"
+```
+
+If `url` is empty, the chart auto-computes:
+`http://connect-cluster-connect-api.<kafkaNamespace>.svc.<clusterDomain>:8083`.
+
+> **Cross-namespace is common.** Connect frequently runs in its own namespace
+> (e.g. `connect`), while the auto-computed URL assumes the Kafka namespace. Set
+> `url` explicitly to the real Service, and add a NetworkPolicy rule (below) —
+> the derived egress rule only targets the Kafka namespace.
+
+## Authentication
+
+For a Connect REST API secured with Basic Auth. The password is sourced from a
+Secret and injected as `KAFKA_CONNECT_PASSWORD` — never in the ConfigMap.
+
+```yaml
+kafkaConnect:
+  enabled: true
+  url: "http://connect-cluster-rest-api.connect.svc:8083"
+  auth:
+    enabled: true
+    username: "connect-admin"
+    password: "s3cr3t"                # chart creates <fullname>-kafka-connect Secret
+    # existingSecret: my-connect-secret
+    # passwordKey: password
+```
+
+## Network policy
+
+The chart derives the egress **port** from `kafkaConnect.url`, but targets the
+**Kafka namespace**. When Connect runs elsewhere, allow it explicitly:
+
+```yaml
+networkPolicy:
+  extraEgress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: connect
+      ports:
+        - port: 8083
+          protocol: TCP
+```
+
+## Multiple Connect clusters
+
+The chart currently configures a **single** Connect cluster. To wire additional
+ones, append to the rendered config via `extraConfig` (merged into `config.yml`):
+
+```yaml
+extraConfig:
+  kafka:
+    clusters:
+      - name: krafter
+        kafkaConnect:
+          - name: connect-a
+            address: http://connect-a-rest-api.connect.svc:8083
+          - name: connect-b
+            address: http://connect-b-rest-api.connect.svc:8083
+```
+
+> Multi-cluster and multi-Connect first-class support is a planned enhancement;
+> `extraConfig` is the escape hatch until then.
+
+## Verify
+
+```bash
+# Connect REST reachable from the pod
+kubectl exec deploy/kafka-ui -n kafka -- \
+  wget -qO- http://connect-cluster-rest-api.connect.svc:8083/connectors
+# [] or a JSON list of connector names
+
+# In the UI: the "Kafka Connect" section lists the cluster and its connectors.
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| "Kafka Connect" tab empty / cluster missing | `kafkaConnect.enabled=false` or wrong `url` |
+| Connection refused / timeout | Connect in another namespace + no `extraEgress` rule, or wrong port |
+| 401/403 from Connect | `kafkaConnect.auth` not set or wrong credentials |

--- a/charts/kafka-ui/docs/README.md
+++ b/charts/kafka-ui/docs/README.md
@@ -1,0 +1,48 @@
+# Kafka UI — Documentation
+
+Guides for deploying and configuring the `kafka-ui` chart (Kafbat UI) against a
+Strimzi-managed Kafka cluster, with Schema Registry and Kafka Connect
+integration.
+
+> These guides complement the [chart README](../README.md) (the parameter
+> reference). Start here for task-oriented, end-to-end walkthroughs.
+
+## Contents
+
+| Guide | What it covers |
+|-------|----------------|
+| [01 — Setup & Access](01-setup.md) | Prerequisites, install, overlays, web login, access, verification, hardening |
+| [02 — Kafka Connection & ACLs](02-kafka-and-acls.md) | Bootstrap discovery, SCRAM/TLS auth, the `KafkaUser`, and **ACLs** (monitor / read-write / admin) |
+| [03 — Schema Registry](03-schema-registry.md) | Apicurio (Confluent-compatible) integration, authentication, network policy |
+| [04 — Kafka Connect](04-kafka-connect.md) | Connect REST integration, cross-namespace access, authentication, network policy |
+
+## The stack these guides assume
+
+The examples target the reference stack in this repo (adjust names to your own):
+
+| Component | Value | Namespace |
+|-----------|-------|-----------|
+| Strimzi Kafka cluster | `krafter` | `kafka` |
+| SCRAM listener | `:9092` (`SASL_PLAINTEXT`, `scram-sha-512`) | `kafka` |
+| TLS listener | `:9093` (mutual TLS) | `kafka` |
+| Authorization | `simple` (ACLs enforced) | — |
+| Schema Registry (Apicurio) | `apicurio-apicurio-registry:80` | `kafka` |
+| Kafka Connect REST | `connect-cluster-rest-api:8083` | `connect` |
+
+## 60-second install
+
+```bash
+helm upgrade --install kafka-ui charts/kafka-ui -n kafka \
+  --set kafka.clusterName=krafter \
+  --set service.type=NodePort --set service.nodePort=30081 \
+  --set auth.enabled=true --set auth.type=LOGIN_FORM \
+  --wait
+
+# Web password (auto-generated on first install):
+kubectl get secret kafka-ui-web-password -n kafka -o jsonpath='{.data.password}' | base64 -d; echo
+
+# Verify:
+helm test kafka-ui -n kafka
+```
+
+See [01 — Setup & Access](01-setup.md) for the full walkthrough.

--- a/charts/kafka-ui/templates/NOTES.txt
+++ b/charts/kafka-ui/templates/NOTES.txt
@@ -36,3 +36,17 @@ Or via Ingress:
 Kafka cluster: {{ .Values.kafka.clusterName }}
 Bootstrap:     {{ include "kafka-ui.bootstrapServers" . }}
 KafkaUser:     {{ .Values.kafkaUser.name }}
+
+{{- if and .Values.auth.enabled (eq .Values.auth.type "LOGIN_FORM") }}
+
+Web login: {{ .Values.auth.username }}
+{{- if .Values.auth.existingSecret }}
+  Password: from your Secret "{{ .Values.auth.existingSecret }}" (key: password)
+{{- else }}
+  Retrieve the generated password:
+    kubectl get secret {{ .Values.auth.passwordSecret }} -n {{ include "kafka-ui.namespace" . }} -o jsonpath='{.data.password}' | base64 -d
+{{- end }}
+{{- end }}
+
+Verify the deployment:
+  helm test {{ .Release.Name }} -n {{ include "kafka-ui.namespace" . }}

--- a/charts/kafka-ui/templates/_helpers.tpl
+++ b/charts/kafka-ui/templates/_helpers.tpl
@@ -44,6 +44,9 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/component: dashboard
 app.kubernetes.io/part-of: kates
+{{- with .Values.extraLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -132,6 +135,40 @@ KafkaUser secret name — the Strimzi-generated SCRAM credential.
 */}}
 {{- define "kafka-ui.secretName" -}}
 {{- .Values.kafkaUser.name | default "kafka-ui" -}}
+{{- end -}}
+
+{{/*
+ServiceAccount name to use.
+*/}}
+{{- define "kafka-ui.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- .Values.serviceAccount.name | default (include "kafka-ui.fullname" .) -}}
+{{- else -}}
+{{- .Values.serviceAccount.name | default "default" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+TCP port of the Schema Registry endpoint, derived from its URL
+(explicit :port wins; else 443 for https, 80 for http).
+*/}}
+{{- define "kafka-ui.schemaRegistryPort" -}}
+{{- $url := include "kafka-ui.schemaRegistryUrl" . -}}
+{{- $host := (urlParse $url).host -}}
+{{- if contains ":" $host -}}
+{{- $host | splitList ":" | last -}}
+{{- else if hasPrefix "https" $url -}}443{{- else -}}80{{- end -}}
+{{- end -}}
+
+{{/*
+TCP port of the Kafka Connect endpoint, derived from its URL.
+*/}}
+{{- define "kafka-ui.kafkaConnectPort" -}}
+{{- $url := include "kafka-ui.kafkaConnectUrl" . -}}
+{{- $host := (urlParse $url).host -}}
+{{- if contains ":" $host -}}
+{{- $host | splitList ":" | last -}}
+{{- else if hasPrefix "https" $url -}}443{{- else -}}80{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/kafka-ui/templates/configmap.yaml
+++ b/charts/kafka-ui/templates/configmap.yaml
@@ -24,19 +24,25 @@ data:
               password="${KAFKA_UI_PASSWORD}";
             {{- if .Values.kafka.tls.enabled }}
             ssl.truststore.type: PEM
+            ssl.truststore.location: /etc/kafka-ui/certs/{{ .Values.kafka.tls.certificateKey | default "ca.crt" }}
             {{- end }}
           {{- if .Values.schemaRegistry.enabled }}
           schemaRegistry: {{ include "kafka-ui.schemaRegistryUrl" . }}
           {{- if .Values.schemaRegistry.auth.enabled }}
           schemaRegistryAuth:
             username: {{ .Values.schemaRegistry.auth.username }}
-            password: {{ .Values.schemaRegistry.auth.password }}
+            # Password is injected from a Secret via the env var below.
+            password: ${SCHEMA_REGISTRY_PASSWORD}
           {{- end }}
           {{- end }}
           {{- if .Values.kafkaConnect.enabled }}
           kafkaConnect:
             - name: {{ .Values.kafkaConnect.name | default "connect-cluster" }}
               address: {{ include "kafka-ui.kafkaConnectUrl" . }}
+              {{- if .Values.kafkaConnect.auth.enabled }}
+              username: {{ .Values.kafkaConnect.auth.username }}
+              password: ${KAFKA_CONNECT_PASSWORD}
+              {{- end }}
           {{- end }}
 
     auth:

--- a/charts/kafka-ui/templates/deployment.yaml
+++ b/charts/kafka-ui/templates/deployment.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "kafka-ui.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "kafka-ui.selectorLabels" . | nindent 6 }}
@@ -20,6 +22,8 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      serviceAccountName: {{ include "kafka-ui.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -48,12 +52,26 @@ spec:
                 secretKeyRef:
                   name: {{ include "kafka-ui.secretName" . }}
                   key: password
-            {{- if and .Values.auth.enabled (eq .Values.auth.type "LOGIN_FORM") .Values.auth.passwordSecret }}
+            {{- if and .Values.auth.enabled (eq .Values.auth.type "LOGIN_FORM") }}
             - name: KAFKA_UI_WEB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.auth.passwordSecret }}
+                  name: {{ .Values.auth.existingSecret | default .Values.auth.passwordSecret }}
                   key: password
+            {{- end }}
+            {{- if and .Values.schemaRegistry.enabled .Values.schemaRegistry.auth.enabled }}
+            - name: SCHEMA_REGISTRY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.schemaRegistry.auth.existingSecret | default (printf "%s-schema-registry" (include "kafka-ui.fullname" .)) }}
+                  key: {{ .Values.schemaRegistry.auth.passwordKey | default "password" }}
+            {{- end }}
+            {{- if and .Values.kafkaConnect.enabled .Values.kafkaConnect.auth.enabled }}
+            - name: KAFKA_CONNECT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.kafkaConnect.auth.existingSecret | default (printf "%s-kafka-connect" (include "kafka-ui.fullname" .)) }}
+                  key: {{ .Values.kafkaConnect.auth.passwordKey | default "password" }}
             {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
@@ -61,6 +79,16 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/kafkaui
+            {{- if .Values.kafka.tls.enabled }}
+            - name: kafka-certs
+              mountPath: /etc/kafka-ui/certs
+              readOnly: true
+            {{- end }}
+            - name: tmp
+              mountPath: /tmp
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -99,12 +127,26 @@ spec:
         - name: config
           configMap:
             name: {{ include "kafka-ui.fullname" . }}-config
+        {{- if .Values.kafka.tls.enabled }}
+        - name: kafka-certs
+          secret:
+            secretName: {{ required "kafka.tls.trustedCertificateSecret is required when kafka.tls.enabled" .Values.kafka.tls.trustedCertificateSecret }}
+        {{- end }}
+        - name: tmp
+          emptyDir: {}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}

--- a/charts/kafka-ui/templates/hpa.yaml
+++ b/charts/kafka-ui/templates/hpa.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "kafka-ui.fullname" . }}
+  namespace: {{ include "kafka-ui.namespace" . }}
+  labels:
+    {{- include "kafka-ui.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "kafka-ui.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas | default 1 }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas | default 5 }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/kafka-ui/templates/networkpolicy.yaml
+++ b/charts/kafka-ui/templates/networkpolicy.yaml
@@ -33,10 +33,13 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: monitoring
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.monitoringNamespace | default "monitoring" }}
       ports:
         - port: 8080
           protocol: TCP
+    {{- with .Values.networkPolicy.extraIngress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   egress:
     # DNS resolution
     - to: []
@@ -59,28 +62,35 @@ spec:
         - port: 9093
           protocol: TCP
     {{- if .Values.schemaRegistry.enabled }}
-    # To Schema Registry (Apicurio)
+    # To Schema Registry (port derived from schemaRegistry.url)
     - to:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: {{ include "kafka-ui.kafkaNamespace" . }}
       ports:
-        - port: 8080
+        - port: {{ include "kafka-ui.schemaRegistryPort" . }}
           protocol: TCP
     {{- end }}
     {{- if .Values.kafkaConnect.enabled }}
-    # To Kafka Connect REST API
+    # To Kafka Connect REST API (port derived from kafkaConnect.url)
     - to:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: {{ include "kafka-ui.kafkaNamespace" . }}
       ports:
-        - port: 8083
+        - port: {{ include "kafka-ui.kafkaConnectPort" . }}
           protocol: TCP
     {{- end }}
-    # Kubernetes API server (for Secret reads and health checks)
+    {{- if .Values.networkPolicy.apiServerEgress }}
+    # Kubernetes API server (only if explicitly enabled)
     - to: []
       ports:
         - port: 443
           protocol: TCP
+        - port: 6443
+          protocol: TCP
+    {{- end }}
+    {{- with .Values.networkPolicy.extraEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/kafka-ui/templates/pdb.yaml
+++ b/charts/kafka-ui/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "kafka-ui.fullname" . }}
+  namespace: {{ include "kafka-ui.namespace" . }}
+  labels:
+    {{- include "kafka-ui.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "kafka-ui.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/kafka-ui/templates/secret.yaml
+++ b/charts/kafka-ui/templates/secret.yaml
@@ -1,18 +1,52 @@
-{{- if and .Values.auth.enabled (eq .Values.auth.type "LOGIN_FORM") }}
+{{- $ns := include "kafka-ui.namespace" . -}}
+{{- if and .Values.auth.enabled (eq .Values.auth.type "LOGIN_FORM") (not .Values.auth.existingSecret) }}
 {{- $secretName := .Values.auth.passwordSecret }}
-{{- $secret := lookup "v1" "Secret" .Release.Namespace $secretName }}
+{{- $existing := lookup "v1" "Secret" $ns $secretName }}
+{{- $pw := "" }}
+{{- if .Values.auth.password }}
+{{- $pw = .Values.auth.password }}
+{{- else if and $existing $existing.data (index $existing.data "password") }}
+{{- $pw = (index $existing.data "password" | b64dec) }}
+{{- else }}
+{{- $pw = randAlphaNum 24 }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "kafka-ui.labels" . | nindent 4 }}
+  annotations:
+    # Preserve a generated password across upgrades / helm history.
+    helm.sh/resource-policy: keep
+type: Opaque
+data:
+  password: {{ $pw | b64enc | quote }}
+{{- end }}
+{{- if and .Values.schemaRegistry.enabled .Values.schemaRegistry.auth.enabled (not .Values.schemaRegistry.auth.existingSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kafka-ui.fullname" . }}-schema-registry
+  namespace: {{ $ns }}
   labels:
     {{- include "kafka-ui.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- if $secret }}
-  password: {{ index $secret.data "password" }}
-  {{- else }}
-  password: {{ "admin" | b64enc }}
-  {{- end }}
+  {{ .Values.schemaRegistry.auth.passwordKey | default "password" }}: {{ .Values.schemaRegistry.auth.password | b64enc | quote }}
+{{- end }}
+{{- if and .Values.kafkaConnect.enabled .Values.kafkaConnect.auth.enabled (not .Values.kafkaConnect.auth.existingSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kafka-ui.fullname" . }}-kafka-connect
+  namespace: {{ $ns }}
+  labels:
+    {{- include "kafka-ui.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ .Values.kafkaConnect.auth.passwordKey | default "password" }}: {{ .Values.kafkaConnect.auth.password | b64enc | quote }}
 {{- end }}

--- a/charts/kafka-ui/templates/serviceaccount.yaml
+++ b/charts/kafka-ui/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kafka-ui.serviceAccountName" . }}
+  namespace: {{ include "kafka-ui.namespace" . }}
+  labels:
+    {{- include "kafka-ui.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/kafka-ui/templates/servicemonitor.yaml
+++ b/charts/kafka-ui/templates/servicemonitor.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.metrics.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+{{- $sm := .Values.metrics.serviceMonitor }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "kafka-ui.fullname" . }}
+  namespace: {{ include "kafka-ui.namespace" . }}
+  labels:
+    {{- include "kafka-ui.labels" . | nindent 4 }}
+    {{- with $sm.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "kafka-ui.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ include "kafka-ui.namespace" . }}
+  endpoints:
+    - port: http
+      path: {{ $sm.path | default "/actuator/prometheus" }}
+      interval: {{ $sm.interval | default "30s" }}
+      {{- with $sm.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      honorLabels: {{ $sm.honorLabels | default false }}
+      {{- with $sm.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $sm.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/kafka-ui/templates/tests/test-connection.yaml
+++ b/charts/kafka-ui/templates/tests/test-connection.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "kafka-ui.fullname" . }}-test-connection
+  namespace: {{ include "kafka-ui.namespace" . }}
+  labels:
+    {{- include "kafka-ui.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: test
+      image: busybox:1.36
+      command: ['sh', '-c']
+      args:
+        - |
+          echo "Probing Kafka UI health endpoint..."
+          for i in $(seq 1 15); do
+            if wget -q -O- --timeout=5 \
+              "http://{{ include "kafka-ui.fullname" . }}.{{ include "kafka-ui.namespace" . }}.svc.{{ .Values.kafka.clusterDomain | default "cluster.local" }}:{{ .Values.service.port }}/actuator/health" \
+              2>/dev/null | grep -q '"status":"UP"'; then
+              echo "✅ Kafka UI is UP"
+              exit 0
+            fi
+            echo "Attempt $i/15..."
+            sleep 4
+          done
+          echo "❌ Kafka UI did not report UP"
+          exit 1

--- a/charts/kafka-ui/values-prod.yaml
+++ b/charts/kafka-ui/values-prod.yaml
@@ -4,6 +4,9 @@ replicas: 2
 auth:
   enabled: true
   type: "LOGIN_FORM"
+  # Web password is auto-generated and preserved across upgrades. Retrieve with:
+  #   kubectl get secret kafka-ui-web-password -o jsonpath='{.data.password}' | base64 -d
+  # Or set auth.existingSecret / auth.password to manage it yourself.
 
 ingress:
   enabled: true
@@ -23,6 +26,9 @@ ingress:
 kafka:
   tls:
     enabled: true
+    # Strimzi-generated cluster CA cert (named <clusterName>-cluster-ca-cert)
+    trustedCertificateSecret: krafter-cluster-ca-cert
+    certificateKey: ca.crt
 
 schemaRegistry:
   enabled: true
@@ -35,3 +41,22 @@ kafkaConnect:
 
 networkPolicy:
   enabled: true
+
+# Spread the two replicas and protect them during disruptions.
+pdb:
+  enabled: true
+  minAvailable: 1
+
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app: kafka-ui
+
+metrics:
+  serviceMonitor:
+    enabled: true
+    labels:
+      release: monitoring

--- a/charts/kafka-ui/values.schema.json
+++ b/charts/kafka-ui/values.schema.json
@@ -1,0 +1,192 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string", "minLength": 1 },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
+        "digest": { "type": "string" }
+      }
+    },
+    "imagePullSecrets": { "type": "array" },
+    "replicas": { "type": "integer", "minimum": 0 },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "namespaceOverride": { "type": "string" },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean" },
+        "name": { "type": "string" },
+        "annotations": { "type": "object" },
+        "automountServiceAccountToken": { "type": "boolean" }
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "nodePort": { "type": ["integer", "string"] },
+        "annotations": { "type": "object" }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "className": { "type": "string" },
+        "annotations": { "type": "object" },
+        "hosts": { "type": "array" },
+        "tls": { "type": "array" }
+      }
+    },
+    "kafka": {
+      "type": "object",
+      "properties": {
+        "clusterName": { "type": "string", "minLength": 1 },
+        "namespace": { "type": "string" },
+        "bootstrapServers": { "type": "string" },
+        "clusterDomain": { "type": "string" },
+        "tls": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "trustedCertificateSecret": { "type": "string" },
+            "certificateKey": { "type": "string" }
+          }
+        }
+      }
+    },
+    "schemaRegistry": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "url": { "type": "string" },
+        "auth": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "username": { "type": "string" },
+            "password": { "type": "string" },
+            "existingSecret": { "type": "string" },
+            "passwordKey": { "type": "string" }
+          }
+        }
+      }
+    },
+    "kafkaConnect": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "name": { "type": "string" },
+        "url": { "type": "string" },
+        "auth": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "username": { "type": "string" },
+            "password": { "type": "string" },
+            "existingSecret": { "type": "string" },
+            "passwordKey": { "type": "string" }
+          }
+        }
+      }
+    },
+    "auth": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "type": { "type": "string", "enum": ["DISABLED", "LOGIN_FORM"] },
+        "username": { "type": "string" },
+        "passwordSecret": { "type": "string" },
+        "password": { "type": "string" },
+        "existingSecret": { "type": "string" },
+        "rbac": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "roles": { "type": "array" }
+          }
+        }
+      }
+    },
+    "kafkaUser": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "name": { "type": "string" },
+        "quotas": { "type": "object" },
+        "acls": { "type": "array" }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "ingressNamespace": { "type": "string" },
+        "monitoringNamespace": { "type": "string" },
+        "apiServerEgress": { "type": "boolean" },
+        "extraIngress": { "type": "array" },
+        "extraEgress": { "type": "array" }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "properties": {
+        "serviceMonitor": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "path": { "type": "string" },
+            "interval": { "type": "string", "pattern": "^[0-9]+[smh]$" },
+            "scrapeTimeout": { "type": "string" },
+            "honorLabels": { "type": "boolean" },
+            "labels": { "type": "object" },
+            "relabelings": { "type": "array" },
+            "metricRelabelings": { "type": "array" }
+          }
+        }
+      }
+    },
+    "pdb": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minAvailable": { "type": ["integer", "string"] },
+        "maxUnavailable": { "type": ["integer", "string"] }
+      }
+    },
+    "autoscaling": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minReplicas": { "type": "integer", "minimum": 1 },
+        "maxReplicas": { "type": "integer", "minimum": 1 },
+        "targetCPUUtilizationPercentage": { "type": ["integer", "string"] },
+        "targetMemoryUtilizationPercentage": { "type": ["integer", "string"] }
+      }
+    },
+    "resources": { "type": "object" },
+    "livenessProbe": { "type": "object" },
+    "readinessProbe": { "type": "object" },
+    "startupProbe": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "podAnnotations": { "type": "object" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array" },
+    "affinity": { "type": "object" },
+    "topologySpreadConstraints": { "type": "array" },
+    "extraVolumes": { "type": "array" },
+    "extraVolumeMounts": { "type": "array" },
+    "extraEnv": { "type": "array" },
+    "extraLabels": { "type": "object" },
+    "extraConfig": { "type": "object" },
+    "logging": { "type": "object" }
+  }
+}

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -14,13 +14,22 @@ image:
 imagePullSecrets: []
 #  - name: ghcr-credentials
 
-# -- Number of replicas
+# -- Number of replicas (ignored when autoscaling.enabled)
 replicas: 1
 
 # -- Override names
 nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
+
+# -- ServiceAccount for the Kafka UI pod. Kafka UI does not call the Kubernetes
+# API, so the token is not mounted by default.
+serviceAccount:
+  create: true
+  # -- Name (defaults to the fullname when create=true)
+  name: ""
+  annotations: {}
+  automountServiceAccountToken: false
 
 # -- Service configuration
 service:
@@ -60,11 +69,16 @@ schemaRegistry:
   enabled: false
   # -- Schema Registry URL (e.g., Apicurio Registry)
   url: ""
-  # -- Authentication for Schema Registry
+  # -- Authentication for Schema Registry. The password is sourced from a
+  # Secret and injected as an env var — never rendered into the ConfigMap.
   auth:
     enabled: false
     username: ""
+    # -- Password (used to create a Secret when existingSecret is empty)
     password: ""
+    # -- Use an existing Secret instead of creating one
+    existingSecret: ""
+    passwordKey: "password"
 
 # -- Kafka Connect integration (shows connectors in Kafka UI)
 kafkaConnect:
@@ -73,6 +87,13 @@ kafkaConnect:
   name: "connect-cluster"
   # -- Kafka Connect REST API URL
   url: ""
+  # -- Basic auth for the Connect REST API (password injected from a Secret)
+  auth:
+    enabled: false
+    username: ""
+    password: ""
+    existingSecret: ""
+    passwordKey: "password"
 
 # -- Kafka UI application authentication (login to the web UI itself)
 auth:
@@ -82,8 +103,15 @@ auth:
   type: "DISABLED"
   # -- Username for Basic Authentication (when type is LOGIN_FORM)
   username: "admin"
-  # -- The name of the Kubernetes Secret containing the password (in a key named 'password')
+  # -- The name of the Kubernetes Secret containing the password (key 'password').
+  # Created by the chart if it does not already exist.
   passwordSecret: "kafka-ui-web-password"
+  # -- Explicit web password. When empty, a random password is generated on
+  # first install and preserved across upgrades (via lookup). Never defaults
+  # to a well-known value.
+  password: ""
+  # -- Use a pre-existing Secret (key 'password') instead of managing one
+  existingSecret: ""
   
   # -- Role-Based Access Control (RBAC) settings for Kafka UI
   rbac:
@@ -169,6 +197,14 @@ networkPolicy:
   enabled: true
   # -- Namespace of the ingress controller (for browser access restriction)
   ingressNamespace: "ingress-nginx"
+  # -- Namespace allowed to scrape metrics (Prometheus)
+  monitoringNamespace: "monitoring"
+  # -- Allow egress to the Kubernetes API server. Off by default — Kafka UI
+  # does not call the API (Secrets are injected by the kubelet).
+  apiServerEgress: false
+  # -- Extra ingress/egress rules appended verbatim
+  extraIngress: []
+  extraEgress: []
 
 # -- Pod annotations (e.g., Prometheus scraping)
 podAnnotations: {}
@@ -212,10 +248,11 @@ podSecurityContext:
   runAsUser: 1001
   fsGroup: 1001
 
-# -- Container-level security context
+# -- Container-level security context. readOnlyRootFilesystem is on; the chart
+# mounts an emptyDir at /tmp for the app's scratch space.
 securityContext:
   allowPrivilegeEscalation: false
-  readOnlyRootFilesystem: false
+  readOnlyRootFilesystem: true
   capabilities:
     drop:
       - ALL
@@ -228,6 +265,47 @@ tolerations: []
 
 # -- Affinity rules
 affinity: {}
+
+# -- Topology spread constraints (spread replicas across nodes/zones)
+topologySpreadConstraints: []
+#  - maxSkew: 1
+#    topologyKey: topology.kubernetes.io/zone
+#    whenUnsatisfiable: ScheduleAnyway
+#    labelSelector:
+#      matchLabels:
+#        app: kafka-ui
+
+# -- PodDisruptionBudget (recommended when replicas > 1)
+pdb:
+  enabled: false
+  minAvailable: 1
+  maxUnavailable: ""
+
+# -- Horizontal Pod Autoscaler
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: ""
+
+# -- Prometheus monitoring integration
+metrics:
+  serviceMonitor:
+    # -- Create a ServiceMonitor (requires the Prometheus Operator CRDs)
+    enabled: false
+    # -- Metrics path exposed by Kafka UI (Spring Boot Actuator)
+    path: /actuator/prometheus
+    interval: 30s
+    scrapeTimeout: ""
+    honorLabels: false
+    labels: {}
+    relabelings: []
+    metricRelabelings: []
+
+# -- Extra volumes / mounts (e.g. custom truststores, serde descriptors)
+extraVolumes: []
+extraVolumeMounts: []
 
 # -- Extra environment variables
 extraEnv: []

--- a/docs/book/appendix-d-versions.md
+++ b/docs/book/appendix-d-versions.md
@@ -18,7 +18,7 @@ Every version the platform pins, in one place. This table is generated from the 
 | `connect-cluster` chart | 1.2.0 (app 4.2.0) | `charts/connect-cluster/Chart.yaml` |
 | `headlamp` chart | 0.1.0 (app 0.40.1) | `charts/headlamp/Chart.yaml` |
 | `kafka-cluster` chart | 0.1.1 (app 4.2.0) | `charts/kafka-cluster/Chart.yaml` |
-| `kafka-ui` chart | 0.2.0 (app v1.5.0) | `charts/kafka-ui/Chart.yaml` |
+| `kafka-ui` chart | 0.3.0 (app v1.5.0) | `charts/kafka-ui/Chart.yaml` |
 | `kates-chaos` chart | 2.0.0 (app 3.28.0) | `charts/kates-chaos/Chart.yaml` |
 | `kates-platform` chart | 0.2.0 (app 1.0.0) | `charts/kates-platform/Chart.yaml` |
 | `kates` chart | 0.4.4 (app 1.20.0) | `charts/kates/Chart.yaml` |


### PR DESCRIPTION
## Why

The `kafka-ui` chart is clean but lagged the repo's more mature charts (`connect-cluster`, `kates-chaos`) on validation, observability, HA, and hardening — and it had real bugs, one of which broke the production path.

## Bug fixes

- **TLS to Kafka was broken.** `kafka.tls.enabled=true` set `security.protocol: SASL_SSL` and `ssl.truststore.type: PEM` but **never mounted the CA cert nor set `ssl.truststore.location`** — so `kafka.tls.trustedCertificateSecret`/`certificateKey` were dead config and the prod overlay (which enables TLS) couldn't verify the broker cert. Now the Secret is mounted at `/etc/kafka-ui/certs` and the truststore location is set; `trustedCertificateSecret` is `required()` when TLS is on (clear error instead of a silent failure).
- **Schema Registry / Connect passwords leaked into the ConfigMap in plaintext.** They're now sourced from Secrets and injected via env vars (`${SCHEMA_REGISTRY_PASSWORD}`, `${KAFKA_CONNECT_PASSWORD}`), like the Kafka SASL password already was.
- **NetworkPolicy dropped Schema Registry traffic.** Egress only opened port `8080`, but the kind overlay points SR at `:80`. Egress ports are now derived from the SR/Connect URLs.
- **Default web password was `admin`.** Now a random password is generated on first install and preserved across upgrades via `lookup`; `auth.password` / `auth.existingSecret` supported.
- Dropped the unnecessary Kubernetes API-server egress (gated behind `networkPolicy.apiServerEgress`); wired `extraLabels` (declared but never applied).

## Hardening

- Dedicated `ServiceAccount` with `automountServiceAccountToken: false` (Kafka UI never calls the API).
- `readOnlyRootFilesystem: true` with an `emptyDir` mounted at `/tmp`.

## Observability & HA

- `ServiceMonitor` (path `/actuator/prometheus`), `PodDisruptionBudget`, `HorizontalPodAutoscaler`, `topologySpreadConstraints`, and a Helm test that probes `/actuator/health`. The prod overlay enables PDB + spread + ServiceMonitor and pins the Strimzi cluster CA secret.

## Configurability & docs

- `values.schema.json`; `extraVolumes`/`extraVolumeMounts`; Kafka Connect basic auth; configurable NetworkPolicy monitoring namespace + `extraIngress`/`extraEgress`.
- README: new TLS, Secret-auth, Observability, HA, and Security sections + expanded parameter tables. Chart `0.2.0 → 0.3.0` with artifacthub annotations; root README chart table + book version matrix synced.

## Notes for reviewers

- **Behavioral changes to review:** `readOnlyRootFilesystem` flips to `true`; enabling `kafka.tls` now requires `trustedCertificateSecret`; the API-server egress is removed by default. These are the intended fixes, but call them out for anyone relying on the old (broken) behavior.
- **Not runtime-verified:** validation is render/lint/schema-level. `readOnlyRootFilesystem: true` is covered by the `/tmp` emptyDir for Spring Boot's usual scratch needs, but hasn't been confirmed against a live pod — easy to relax if kafbat writes elsewhere.
- **Left as a follow-up:** full multi-cluster support (the chart still models a single Kafka cluster) — the biggest change, deserves its own pass.
- Verified: `helm lint` + `helm template` pass across `values.yaml` and all four overlays; rendered manifests parse; schema rejects bad enums; `gen-chart-table`/`gen-version-matrix` checks pass.
