### PR TITLE
feat: upgrade Strimzi Operator to 1.1.0 and Kafka to 4.3.0

### DIFF
--- a/Dockerfile.connect
+++ b/Dockerfile.connect
@@ -1,4 +1,4 @@
-FROM quay.io/strimzi/kafka:1.0.0-kafka-4.2.0 AS base
+FROM quay.io/strimzi/kafka:1.1.0-kafka-4.3.0 AS base
 # Trigger build
 # ─── Stage 1: Download connector plugins ─────────────────────────────────────
 #
@@ -110,6 +110,6 @@ LABEL org.opencontainers.image.url="https://github.com/bmscomp/kates/pkgs/contai
 LABEL org.opencontainers.image.documentation="https://github.com/bmscomp/kates/blob/main/docs/kafka-connect.md"
 LABEL org.opencontainers.image.vendor="bmscomp"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
-LABEL org.opencontainers.image.base.name="quay.io/strimzi/kafka:1.0.0-kafka-4.2.0"
+LABEL org.opencontainers.image.base.name="quay.io/strimzi/kafka:1.1.0-kafka-4.3.0"
 LABEL io.debezium.version="${DEBEZIUM_VERSION}"
 LABEL io.aiven.jdbc.version="${AIVEN_JDBC_VERSION}"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
     <a href="https://github.com/bmscomp/kates/releases/latest"><img src="https://img.shields.io/github/v/release/bmscomp/kates?label=release&logo=github" alt="Release" /></a>
     <img src="https://img.shields.io/badge/CLI-Go%201.25-00ADD8?logo=go&logoColor=white" alt="Go" />
     <img src="https://img.shields.io/badge/Backend-Quarkus%203.15-4695EB?logo=quarkus&logoColor=white" alt="Quarkus" />
-    <img src="https://img.shields.io/badge/Kafka-4.2.0%20KRaft-231F20?logo=apachekafka&logoColor=white" alt="Kafka" />
+    <img src="https://img.shields.io/badge/Kafka-4.3.0%20KRaft-231F20?logo=apachekafka&logoColor=white" alt="Kafka" />
     <img src="https://img.shields.io/badge/Charts-Helm-0F1689?logo=helm&logoColor=white" alt="Helm" />
   </p>
 </div>
@@ -161,8 +161,8 @@ Kates ships its platform as independently versioned Helm charts, composable via 
 | Chart | Version | App Version | Description |
 |:------|:--------|:------------|:------------|
 | [`kates`](charts/kates/) | 0.4.4 | 1.20.0 | The Kates backend (Quarkus REST/gRPC) and frontend, deployed as a single Kubernetes Deployment with ConfigMap-driven configuration. |
-| [`kafka-cluster`](charts/kafka-cluster/) | 0.1.1 | 4.2.0 | A Strimzi-managed KRaft Kafka cluster with zone-aware broker pools, SCRAM-SHA-512 authentication, and rack-affinity storage classes. |
-| [`connect-cluster`](charts/connect-cluster/) | 1.2.0 | 4.2.0 | A Strimzi-managed Kafka Connect cluster with a managed KafkaUser, least-privilege ACLs, default-deny NetworkPolicies, and in-chart JMX metrics. |
+| [`kafka-cluster`](charts/kafka-cluster/) | 0.2.0 | 4.3.0 | A Strimzi-managed KRaft Kafka cluster with zone-aware broker pools, SCRAM-SHA-512 authentication, and rack-affinity storage classes. |
+| [`connect-cluster`](charts/connect-cluster/) | 1.3.0 | 4.3.0 | A Strimzi-managed Kafka Connect cluster with a managed KafkaUser, least-privilege ACLs, default-deny NetworkPolicies, and in-chart JMX metrics. |
 | [`kafka-ui`](charts/kafka-ui/) | 0.3.0 | v1.5.0 | A web-based Kafka management interface for topic inspection, consumer group monitoring, and message browsing. |
 | [`kates-chaos`](charts/kates-chaos/) | 2.0.0 | 3.28.0 | A LitmusChaos execution-plane wrapper (operator, exporter, CRDs) with Kafka-specific RBAC, ChaosExperiment/ChaosEngine templating, and monitoring for broker and network faults. |
 | [`kates-monitoring`](charts/monitoring/) | 1.0.0 | 82.4.3 | The Prometheus and Grafana monitoring stack, pre-configured with scrape jobs, recording rules, and auto-provisioned dashboards for Kafka, JVM, and Strimzi metrics. |

--- a/charts/connect-cluster/Chart.yaml
+++ b/charts/connect-cluster/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: connect-cluster
 description: A Helm chart for deploying Strimzi Kafka Connect clusters
 type: application
-version: 1.2.0
-appVersion: "4.2.0"
+version: 1.3.0
+appVersion: "4.3.0"
 kubeVersion: ">=1.27.0-0"
 home: https://github.com/bmscomp/kates
 sources:

--- a/charts/connect-cluster/README.md
+++ b/charts/connect-cluster/README.md
@@ -60,7 +60,7 @@ helm install backend-connect charts/connect-cluster \
 |-----------|-------------|---------|
 | `replicas` | Number of Connect worker replicas | `3` |
 | `image` | Connect container image | `ghcr.io/bmscomp/connect:3.0.2` |
-| `version` | Kafka version | `4.2.0` |
+| `version` | Kafka version | `4.3.0` |
 | `groupId` | Connect cluster group ID | `kates-connect-cluster` |
 | `clusterDomain` | Kubernetes cluster DNS domain | `cluster.local` |
 | `nameOverride` | Override chart name | `""` |

--- a/charts/connect-cluster/values.yaml
+++ b/charts/connect-cluster/values.yaml
@@ -22,7 +22,7 @@ replicas: 3
 # -- Kafka Connect image (leave empty to use Strimzi default)
 image: "ghcr.io/bmscomp/connect:3.6.0"
 # -- Kafka version
-version: "4.2.0"
+version: "4.3.0"
 # -- Group ID for the Connect cluster
 groupId: kates-connect-cluster
 

--- a/charts/kafka-cluster/Chart.yaml
+++ b/charts/kafka-cluster/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kafka-cluster
 description: Strimzi-based Kafka cluster deployment with KRaft, zone-aware broker pools, and full observability
 type: application
-version: 0.1.1
-appVersion: "4.2.0"
+version: 0.2.0
+appVersion: "4.3.0"
 icon: https://strimzi.io/assets/images/strimzi_logo.png
 home: https://strimzi.io/
 keywords:

--- a/charts/kafka-cluster/INSTALL.md
+++ b/charts/kafka-cluster/INSTALL.md
@@ -41,7 +41,7 @@ The chart bundles the **Strimzi Operator** as a subchart (`strimziOperator.enabl
 ```bash
 helm install strimzi-kafka-operator \
   oci://quay.io/strimzi-helm/strimzi-kafka-operator \
-  --version 1.0.0 \
+  --version 1.1.0 \
   --namespace kafka --create-namespace \
   --wait
 ```
@@ -167,7 +167,7 @@ global:
   imageRegistry: "my-registry.example.com"
   imageRepository: "strimzi"
 images:
-  kafka: "my-registry.example.com/strimzi/kafka:1.0.0-kafka-4.2.0"
+  kafka: "my-registry.example.com/strimzi/kafka:1.1.0-kafka-4.3.0"
   kubectl: "my-registry.example.com/bitnami/kubectl:1.33.0"
 ```
 

--- a/charts/kafka-cluster/README.md
+++ b/charts/kafka-cluster/README.md
@@ -18,7 +18,7 @@ Production-ready Apache Kafka deployment on Kubernetes using the [Strimzi](https
 |-------------|---------|
 | Kubernetes | ≥ 1.25 |
 | Helm | ≥ 3.12 |
-| Strimzi Operator | 1.0.0 (bundled as subchart) |
+| Strimzi Operator | 1.1.0 (bundled as subchart) |
 
 ## Quick Start
 
@@ -218,8 +218,8 @@ graph LR
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `clusterName` | Kafka cluster name (Kubernetes resource name) | `krafter` |
-| `kafkaVersion` | Apache Kafka version | `4.2.0` |
-| `strimziVersion` | Strimzi operator version | `1.0.0` |
+| `kafkaVersion` | Apache Kafka version | `4.3.0` |
+| `strimziVersion` | Strimzi operator version | `1.1.0` |
 
 ### Global Image Configuration
 
@@ -229,7 +229,7 @@ Override these to pull all images from a private or air-gapped registry:
 |-----------|-------------|---------|
 | `global.imageRegistry` | Container image registry for all chart images | `quay.io` |
 | `global.imageRepository` | Container image repository (org/project) | `strimzi` |
-| `images.kafka` | Kafka client image (Helm test tier 2) | `quay.io/strimzi/kafka:1.0.0-kafka-4.2.0` |
+| `images.kafka` | Kafka client image (Helm test tier 2) | `quay.io/strimzi/kafka:1.1.0-kafka-4.3.0` |
 | `images.kubectl` | kubectl image (Helm tests + CRD upgrade hook) | `bitnami/kubectl:1.33.0` |
 
 Example: redirect all images to a private registry:
@@ -239,7 +239,7 @@ global:
   imageRegistry: "my-registry.example.com"
   imageRepository: "strimzi"
 images:
-  kafka: "my-registry.example.com/strimzi/kafka:1.0.0-kafka-4.2.0"
+  kafka: "my-registry.example.com/strimzi/kafka:1.1.0-kafka-4.3.0"
   kubectl: "my-registry.example.com/bitnami/kubectl:1.33.0"
 ```
 
@@ -715,7 +715,7 @@ Set `strimziOperator.enabled: false` if the operator is already installed in the
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `drainCleaner.enabled` | Deploy Strimzi Drain Cleaner | `true` |
-| `drainCleaner.image` | Container image | `quay.io/strimzi/drain-cleaner:1.0.0` |
+| `drainCleaner.image` | Container image | `quay.io/strimzi/drain-cleaner:1.6.1` |
 
 ### Pod Security
 

--- a/charts/kafka-cluster/templates/_helpers.tpl
+++ b/charts/kafka-cluster/templates/_helpers.tpl
@@ -60,7 +60,7 @@ seccompProfile:
 
 {{/*
 Resolve the Kafka client image used in Helm tests.
-Default: quay.io/strimzi/kafka:1.0.0-kafka-4.2.0
+Default: quay.io/strimzi/kafka:1.1.0-kafka-4.3.0
 Override via: images.kafka or global.imageRegistry + global.imageRepository
 */}}
 {{- define "kafka-cluster.kafkaImage" -}}

--- a/charts/kafka-cluster/values-kind.yaml
+++ b/charts/kafka-cluster/values-kind.yaml
@@ -8,7 +8,7 @@
 
 # Simplify Kafka listeners for local access — no external nodeport
 kafka:
-  metadataVersion: 3.7-IV4
+  metadataVersion: 4.2-IV1
   listeners:
     - name: plain
       port: 9092

--- a/charts/kafka-cluster/values.yaml
+++ b/charts/kafka-cluster/values.yaml
@@ -1,6 +1,6 @@
 clusterName: krafter
-kafkaVersion: "4.2.0"
-strimziVersion: "1.0.0"
+kafkaVersion: "4.3.0"
+strimziVersion: "1.1.0"
 
 nameOverride: ""
 fullnameOverride: ""
@@ -25,6 +25,13 @@ testImages:
   kubectl: "ghcr.io/bmscomp/kates-tester:1.17.0"
 
 kafka:
+  # KRaft metadata version, pinned one step behind the Kafka version per the
+  # Strimzi upgrade procedure: if left unset the operator auto-raises it to the
+  # new version's default as soon as `kafkaVersion` changes, which forecloses
+  # any rollback to the previous Kafka line. Raise to 4.3-IV0 in a follow-up
+  # once 4.3.0 is proven. Must stay >= 4.2-IV0 or share groups will not
+  # bootstrap on new clusters.
+  metadataVersion: 4.2-IV1
   listeners:
     - name: plain
       port: 9092
@@ -586,7 +593,7 @@ rebalance:
 
 drainCleaner:
   enabled: false
-  image: quay.io/strimzi/drain-cleaner:1.0.0
+  image: quay.io/strimzi/drain-cleaner:1.6.1
   resources:
     requests:
       memory: 64Mi
@@ -606,7 +613,7 @@ strimziOperator:
 strimzi-kafka-operator:
   replicas: 1
   watchAnyNamespace: true
-  defaultImageTag: 1.0.0
+  defaultImageTag: 1.1.0
   # Cluster DNS domain — must match global.clusterDomain for correct FQDN resolution
   kubernetesServiceDnsDomain: cluster.local
   # When global.imageRegistry is set, pass it to the Strimzi subchart

--- a/cli/cmd/deploy_components.go
+++ b/cli/cmd/deploy_components.go
@@ -53,7 +53,7 @@ kind: Namespace
 metadata:
   name: strimzi-operator`)
 			clusterDomain := dc.resolveClusterDomain()
-			err := runHelmFn(gCtx, "upgrade", "--install", "strimzi-operator", "oci://quay.io/strimzi-helm/strimzi-kafka-operator", "--version", "1.0.0", "-n", "strimzi-operator",
+			err := runHelmFn(gCtx, "upgrade", "--install", "strimzi-operator", "oci://quay.io/strimzi-helm/strimzi-kafka-operator", "--version", "1.1.0", "-n", "strimzi-operator",
 				"--set", "watchAnyNamespace=true",
 				"--set", "kubernetesServiceDnsDomain="+clusterDomain,
 				"--set", "replicas=1",

--- a/config/kafka-connect/kafka-connect.yaml
+++ b/config/kafka-connect/kafka-connect.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     strimzi.io/use-connector-resources: "true"
 spec:
-  version: 4.2.0
+  version: 4.3.0
   replicas: 1
   bootstrapServers: krafter-kafka-bootstrap:9092
   authentication:

--- a/config/kafka-connect/kafka-mirror-maker.yaml
+++ b/config/kafka-connect/kafka-mirror-maker.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     strimzi.io/cluster: krafter
 spec:
-  version: 4.2.0
+  version: 4.3.0
   replicas: 1
   connectCluster: target
   clusters:

--- a/config/kafka/kafka.yaml
+++ b/config/kafka/kafka.yaml
@@ -223,7 +223,10 @@ metadata:
     strimzi.io/kraft: enabled
 spec:
   kafka:
-    version: 4.1.1
+    version: 4.3.0
+    # Pinned one step behind version so the 4.3.0 rollout stays reversible;
+    # raise to 4.3-IV0 in a follow-up once the cluster is proven healthy.
+    metadataVersion: 4.2-IV1
     listeners:
       - name: plain
         port: 9092

--- a/config/kafka/strimzi-drain-cleaner.yaml
+++ b/config/kafka/strimzi-drain-cleaner.yaml
@@ -67,7 +67,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:1.0.0
+          image: quay.io/strimzi/drain-cleaner:1.6.1
           ports:
             - containerPort: 8443
               name: https

--- a/config/kafka/strimzi-values.yaml
+++ b/config/kafka/strimzi-values.yaml
@@ -3,7 +3,7 @@
 
 replicas: 1
 watchAnyNamespace: true
-defaultImageTag: 1.0.0
+defaultImageTag: 1.1.0
 
 
 fullReconciliationIntervalMs: 60000

--- a/docs/book/02-architecture.md
+++ b/docs/book/02-architecture.md
@@ -349,8 +349,8 @@ sequenceDiagram
 | CLI | Go | 1.25+ | Cross-platform binary |
 | CLI Framework | Cobra | Latest | Command parsing, help generation |
 | Cluster | Kind | Latest | Local Kubernetes simulation |
-| Kafka | Apache Kafka | 4.2.0 | KRaft mode, Share Groups |
-| Operator | Strimzi | 1.0.0 | Kafka lifecycle management |
+| Kafka | Apache Kafka | 4.3.0 | KRaft mode, Share Groups |
+| Operator | Strimzi | 1.1.0 | Kafka lifecycle management |
 | Chaos | LitmusChaos | Latest | Advanced chaos experiments |
 | Monitoring | Prometheus + Grafana | Latest | Metrics collection and visualization |
 | Tracing | Jaeger (OTLP) | 2.15.0 | Distributed trace collection |

--- a/docs/book/10-cli-reference.md
+++ b/docs/book/10-cli-reference.md
@@ -378,7 +378,7 @@ kates cluster topology -o json
 Expected output (abbreviated — full output includes all sections listed below):
 
 ```text
- Kafka Cluster Topology — Cluster: krafter  │  Kafka 4.2.0  │  KRaft Mode
+ Kafka Cluster Topology — Cluster: krafter  │  Kafka 4.3.0  │  KRaft Mode
 
   Kubernetes Platform
   Version:   v1.31.4
@@ -386,7 +386,7 @@ Expected output (abbreviated — full output includes all sections listed below)
   Nodes:     3
 
   Strimzi Operator
-  Version:     1.0.0
+  Version:     1.1.0
   Components:  ✓ Operator  ✓ Entity Operator  ✓ Cruise Control
 
   Kafka Cluster

--- a/docs/book/15-kafka-deployment.md
+++ b/docs/book/15-kafka-deployment.md
@@ -13,11 +13,11 @@ After this chapter, you can:
 
 ## Strimzi Operator
 
-Kafka on Kubernetes is managed by the **Strimzi Kafka Operator** (`1.0.0`), installed from the OCI Helm chart on quay.io into a dedicated `strimzi-operator` namespace (this is exactly what `scripts/deploy-kafka.sh` runs when the Strimzi CRDs are not yet present):
+Kafka on Kubernetes is managed by the **Strimzi Kafka Operator** (`1.1.0`), installed from the OCI Helm chart on quay.io into a dedicated `strimzi-operator` namespace (this is exactly what `scripts/deploy-kafka.sh` runs when the Strimzi CRDs are not yet present):
 
 ```bash
 helm upgrade --install strimzi-operator oci://quay.io/strimzi-helm/strimzi-kafka-operator \
-  --version 1.0.0 \
+  --version 1.1.0 \
   --namespace strimzi-operator \
   --set watchAnyNamespace=true \
   --set replicas=1 \
@@ -605,7 +605,7 @@ Expect the Kafka CR to report Ready, every node pool at its desired replica coun
 
 ```bash
 helm upgrade --install strimzi-operator oci://quay.io/strimzi-helm/strimzi-kafka-operator \
-  --version 1.0.0 --namespace strimzi-operator
+  --version 1.1.0 --namespace strimzi-operator
 ```
 
 ### Brokers Crash with ConfigException

--- a/docs/book/18-upgrade-playbook.md
+++ b/docs/book/18-upgrade-playbook.md
@@ -25,9 +25,9 @@ Each Strimzi release supports only a narrow window of Kafka versions, and that w
 
 | Component | Pinned version | Source |
 |-----------|----------------|--------|
-| Strimzi operator | 1.0.0 | `STRIMZI_VERSION` in `versions.env` |
-| Kafka image | `quay.io/strimzi/kafka:1.0.0-kafka-4.2.0` | `STRIMZI_KAFKA_VERSION` in `versions.env` |
-| Chart default (`kafkaVersion`) | 4.2.0 | `charts/kafka-cluster/values.yaml` |
+| Strimzi operator | 1.1.0 | `STRIMZI_VERSION` in `versions.env` |
+| Kafka image | `quay.io/strimzi/kafka:1.1.0-kafka-4.3.0` | `STRIMZI_KAFKA_VERSION` in `versions.env` |
+| Chart default (`kafkaVersion`) | 4.3.0 | `charts/kafka-cluster/values.yaml` |
 
 ### Procedure
 
@@ -66,7 +66,7 @@ kates test create --type INTEGRITY --records 50000 --wait
 # In config/kafka/kafka.yaml — change the version
 spec:
   kafka:
-    version: 4.1.1  # → new version
+    version: 4.3.0  # → new version
 ```
 
 ```bash
@@ -144,7 +144,7 @@ kubectl apply -f config/kafka/
 
 ## Drain Cleaner Upgrade
 
-Drain Cleaner is not a standalone Helm release in this repository — it is deployed by the `kafka-cluster` chart (`charts/kafka-cluster/templates/drain-cleaner.yaml`) when `drainCleaner.enabled` is true (the prod values enable it), with the image pinned by the `drainCleaner.image` value (default `quay.io/strimzi/drain-cleaner:1.0.0`). To upgrade it, bump the image tag and re-deploy the chart:
+Drain Cleaner is not a standalone Helm release in this repository — it is deployed by the `kafka-cluster` chart (`charts/kafka-cluster/templates/drain-cleaner.yaml`) when `drainCleaner.enabled` is true (the prod values enable it), with the image pinned by the `drainCleaner.image` value (default `quay.io/strimzi/drain-cleaner:1.6.1`). To upgrade it, bump the image tag and re-deploy the chart:
 
 ```bash
 # Update drainCleaner.image in charts/kafka-cluster/values.yaml, then:

--- a/docs/book/20-installation-guide.md
+++ b/docs/book/20-installation-guide.md
@@ -228,7 +228,7 @@ The kafka-cluster chart creates Strimzi custom resources, but it does **not** bu
 
 ```bash
 helm upgrade --install strimzi-operator oci://quay.io/strimzi-helm/strimzi-kafka-operator \
-  --version 1.0.0 \
+  --version 1.1.0 \
   --namespace strimzi-operator --create-namespace \
   --set watchAnyNamespace=true \
   --wait
@@ -249,8 +249,8 @@ The chart ships with sensible defaults in `values.yaml`, but you should review k
 
 ```yaml
 clusterName: krafter       # Name of the Kafka cluster
-kafkaVersion: "4.2.0"      # Apache Kafka version
-strimziVersion: "1.0.0"   # Strimzi operator version
+kafkaVersion: "4.3.0"      # Apache Kafka version
+strimziVersion: "1.1.0"   # Strimzi operator version
 ```
 
 **Broker pools — define one pool per availability zone:**
@@ -461,7 +461,7 @@ Example — connect from a debug pod:
 # Get the SCRAM password first (you'll paste it into the client config below):
 kubectl get secret kates-backend -n kafka -o jsonpath='{.data.password}' | base64 -d
 
-kubectl run kafka-debug -it --rm --image=quay.io/strimzi/kafka:latest-kafka-4.2.0 \
+kubectl run kafka-debug -it --rm --image=quay.io/strimzi/kafka:latest-kafka-4.3.0 \
   -n kafka -- /bin/bash
 
 # Inside the pod — create the client config with the SCRAM credentials:
@@ -1135,7 +1135,7 @@ The Job runs with a dedicated `ServiceAccount` and `ClusterRole` scoped only to 
 ```yaml
 drainCleaner:
   enabled: false     # Enable for production clusters with node upgrade cycles
-  image: quay.io/strimzi/drain-cleaner:1.0.0
+  image: quay.io/strimzi/drain-cleaner:1.6.1
   resources:
     requests:
       memory: 64Mi
@@ -1570,7 +1570,7 @@ helm test kafka-cluster -n kafka
 | Value | Default | Description |
 |-------|---------|-------------|
 | `clusterName` | `krafter` | Name of the Kafka cluster |
-| `kafkaVersion` | `4.2.0` | Apache Kafka version |
+| `kafkaVersion` | `4.3.0` | Apache Kafka version |
 | `controllerPools` | `[]` | Controller pool definitions (generate with `kates detect --generate-values`) |
 | `brokerPools` | `[]` | Broker pool definitions (generate with `kates detect --generate-values`) |
 | `brokerDefaults.resources.requests.memory` | `4Gi` | Broker memory request |

--- a/docs/book/21-kafka-connect.md
+++ b/docs/book/21-kafka-connect.md
@@ -68,7 +68,7 @@ The `connect-cluster` chart lives at `charts/connect-cluster/` and produces the 
 
 ```text
 charts/connect-cluster/
-├── Chart.yaml                          # v1.2.0, appVersion 4.2.0
+├── Chart.yaml                          # v1.3.0, appVersion 4.3.0
 ├── values.yaml                         # Production defaults
 ├── values-generic.yaml                 # Generic cluster overlay (no Prometheus CRDs)
 ├── values-kind.yaml                    # Kind overlay (generic + local DB egress, Schema Registry)
@@ -163,7 +163,7 @@ sequenceDiagram
 | `replicas` | 3 (the CLI sets 1 with `--ha=false`; the dev overlay uses 1) | Number of worker pods |
 | `image` | `ghcr.io/bmscomp/connect:3.6.0` | Pre-built image with Debezium + Apicurio plugins |
 | `kafka.bootstrapServers` | `""` — computed as `<clusterName>-kafka-bootstrap.<ns>.svc:9092` (9093 when `kafka.tls.enabled`) | Connection to Kafka |
-| `version` | 4.2.0 | Kafka protocol version |
+| `version` | 4.3.0 | Kafka protocol version |
 
 ### Internal Topics
 

--- a/docs/book/appendix-d-versions.md
+++ b/docs/book/appendix-d-versions.md
@@ -5,8 +5,8 @@ Every version the platform pins, in one place. This table is generated from the 
 <!-- version-matrix:start -->
 | Component | Version | Source |
 |:----------|:--------|:-------|
-| Apache Kafka | 4.2.0 | `versions.env` (`STRIMZI_KAFKA_VERSION`) |
-| Strimzi operator | 1.0.0 | `versions.env` |
+| Apache Kafka | 4.3.0 | `versions.env` (`STRIMZI_KAFKA_VERSION`) |
+| Strimzi operator | 1.1.0 | `versions.env` |
 | LitmusChaos | 3.28.0 | `versions.env` |
 | Prometheus stack chart | 82.4.3 | `versions.env` |
 | Jaeger chart | 3.4.1 | `versions.env` |
@@ -15,9 +15,9 @@ Every version the platform pins, in one place. This table is generated from the 
 | Quarkus | 3.15.7 | `kates/pom.xml` |
 | Go (CLI) | 1.25.7 | `cli/go.mod` |
 | `apicurio-registry` chart | 0.1.5 (app 3.3.0) | `charts/apicurio-registry/Chart.yaml` |
-| `connect-cluster` chart | 1.2.0 (app 4.2.0) | `charts/connect-cluster/Chart.yaml` |
+| `connect-cluster` chart | 1.3.0 (app 4.3.0) | `charts/connect-cluster/Chart.yaml` |
 | `headlamp` chart | 0.1.0 (app 0.40.1) | `charts/headlamp/Chart.yaml` |
-| `kafka-cluster` chart | 0.1.1 (app 4.2.0) | `charts/kafka-cluster/Chart.yaml` |
+| `kafka-cluster` chart | 0.2.0 (app 4.3.0) | `charts/kafka-cluster/Chart.yaml` |
 | `kafka-ui` chart | 0.3.0 (app v1.5.0) | `charts/kafka-ui/Chart.yaml` |
 | `kates-chaos` chart | 2.0.0 (app 3.28.0) | `charts/kates-chaos/Chart.yaml` |
 | `kates-platform` chart | 0.2.0 (app 1.0.0) | `charts/kates-platform/Chart.yaml` |

--- a/docs/kafka-connect.md
+++ b/docs/kafka-connect.md
@@ -18,9 +18,9 @@ make connect-build
 
 | Property | Value |
 |----------|-------|
-| **Base Image** | `quay.io/strimzi/kafka:1.0.0-kafka-4.2.0` |
-| **Kafka Version** | 4.2.0 |
-| **Strimzi Version** | 1.0.0 |
+| **Base Image** | `quay.io/strimzi/kafka:1.1.0-kafka-4.3.0` |
+| **Kafka Version** | 4.3.0 |
+| **Strimzi Version** | 1.1.0 |
 | **Architecture** | `linux/amd64`, `linux/arm64` |
 | **License** | Apache 2.0 |
 

--- a/images.env
+++ b/images.env
@@ -4,8 +4,8 @@
 
 # Strimzi Kafka
 STRIMZI_IMAGES=(
-    "quay.io/strimzi/operator:1.0.0"
-    "quay.io/strimzi/kafka:1.0.0-kafka-4.2.0"
+    "quay.io/strimzi/operator:1.1.0"
+    "quay.io/strimzi/kafka:1.1.0-kafka-4.3.0"
 )
 
 # CRD upgrade hook (used by Helm pre-upgrade Job)

--- a/scripts/deploy-kafka-generic.sh
+++ b/scripts/deploy-kafka-generic.sh
@@ -166,7 +166,7 @@ else
         fi
         kubectl create namespace "strimzi-operator" --dry-run=client -o yaml | kubectl apply -f - > /dev/null 2>&1
         helm upgrade --install strimzi-operator oci://quay.io/strimzi-helm/strimzi-kafka-operator \
-            --version 1.0.0 \
+            --version 1.1.0 \
             --namespace "strimzi-operator" \
             --set watchAnyNamespace=true \
             --set replicas=1 \

--- a/scripts/deploy-kafka.sh
+++ b/scripts/deploy-kafka.sh
@@ -20,7 +20,7 @@ if ! kubectl get crd kafkas.kafka.strimzi.io &>/dev/null; then
     info "Strimzi CRDs not found. Installing Strimzi Kafka Operator in strimzi-operator namespace..."
     ensure_namespace "strimzi-operator"
     helm upgrade --install strimzi-operator oci://quay.io/strimzi-helm/strimzi-kafka-operator \
-        --version 1.0.0 \
+        --version 1.1.0 \
         --namespace "strimzi-operator" \
         --set watchAnyNamespace=true \
         --set replicas=1 \

--- a/versions.env
+++ b/versions.env
@@ -1,8 +1,8 @@
 # Centralized chart and component version pins.
 # Source this file from scripts that need version info.
 
-STRIMZI_VERSION="1.0.0"
-STRIMZI_KAFKA_VERSION="1.0.0-kafka-4.2.0"
+STRIMZI_VERSION="1.1.0"
+STRIMZI_KAFKA_VERSION="1.1.0-kafka-4.3.0"
 LITMUS_CHART_VERSION="3.28.0"
 LITMUS_VERSION="3.28.0"
 PROMETHEUS_STACK_VERSION="82.4.3"


### PR DESCRIPTION
## Why

The repo pinned Strimzi **1.0.0** and Kafka **4.2.0**. Strimzi **1.1.0** (2026-06-27) is the current stable release, and it carries the CVE fixes from 1.0.1 ([CVE-2026-55225](https://github.com/strimzi/strimzi-kafka-operator/security/advisories/GHSA-mw9r-p8xp-wx96), [CVE-2026-55226](https://github.com/strimzi/strimzi-kafka-operator/security/advisories/GHSA-r427-j2h7-wv3m)).

## What changed

Strimzi **1.0.0 → 1.1.0** and Kafka **4.2.0 → 4.3.0**, across the pins (`versions.env`, `images.env`, `Dockerfile.connect`, `strimzi-values.yaml`), the charts (`kafka-cluster` 0.1.1 → 0.2.0, `connect-cluster` 1.2.0 → 1.3.0, both `appVersion` 4.3.0), the deploy paths (`deploy-kafka.sh`, `deploy-kafka-generic.sh`, `cli/cmd/deploy_components.go`), the Kafka CRs, and the docs.

## metadataVersion: pinned to 4.2-IV1, deliberately not 4.3-IV0

Previously `metadataVersion` was **unset** in the chart and in `config/kafka/kafka.yaml`. Per the Strimzi upgrade procedure, an unset `metadataVersion` is auto-raised to the new version's default (`4.3-IV0`) the moment `version` changes — and once brokers write the new format, **rollback to 4.2.x is impossible**. Bumping the Kafka version with the field unset would have silently closed that door.

This PR pins `metadataVersion: 4.2-IV1` alongside the version bump, which:

- keeps the 4.3.0 rollout **reversible** (the documented two-phase Strimzi procedure);
- is a **no-op for existing clusters**, which already sit at `4.2-IV1` (the 4.2.0 default);
- is the **oldest pin that keeps share groups working** — `share.version=1` only bootstraps at metadata `4.2-IV0`+ (verified in Kafka 4.3.0's `ShareVersion.java`), and this repo enables share groups (`group.share.enable: true`).

`values-kind.yaml` moves from `3.7-IV4` to `4.2-IV1` for the same share-groups reason.

**Follow-up after this rolls out and 4.3.0 is proven healthy:** raise `metadataVersion` to `4.3-IV0` in its own PR. That step is the irreversible one, which is exactly why it is not in this PR.

## Why not Kafka 4.3.1

The original target was 4.3.1, which exists upstream but **is not reachable from this operator**:

- `kafka-versions.yaml` at tag `1.1.0` tops out at **4.3.0**, marked `default: true`.
- No `quay.io/strimzi/kafka:1.1.0-kafka-4.3.1` image is published — quay has only `1.1.0-kafka-{4.2.0,4.2.1,4.3.0}`.

Setting `version: 4.3.1` would make the operator reject the Kafka CR. Support for 4.3.1 is already merged on Strimzi `main`, so it becomes a small `versions.env` + `kafkaVersion` bump once the next operator release ships — with no metadata change, since 4.3.1 shares `4.3-IV0`.

## Bug this surfaced

**`config/kafka/kafka.yaml` still pinned Kafka 4.1.1.** Strimzi 1.1.0 removes support for the 4.1.x line outright ("Remove support for Kafka 4.1.x" in the changelog; `supported: false` in `kafka-versions.yaml`), so that manifest would have been rejected after the operator bump. It had also drifted from the chart, which was already on 4.2.0. Now 4.3.0.

## Also included

**Drain Cleaner 1.0.0 → 1.6.1.** Strimzi 1.1.0 bundles 1.6.0 in its own install files; the pin here had drifted six minors behind. This is adjacent to the upgrade rather than required by it — happy to pin 1.6.0 exactly or split it out if preferred.

## Breaking changes checked, none apply

- **Entity-operator healthcheck port rename** (`healthcheck` → `healthcheck-to`/`healthcheck-uo`), which 1.1.0 calls out for custom `PodMonitor`/`NetworkPolicy` refs — the string appears nowhere in this repo.
- **`STRIMZI_ENTITY_OPERATOR_WATCHED_NAMESPACE_ENABLED`** now defaults off as of 1.0.1 — `watchedNamespace` is unused here.

## Verification

- `helm lint` clean on both charts; rendered Kafka CR shows `version: 4.3.0` + `metadataVersion: 4.2-IV1` under both default values and the kind overlay.
- `go build ./...` and `go test ./cmd/... ./pkg/detect/...` pass.
- `scripts/gen-version-matrix.sh --check` (the CI drift gate) is in sync; `docs/book/appendix-d-versions.md` regenerated via the script rather than hand-edited.
- All three image tags and the `1.1.0` OCI Helm chart confirmed to resolve on quay, rather than assumed from the tag names.
- Share-group metadata floor confirmed against Kafka 4.3.0 source (`ShareVersion.SV_1` bootstraps at `IBP_4_2_IV0`).