### PR TITLE
feat(strimzi): own the operator install in a chart, with deployment and migration docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,11 @@ on:
       - "kates/**"
       - "cli/**"
       - "charts/kates/**"
+      - "charts/strimzi-operator/**"
       - "config/**"
       - "images.env"
       - "versions.env"
+      - "scripts/check-versions.sh"
       - ".github/workflows/ci.yml"
       - "!**/*.md"
   pull_request:
@@ -18,9 +20,11 @@ on:
       - "kates/**"
       - "cli/**"
       - "charts/kates/**"
+      - "charts/strimzi-operator/**"
       - "config/**"
       - "images.env"
       - "versions.env"
+      - "scripts/check-versions.sh"
       - ".github/workflows/ci.yml"
       - "!**/*.md"
 
@@ -53,6 +57,10 @@ jobs:
               - '.github/workflows/ci.yml'
             helm:
               - 'charts/kates/**'
+              - 'charts/strimzi-operator/**'
+              - 'charts/kafka-cluster/values.yaml'
+              - 'versions.env'
+              - 'scripts/check-versions.sh'
             yaml:
               - 'config/**'
 
@@ -101,6 +109,46 @@ jobs:
 
       - name: Template validation
         run: helm template kates charts/kates/ > /dev/null
+
+      # The Strimzi version is declared in five places. If values.yaml's
+      # strimziVersion drifts from the Chart.yaml dependency version, the CRD
+      # hook applies CRDs for a different operator than the one installed —
+      # silently. This is the only thing that catches that.
+      - name: Check Strimzi version pins agree
+        run: bash scripts/check-versions.sh
+
+      # The wrapper chart does not render until its subchart is fetched.
+      # `build` resolves from Chart.lock so the pinned version cannot drift.
+      - name: Fetch strimzi-operator chart dependencies
+        run: helm dependency build charts/strimzi-operator/
+
+      - name: Lint strimzi-operator chart
+        run: helm lint charts/strimzi-operator/
+
+      - name: Template validation (strimzi-operator, all overlays)
+        run: |
+          helm template strimzi-operator charts/strimzi-operator/ \
+            -n strimzi-operator > /dev/null
+          for overlay in kind dev prod generic; do
+            echo "  values-${overlay}.yaml"
+            helm template strimzi-operator charts/strimzi-operator/ \
+              -n strimzi-operator \
+              -f "charts/strimzi-operator/values-${overlay}.yaml" > /dev/null
+          done
+
+      # The chart's reason to exist is that a typo'd key fails loudly instead of
+      # being silently ignored (as leaderElection.enabled was for the lifetime
+      # of the old release). Assert the schema actually rejects one.
+      - name: Assert values schema rejects unknown keys
+        run: |
+          if helm template strimzi-operator charts/strimzi-operator/ \
+               -n strimzi-operator \
+               --set 'strimzi-kafka-operator.leaderElection.enabled=false' \
+               > /dev/null 2>&1; then
+            echo "::error::values.schema.json accepted a misspelled key (leaderElection.enabled)"
+            exit 1
+          fi
+          echo "OK: schema rejected the misspelled key"
 
   kyverno-policy-test:
     name: Kyverno Policy Validation

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,11 @@ all: check-prerequisites
 	@echo "  - Chaos:             execution plane only (no UI) — 'make chaos-status'"
 	@echo ""
 
+# Assert the Strimzi version pins agree across all five places that declare one.
+# Also run in CI (.github/workflows/ci.yml, Helm Lint job).
+check-versions: ## Verify the Strimzi version pins agree
+	@./scripts/check-versions.sh
+
 # Check prerequisites — only kubectl and helm are strictly required for generic clusters
 check-prerequisites:
 	@echo "🔍 Checking prerequisites..."

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Kates ships its platform as independently versioned Helm charts, composable via 
 | [`kafka-cluster`](charts/kafka-cluster/) | 0.2.0 | 4.3.0 | A Strimzi-managed KRaft Kafka cluster with zone-aware broker pools, SCRAM-SHA-512 authentication, and rack-affinity storage classes. |
 | [`connect-cluster`](charts/connect-cluster/) | 1.3.0 | 4.3.0 | A Strimzi-managed Kafka Connect cluster with a managed KafkaUser, least-privilege ACLs, default-deny NetworkPolicies, and in-chart JMX metrics. |
 | [`kafka-ui`](charts/kafka-ui/) | 0.3.0 | v1.5.0 | A web-based Kafka management interface for topic inspection, consumer group monitoring, and message browsing. |
+| [`strimzi-operator`](charts/strimzi-operator/) | 0.1.0 | 1.1.0 | The Strimzi Kafka Operator, wrapping the upstream chart with pinned kates defaults, an owned CRD-upgrade hook, and a strict values schema. |
 | [`kates-chaos`](charts/kates-chaos/) | 2.0.0 | 3.28.0 | A LitmusChaos execution-plane wrapper (operator, exporter, CRDs) with Kafka-specific RBAC, ChaosExperiment/ChaosEngine templating, and monitoring for broker and network faults. |
 | [`kates-monitoring`](charts/monitoring/) | 1.0.0 | 82.4.3 | The Prometheus and Grafana monitoring stack, pre-configured with scrape jobs, recording rules, and auto-provisioned dashboards for Kafka, JVM, and Strimzi metrics. |
 | [`apicurio-registry`](charts/apicurio-registry/) | 0.1.5 | 3.3.0 | Apicurio Schema Registry deployed with KafkaSQL persistence, providing schema validation and compatibility enforcement for Avro, Protobuf, and JSON Schema. |

--- a/charts/strimzi-operator/.helmignore
+++ b/charts/strimzi-operator/.helmignore
@@ -1,0 +1,26 @@
+# Patterns to ignore when building packages.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# Helm value overlays (included explicitly via -f flag)
+values-kind.yaml
+values-dev.yaml
+values-generic.yaml
+values-prod.yaml

--- a/charts/strimzi-operator/Chart.yaml
+++ b/charts/strimzi-operator/Chart.yaml
@@ -1,0 +1,33 @@
+apiVersion: v2
+name: strimzi-operator
+version: 0.1.0
+# Tracks the Strimzi operator version this chart deploys.
+appVersion: "1.1.0"
+description: The Strimzi Kafka Operator — wraps the upstream chart with pinned kates defaults, an owned CRD-upgrade hook, and a strict values schema
+kubeVersion: ">=1.27.0-0"
+home: https://github.com/bmscomp/kates
+sources:
+  - https://github.com/bmscomp/kates
+keywords:
+  - kafka
+  - strimzi
+  - operator
+  - kraft
+  - kates
+maintainers:
+  - name: bmscomp
+    url: https://github.com/bmscomp
+dependencies:
+  - name: strimzi-kafka-operator
+    version: 1.1.0
+    repository: oci://quay.io/strimzi-helm
+annotations:
+  artifacthub.io/category: streaming-messaging
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/changes: |
+    - kind: added
+      description: Initial chart — extracts the Strimzi operator install from ad-hoc helm calls
+    - kind: added
+      description: Owns Strimzi CRD upgrade via a pre-install/pre-upgrade hook
+    - kind: fixed
+      description: leaderElection.enable is now the honored key (the CLI previously set a misspelled leaderElection.enabled that was silently ignored)

--- a/charts/strimzi-operator/README.md
+++ b/charts/strimzi-operator/README.md
@@ -1,0 +1,191 @@
+# strimzi-operator
+
+The [Strimzi](https://strimzi.io/) Kafka Operator. Wraps the upstream `strimzi-kafka-operator` chart with pinned kates defaults, an owned CRD-upgrade hook, and a strict values schema.
+
+> For the deployment narrative, the migration from the ad-hoc install, and the CRD mechanics, see the book chapter [Deploying the Strimzi Operator](../../docs/book/deploying-strimzi-operator.md). Versions live in the [Version & Compatibility Matrix](../../docs/book/appendix-d-versions.md).
+
+## Overview
+
+The operator was previously installed by three ad-hoc `helm install oci://...` calls that had drifted apart (different memory limits, different timeouts, one silently-misspelled flag). This chart makes that install a reviewable artifact.
+
+What it manages:
+
+- **The operator** — via the upstream `strimzi-kafka-operator` subchart, pinned to one version, with the union of what the three retired call sites actually did.
+- **CRD lifecycle** — a `pre-install`/`pre-upgrade` hook Job applies the Strimzi CRD bundle with server-side apply. This is the part Helm does not do for you (see [CRD Lifecycle](#crd-lifecycle)).
+- **A strict schema** — `values.schema.json` rejects the stale flat keys the old call sites used, so a mistake fails loudly instead of being silently ignored.
+- **Helm tests** — the operator is `Available`, all ten CRDs are `Established`, and the watch scope did not collapse.
+
+The chart is a **cluster singleton**: 13 of the operator's 17 resources are cluster-scoped with hardcoded names. Two releases can never coexist.
+
+## Prerequisites
+
+| Requirement | Minimum | Notes |
+|-------------|---------|-------|
+| **`helm dependency build`** | — | **Required.** The chart will not render without it — see below. |
+| Kubernetes | 1.27+ | Enforced via `kubeVersion` |
+| Helm | 3.12+ | Tested on Helm 4.2.x |
+| Egress to `quay.io` | — | `helm dependency build` pulls the operator subchart |
+| Egress to `github.com` | — | The CRD hook fetches the bundle on **every** install and upgrade. Mirror it via `crdUpgrade.url` — see `values-prod.yaml`. |
+
+**The dependency build is not optional.** This chart declares a subchart, so without it every `helm template`/`install`/`upgrade`/`lint` fails before contacting the cluster:
+
+```text
+Error: an error occurred while checking for chart dependencies: found in Chart.yaml, but missing in charts/ directory: strimzi-kafka-operator
+```
+
+Note that `helm lint` only **warns** about this, so a green lint does not mean a deployable chart.
+
+## Installation
+
+```bash
+# 1. Dependencies (REQUIRED — see above)
+helm dependency build charts/strimzi-operator
+
+# 2. Install
+helm upgrade --install strimzi-operator charts/strimzi-operator \
+  -n strimzi-operator --create-namespace \
+  --timeout 5m --wait
+```
+
+Verify the watch scope actually took effect:
+
+```bash
+kubectl get deploy strimzi-cluster-operator -n strimzi-operator \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="STRIMZI_NAMESPACE")].value}'
+```
+
+```text
+*
+```
+
+### Environment Overlays
+
+| Overlay | Purpose |
+|---------|---------|
+| `values-kind.yaml` | Local kind — lowers the operator to 384Mi |
+| `values-dev.yaml` | Dev — `logLevel: DEBUG` |
+| `values-prod.yaml` | Prod **uplift** — hardening, PDB, NetworkPolicy. Never applied to any cluster before; read the header. |
+| `values-generic.yaml` | Unknown clusters — documents DNS-domain injection and registry redirection |
+
+## Configuration Reference
+
+### Chart-owned keys
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `strimziVersion` | `1.1.0` | Builds the CRD bundle URL. Must equal `Chart.yaml` `appVersion` + dependency version. |
+| `testImages.kubectl` | `ghcr.io/bmscomp/kates-tester:1.17.0` | Image for the CRD hook Job and Helm tests |
+| `crdUpgrade.enabled` | `true` | Apply CRDs via the pre-install/pre-upgrade hook |
+| `crdUpgrade.url` | `""` | Override the bundle URL (empty = derive from `strimziVersion`). Use an internal mirror when airgapped. |
+| `crdUpgrade.backoffLimit` | `3` | Job retries before the install/upgrade aborts |
+| `crdUpgrade.ttlSecondsAfterFinished` | `300` | Retention of a **failed** Job for log inspection. A successful Job is deleted immediately by Helm's `hook-succeeded` policy, so this only governs the failure path. |
+| `nameOverride` / `fullnameOverride` | `""` | Standard name overrides |
+| `commonLabels` / `commonAnnotations` | `{}` | Applied to chart-owned resources |
+
+### Operator keys (`strimzi-kafka-operator.*`)
+
+Only these deviate from stock upstream. Everything else in the [upstream values](https://github.com/strimzi/strimzi-kafka-operator/blob/main/helm-charts/helm3/strimzi-kafka-operator/values.yaml) passes through.
+
+| Key | Default | Why |
+|-----|---------|-----|
+| `strimzi-kafka-operator.replicas` | `1` | All three retired call sites |
+| `strimzi-kafka-operator.watchAnyNamespace` | `true` | All three retired call sites; verified live. This default is what makes the retired flat key harmless. |
+| `strimzi-kafka-operator.operationTimeoutMs` | `900000` | Live value (upstream: 300000) |
+| `strimzi-kafka-operator.resources.{limits,requests}.memory` | `768Mi` | Live value (upstream: 384Mi). **Memory only** — cpu inherits upstream's 1000m/200m rather than duplicating it here. |
+| `strimzi-kafka-operator.leaderElection.enable` | `true` | The **correct** key. See [Upgrading](#upgrading). |
+| `strimzi-kafka-operator.kubernetesServiceDnsDomain` | `cluster.local` | Upstream only emits `KUBERNETES_SERVICE_DNS_DOMAIN` when this differs — callers on custom domains **must** inject it. |
+| `strimzi-kafka-operator.fullReconciliationIntervalMs` | `120000` | Upstream default, verified live |
+| `strimzi-kafka-operator.createGlobalResources` | `true` | `false` leaves four bindings with dangling roleRefs |
+
+> **There is no `global` block.** Upstream contains zero `.Values.global` references and ignores `global.imageRegistry` entirely. Declaring it to satisfy the schema would convert a loud failure into a silent one, so `--set global.*` is rejected. For registry redirection use `strimzi-kafka-operator.defaultImageRegistry`.
+
+## Examples
+
+Redirect images to an internal registry:
+
+```bash
+helm upgrade --install strimzi-operator charts/strimzi-operator -n strimzi-operator \
+  --set strimzi-kafka-operator.defaultImageRegistry=registry.internal \
+  --set strimzi-kafka-operator.defaultImageRepository=strimzi
+```
+
+Non-default cluster DNS domain:
+
+```bash
+helm upgrade --install strimzi-operator charts/strimzi-operator -n strimzi-operator \
+  -f charts/strimzi-operator/values-generic.yaml \
+  --set strimzi-kafka-operator.kubernetesServiceDnsDomain="${CLUSTER_DOMAIN}"
+```
+
+Airgapped CRD mirror:
+
+```bash
+helm upgrade --install strimzi-operator charts/strimzi-operator -n strimzi-operator \
+  --set crdUpgrade.url=https://mirror.internal/strimzi-crds-1.1.0.yaml
+```
+
+## CRD Lifecycle
+
+Helm applies a chart's `crds/` directory **on install only**. Per `helm upgrade --help`: *"no CRDs will be installed when an upgrade is performed with install flag enabled. By default, CRDs are installed if not already present."* There is no upgrade path — and `helm uninstall` never removes them either.
+
+The upstream chart ships all ten Strimzi CRDs in `crds/`. Left alone, they would freeze at whatever version was first installed while the operator moved on, and the API server would **silently prune** fields the frozen schema does not know about — no error, no event.
+
+The `crdUpgrade` hook closes that gap: it fetches the pinned bundle, validates it (non-empty, exactly ten CRDs, server-side dry-run) **before** mutating anything, then applies with `--server-side --force-conflicts`.
+
+The CRDs deliberately stay in the subchart's `crds/` and are **never templated**. Templating them would break adoption of the existing release with an ownership error and — far worse — would grant `helm uninstall` the power to cascade-delete every Kafka CR in the cluster (`CRD → Kafka/KafkaNodePool → StrimziPodSet → Pods`).
+
+## Helm Tests
+
+```bash
+helm test strimzi-operator -n strimzi-operator
+```
+
+Three hooks, all on a scoped ephemeral ServiceAccount: the operator Deployment is `Available`; all ten CRDs are `Established`; and — when `watchAnyNamespace` is true — `STRIMZI_NAMESPACE == "*"`. The last is defense-in-depth: the subchart's values block keeps `additionalProperties: true` (upstream has ~40 keys that drift each release), so a typo *inside* that block stays silent, and this assertion is what makes it loud.
+
+## Upgrading
+
+### Ad-hoc OCI install → this chart
+
+Adoption is a pure in-place patch — every resource name is identical, so nothing is recreated. Retarget your `--set` flags:
+
+| Old | New |
+|-----|-----|
+| `--set watchAnyNamespace=X` | `--set strimzi-kafka-operator.watchAnyNamespace=X` |
+| `--set replicas=X` | `--set strimzi-kafka-operator.replicas=X` |
+| `--set resources.*` | `--set strimzi-kafka-operator.resources.*` |
+| `--set operationTimeoutMs=X` | `--set strimzi-kafka-operator.operationTimeoutMs=X` |
+| `--set kubernetesServiceDnsDomain=X` | `--set strimzi-kafka-operator.kubernetesServiceDnsDomain=X` |
+| `--set leaderElection.enabled=X` | `--set strimzi-kafka-operator.leaderElection.enable=X` — **the old key was a silent no-op** |
+| `--set global.imageRegistry=X` | `--set strimzi-kafka-operator.defaultImageRegistry=X` — **`global` was always ignored by upstream** |
+
+**Behavioral changes to review:**
+
+1. **NEVER upgrade without explicit values — bare `helm upgrade` *is* `--reuse-values`.** Helm copies the previous release's stored values when none are supplied. Those stored values are the stale flat keys from the retired call sites, which this chart's schema rejects:
+
+   ```text
+   Error: UPGRADE FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
+   strimzi-operator:
+   - at '': additional properties 'kubernetesServiceDnsDomain', 'leaderElection', 'replicas', 'resources', 'watchAnyNamespace', 'operationTimeoutMs' not allowed
+   ```
+
+   Pass `--reset-values` (or `-f <overlay>`) — the rule is *always pass explicit values*, which is stronger than "never pass `--reuse-values`". This pain is **one-time**: after the first `--reset-values` adoption the stored config is clean and later bare upgrades pass.
+
+2. **`helm upgrade` does not update CRDs.** The `crdUpgrade` hook does. See [CRD Lifecycle](#crd-lifecycle).
+
+3. **This chart is a cluster singleton.** 13 of 17 resources are cluster-scoped with hardcoded names, and the leader-election Lease is namespace-scoped with a hardcoded name — so two releases cannot arbitrate, would both win, and would fight over StrimziPodSet writes. There is no parallel install-then-cutover.
+
+4. **Adopting rolls the entire Kafka data plane.** The operand image tracks the operator version and no node pool pins an image, so every broker and controller restarts. This needs a maintenance window and the `strimzi.io/pause-reconciliation` procedure — see the [book chapter](../../docs/book/deploying-strimzi-operator.md).
+
+### Troubleshooting
+
+Adoption ownership errors:
+
+```text
+invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name"
+```
+
+```text
+annotation validation error: key "meta.helm.sh/release-name" must equal "X": current value is "Y"
+```
+
+Remedy: `kubectl label --overwrite` / `kubectl annotate --overwrite` the offending resource, then retry.

--- a/charts/strimzi-operator/templates/NOTES.txt
+++ b/charts/strimzi-operator/templates/NOTES.txt
@@ -1,0 +1,58 @@
+{{- $op := index .Values "strimzi-kafka-operator" -}}
+Strimzi Operator v{{ .Chart.Version }} (Strimzi {{ .Chart.AppVersion }})
+
+Release:   {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+
+Configuration:
+  Watch scope:      {{ if $op.watchAnyNamespace }}all namespaces (STRIMZI_NAMESPACE="*"){{ else }}{{ .Release.Namespace }} only{{ end }}
+  Replicas:         {{ $op.replicas }}
+  Leader election:  {{ if $op.leaderElection.enable }}enabled{{ else }}disabled{{ end }}
+  DNS domain:       {{ $op.kubernetesServiceDnsDomain }}
+  CRD upgrade hook: {{ if .Values.crdUpgrade.enabled }}enabled{{ else }}DISABLED{{ end }}
+
+{{- if .Values.crdUpgrade.enabled }}
+
+  ✓ CRDs applied from {{ include "strimzi-operator.crdUrl" . }}
+{{- end }}
+
+{{- if not .Values.crdUpgrade.enabled }}
+
+  ⚠ helm upgrade does NOT update CRDs. The upstream chart ships them in crds/,
+    which Helm only applies on install. This chart's crdUpgrade hook keeps them
+    current — you have disabled it, so CRDs freeze at the version first
+    installed and the API server will silently prune fields the frozen schema
+    does not know about. Re-enable with crdUpgrade.enabled=true unless another
+    applier owns them.
+{{- end }}
+
+{{- if not $op.watchAnyNamespace }}
+
+  ⚠ The operator will only watch {{ .Release.Namespace }}. Existing Kafka
+    clusters in other namespaces will go UNMANAGED — their CRs stay in the
+    cluster but nothing reconciles them. Set
+    strimzi-kafka-operator.watchAnyNamespace=true to restore cluster-wide scope.
+{{- end }}
+
+  ⚠ Upgrading? Bare `helm upgrade` REUSES this release's stored values. Pass
+    --reset-values (or -f <overlay>) or it will fail schema validation on the
+    stale flat keys left by the retired ad-hoc install:
+
+      helm upgrade {{ .Release.Name }} <chart> -n {{ .Release.Namespace }} --reset-values
+
+────────────────────────────────────────────
+  Verify
+────────────────────────────────────────────
+
+Watch scope actually in effect (expect "*"):
+  kubectl get deploy strimzi-cluster-operator -n {{ .Release.Namespace }} \
+    -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="STRIMZI_NAMESPACE")].value}'
+
+CRDs installed:
+  kubectl get crd -l strimzi.io/crd-install=true
+
+Operator rollout:
+  kubectl rollout status deploy/strimzi-cluster-operator -n {{ .Release.Namespace }}
+
+Full check:
+  helm test {{ .Release.Name }} -n {{ .Release.Namespace }}

--- a/charts/strimzi-operator/templates/_helpers.tpl
+++ b/charts/strimzi-operator/templates/_helpers.tpl
@@ -1,0 +1,122 @@
+{{/*
+READING THE SUBCHART'S VALUES BLOCK — READ THIS BEFORE EDITING ANY TEMPLATE.
+
+`.Values.strimzi-kafka-operator.watchAnyNamespace` is a Go template PARSE
+ERROR. Hyphens are illegal in field selectors, so that expression does not
+merely return empty — it fails the whole chart at parse time with
+"bad character U+002D", breaking every helm template/install/lint/CI render.
+
+`index` is the only way to read a hyphenated key from a template. Any template
+needing the block opens with:
+
+  {{- $op := index .Values "strimzi-kafka-operator" -}}
+
+and then uses `$op.watchAnyNamespace` normally. No helper is defined for this
+on purpose: `index .Values "strimzi-kafka-operator"` already yields a real map,
+whereas a define would have to round-trip through toYaml/fromYaml to hand one
+back.
+
+Note `--set strimzi-kafka-operator.foo=bar` on the command line and the YAML
+key itself are both FINE; only template field access breaks. A Chart.yaml
+`alias:` would fix the access but relocate the values key, invalidating the
+schema, the README rename table, and the `--set strimzi-kafka-operator.*` UX
+this chart is built around.
+*/}}
+
+{{- define "strimzi-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "strimzi-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "strimzi-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Selector labels — the stable subset used in matchLabels/selectors.
+Never add version-varying labels here.
+*/}}
+{{- define "strimzi-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "strimzi-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Common labels applied to every resource, including user-supplied commonLabels.
+*/}}
+{{- define "strimzi-operator.labels" -}}
+{{ include "strimzi-operator.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: kates
+app.kubernetes.io/component: operator
+helm.sh/chart: {{ include "strimzi-operator.chart" . }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common annotations (empty unless commonAnnotations is set).
+*/}}
+{{- define "strimzi-operator.annotations" -}}
+{{- with .Values.commonAnnotations }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+kubectl image used by the CRD-upgrade hook Job and the Helm tests.
+Flat string, matching kafka-cluster/_helpers.tpl and connect-cluster — the two
+charts that already own a kubectl image.
+*/}}
+{{- define "strimzi-operator.kubectlImage" -}}
+{{- .Values.testImages.kubectl -}}
+{{- end }}
+
+{{/*
+Pod security context for this chart's OWN resources (the hook Job and tests).
+Not the operator's — that is strimzi-kafka-operator.podSecurityContext.
+*/}}
+{{- define "strimzi-operator.podSecurityContext" -}}
+runAsNonRoot: true
+runAsUser: 65534
+seccompProfile:
+  type: RuntimeDefault
+{{- end }}
+
+{{/*
+Container security context for this chart's OWN resources.
+readOnlyRootFilesystem is false: the hook Job writes the downloaded CRD bundle
+to /tmp.
+*/}}
+{{- define "strimzi-operator.containerSecurityContext" -}}
+allowPrivilegeEscalation: false
+readOnlyRootFilesystem: false
+capabilities:
+  drop: ["ALL"]
+{{- end }}
+
+{{/*
+Resolved CRD bundle URL: crdUpgrade.url when set, else the GitHub release
+bundle for .Values.strimziVersion.
+*/}}
+{{- define "strimzi-operator.crdUrl" -}}
+{{- if .Values.crdUpgrade.url -}}
+{{- .Values.crdUpgrade.url -}}
+{{- else -}}
+{{- printf "https://github.com/strimzi/strimzi-kafka-operator/releases/download/%s/strimzi-crds-%s.yaml" .Values.strimziVersion .Values.strimziVersion -}}
+{{- end -}}
+{{- end }}

--- a/charts/strimzi-operator/templates/crd-upgrade.yaml
+++ b/charts/strimzi-operator/templates/crd-upgrade.yaml
@@ -1,0 +1,208 @@
+{{- if .Values.crdUpgrade.enabled }}
+{{- /*
+Strimzi CRD applier.
+
+WHY THIS EXISTS: the upstream subchart ships its CRDs in `crds/`, and per
+`helm upgrade --help` Helm installs those "if not already present" — it never
+UPDATES them on upgrade. Without this hook, CRDs freeze at whatever version was
+first installed and the apiserver silently PRUNES fields the frozen schema does
+not know about. No error, no event; the field just vanishes.
+
+WHY NOT TEMPLATE THE CRDs INSTEAD: live CRDs carry no Helm ownership metadata,
+so templating them would break adoption of the existing release with an
+"invalid ownership metadata" error and — worse — would hand `helm uninstall`
+the power to cascade-delete every Kafka CR in the cluster
+(CRD -> Kafka/KafkaNodePool -> StrimziPodSet -> Pods). They stay in crds/.
+
+WHY A PARENT-SIDE FETCH RATHER THAN READING THE SUBCHART'S crds/: `.Files.Glob`
+cannot reach subchart files, so a hermetic ConfigMap is impossible. The bundle
+fetched here is the same pin as the subchart's crds/.
+
+ORDERING: hook-weight 1 creates the identity, weight 5 runs the Job. Helm
+defers hook-succeeded deletion to a second pass after all hooks in the phase
+complete, so the weight-1 ServiceAccount survives for the weight-5 Job.
+*/ -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "strimzi-operator.fullname" . }}-crd-upgrade
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "strimzi-operator.labels" . | nindent 4 }}
+  annotations:
+    {{- with (include "strimzi-operator.annotations" .) }}
+    {{- . | nindent 4 }}
+    {{- end }}
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "strimzi-operator.fullname" . }}-crd-upgrade
+  labels:
+    {{- include "strimzi-operator.labels" . | nindent 4 }}
+  annotations:
+    {{- with (include "strimzi-operator.annotations" .) }}
+    {{- . | nindent 4 }}
+    {{- end }}
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "strimzi-operator.fullname" . }}-crd-upgrade
+  labels:
+    {{- include "strimzi-operator.labels" . | nindent 4 }}
+  annotations:
+    {{- with (include "strimzi-operator.annotations" .) }}
+    {{- . | nindent 4 }}
+    {{- end }}
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "strimzi-operator.fullname" . }}-crd-upgrade
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "strimzi-operator.fullname" . }}-crd-upgrade
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "strimzi-operator.fullname" . }}-crd-upgrade
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "strimzi-operator.labels" . | nindent 4 }}
+  annotations:
+    {{- with (include "strimzi-operator.annotations" .) }}
+    {{- . | nindent 4 }}
+    {{- end }}
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.crdUpgrade.backoffLimit }}
+  ttlSecondsAfterFinished: {{ .Values.crdUpgrade.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        {{- include "strimzi-operator.selectorLabels" . | nindent 8 }}
+        app: crd-upgrade
+    spec:
+      serviceAccountName: {{ include "strimzi-operator.fullname" . }}-crd-upgrade
+      restartPolicy: OnFailure
+      securityContext:
+        {{- include "strimzi-operator.podSecurityContext" . | nindent 8 }}
+      containers:
+        - name: crd-upgrade
+          image: {{ include "strimzi-operator.kubectlImage" . }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              CRD_URL="{{ include "strimzi-operator.crdUrl" . }}"
+              EXPECTED_CRDS=10
+
+              echo "Applying Strimzi CRDs (v{{ .Values.strimziVersion }})..."
+              echo "Source: ${CRD_URL}"
+
+              # -f makes HTTP errors exit non-zero. Without it curl exits 0 on a
+              # 404 and writes the error body, so the failure would only surface
+              # downstream as a confusing kubectl parse error — after burning
+              # every backoffLimit attempt. --retry-all-errors covers the
+              # transient 429/503 case, which would otherwise abort a live
+              # upgrade and strand the release in pending-upgrade.
+              set +e
+              HTTP_CODE=$(curl -fsSL \
+                    --retry 5 --retry-all-errors --retry-connrefused \
+                    --max-time 120 \
+                    -w '%{http_code}' \
+                    "${CRD_URL}" -o /tmp/strimzi-crds.yaml)
+              CURL_RC=$?
+              set -e
+              if [ "${CURL_RC}" -ne 0 ]; then
+                echo "✗ Download FAILED (curl exit ${CURL_RC}, HTTP ${HTTP_CODE:-unknown})"
+                echo "  URL: ${CRD_URL}"
+                echo "  If this cluster has no egress to the URL above, mirror the"
+                echo "  bundle internally and set crdUpgrade.url — the hook needs"
+                echo "  this URL on EVERY install and upgrade."
+                exit 1
+              fi
+              echo "  Downloaded (HTTP ${HTTP_CODE})"
+
+              # Validate BEFORE mutating anything.
+              if [ ! -s /tmp/strimzi-crds.yaml ]; then
+                echo "✗ Downloaded bundle is EMPTY — refusing to apply."
+                echo "  URL: ${CRD_URL}"
+                exit 1
+              fi
+
+              FOUND=$(grep -c '^kind: CustomResourceDefinition' /tmp/strimzi-crds.yaml || true)
+              if [ "${FOUND}" -ne "${EXPECTED_CRDS}" ]; then
+                echo "✗ Expected ${EXPECTED_CRDS} CustomResourceDefinitions, found ${FOUND}."
+                echo "  URL: ${CRD_URL}"
+                echo "  The response is probably not the CRD bundle (proxy interstitial?)."
+                head -5 /tmp/strimzi-crds.yaml
+                exit 1
+              fi
+              echo "  Bundle contains ${FOUND} CRDs"
+
+              echo "Validating against the API server (dry-run)..."
+              if ! kubectl apply --server-side --force-conflicts \
+                    --dry-run=server -f /tmp/strimzi-crds.yaml >/dev/null; then
+                echo "✗ Server-side dry-run FAILED — refusing to apply."
+                exit 1
+              fi
+
+              # --force-conflicts is required: Helm 4 applies server-side by
+              # default, so its field manager co-owns these CRDs and would
+              # otherwise conflict with this Job's manager.
+              echo "Applying CRDs with server-side apply..."
+              kubectl apply --server-side --force-conflicts -f /tmp/strimzi-crds.yaml
+
+              echo "Verifying CRDs..."
+              MISSING=0
+              for crd in kafkas.kafka.strimzi.io \
+                         kafkaconnects.kafka.strimzi.io \
+                         kafkatopics.kafka.strimzi.io \
+                         kafkausers.kafka.strimzi.io \
+                         kafkanodepools.kafka.strimzi.io \
+                         kafkabridges.kafka.strimzi.io \
+                         kafkaconnectors.kafka.strimzi.io \
+                         kafkamirrormaker2s.kafka.strimzi.io \
+                         kafkarebalances.kafka.strimzi.io \
+                         strimzipodsets.core.strimzi.io; do
+                if kubectl get crd "${crd}" > /dev/null 2>&1; then
+                  echo "  ✓ ${crd}"
+                else
+                  echo "  ✗ ${crd} — MISSING"
+                  MISSING=$((MISSING + 1))
+                fi
+              done
+              if [ "${MISSING}" -gt 0 ]; then
+                echo "✗ ${MISSING} CRD(s) missing after apply."
+                exit 1
+              fi
+              echo "All ${EXPECTED_CRDS} Strimzi CRDs applied successfully."
+          securityContext:
+            {{- include "strimzi-operator.containerSecurityContext" . | nindent 12 }}
+          resources:
+            requests:
+              memory: 64Mi
+              cpu: 50m
+            limits:
+              memory: 128Mi
+              cpu: 200m
+{{- end }}

--- a/charts/strimzi-operator/templates/tests/test-operator.yaml
+++ b/charts/strimzi-operator/templates/tests/test-operator.yaml
@@ -1,0 +1,184 @@
+{{- $op := index .Values "strimzi-kafka-operator" -}}
+{{- $kubectl := include "strimzi-operator.kubectlImage" . }}
+{{- $testSA := printf "%s-test" (include "strimzi-operator.fullname" .) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $testSA }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "strimzi-operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $testSA }}
+  labels:
+    {{- include "strimzi-operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
+  # Read pods so the failure diagnostic below can actually run. Without this
+  # the diagnostic prints Forbidden at exactly the moment it is needed.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $testSA }}
+  labels:
+    {{- include "strimzi-operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $testSA }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $testSA }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "strimzi-operator.fullname" . }}-test-operator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "strimzi-operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  serviceAccountName: {{ $testSA }}
+  securityContext:
+    {{- include "strimzi-operator.podSecurityContext" . | nindent 4 }}
+  containers:
+    - name: test
+      image: {{ $kubectl }}
+      securityContext:
+        {{- include "strimzi-operator.containerSecurityContext" . | nindent 8 }}
+      command: ['sh', '-c']
+      args:
+        - |
+          echo "Waiting for the cluster operator to become Available..."
+          # The Deployment name is hardcoded upstream and is NOT derived from
+          # .Values.serviceAccount (that only sets serviceAccountName).
+          if kubectl wait --for=condition=Available \
+            deploy/strimzi-cluster-operator \
+            -n {{ .Release.Namespace }} --timeout=180s; then
+            echo "✅ Cluster operator Available"
+            exit 0
+          fi
+          echo "❌ Cluster operator not Available"
+          kubectl get pods -n {{ .Release.Namespace }}
+          exit 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "strimzi-operator.fullname" . }}-test-crds
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "strimzi-operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  serviceAccountName: {{ $testSA }}
+  securityContext:
+    {{- include "strimzi-operator.podSecurityContext" . | nindent 4 }}
+  containers:
+    - name: test
+      image: {{ $kubectl }}
+      securityContext:
+        {{- include "strimzi-operator.containerSecurityContext" . | nindent 8 }}
+      command: ['sh', '-c']
+      args:
+        - |
+          echo "Verifying Strimzi CRDs are Established..."
+          CRDS="kafkas.kafka.strimzi.io \
+                kafkaconnects.kafka.strimzi.io \
+                kafkatopics.kafka.strimzi.io \
+                kafkausers.kafka.strimzi.io \
+                kafkanodepools.kafka.strimzi.io \
+                kafkabridges.kafka.strimzi.io \
+                kafkaconnectors.kafka.strimzi.io \
+                kafkamirrormaker2s.kafka.strimzi.io \
+                kafkarebalances.kafka.strimzi.io \
+                strimzipodsets.core.strimzi.io"
+          FAIL=0
+          for crd in $CRDS; do
+            if kubectl wait --for=condition=Established "crd/${crd}" --timeout=60s >/dev/null 2>&1; then
+              echo "  ✅ ${crd}"
+            else
+              echo "  ❌ ${crd} not Established"
+              FAIL=$((FAIL + 1))
+            fi
+          done
+          if [ "$FAIL" -gt 0 ]; then
+            echo "❌ ${FAIL} CRD(s) not Established"
+            exit 1
+          fi
+          echo "✅ All 10 Strimzi CRDs Established"
+{{- if $op.watchAnyNamespace }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "strimzi-operator.fullname" . }}-test-watch-scope
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "strimzi-operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  serviceAccountName: {{ $testSA }}
+  securityContext:
+    {{- include "strimzi-operator.podSecurityContext" . | nindent 4 }}
+  containers:
+    - name: test
+      image: {{ $kubectl }}
+      securityContext:
+        {{- include "strimzi-operator.containerSecurityContext" . | nindent 8 }}
+      command: ['sh', '-c']
+      args:
+        - |
+          # Defense-in-depth. The chart default makes a watch-scope collapse
+          # unreachable today, but the subchart's values block keeps
+          # additionalProperties: true (upstream has ~40 keys that drift every
+          # release), so a typo inside that block stays silent. This assertion
+          # is what makes it loud.
+          echo "Asserting the operator watches ALL namespaces..."
+          SCOPE=$(kubectl get deploy strimzi-cluster-operator \
+            -n {{ .Release.Namespace }} \
+            -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="STRIMZI_NAMESPACE")].value}')
+          echo "  STRIMZI_NAMESPACE=${SCOPE:-<unset>}"
+          if [ "${SCOPE}" = "*" ]; then
+            echo "✅ Watch scope is cluster-wide as configured"
+            exit 0
+          fi
+          echo "❌ watchAnyNamespace=true but STRIMZI_NAMESPACE is not '*'."
+          echo "   Kafka clusters outside {{ .Release.Namespace }} would go UNMANAGED."
+          exit 1
+{{- end }}

--- a/charts/strimzi-operator/values-dev.yaml
+++ b/charts/strimzi-operator/values-dev.yaml
@@ -1,0 +1,15 @@
+# Strimzi Operator — Development Overlay
+# Usage: helm dependency build charts/strimzi-operator && helm upgrade --install strimzi-operator charts/strimzi-operator -n strimzi-operator -f charts/strimzi-operator/values-dev.yaml
+
+strimzi-kafka-operator:
+  # Verbose reconciliation logs for debugging operand behavior.
+  logLevel: DEBUG
+  resources:
+    requests:
+      memory: 384Mi
+
+  # NOTE: leaderElection is deliberately NOT disabled here. The retired CLI call
+  # site passed a misspelled `leaderElection.enabled=false` that Helm silently
+  # ignored, so leader election has never actually been off on any cluster —
+  # setting it false would be a NEW behavior change needing its own
+  # justification, not a dev convenience. With replicas=1 it is nearly free.

--- a/charts/strimzi-operator/values-generic.yaml
+++ b/charts/strimzi-operator/values-generic.yaml
@@ -1,0 +1,34 @@
+# Strimzi Operator — Generic Cluster Overlay
+# Usage: helm dependency build charts/strimzi-operator && helm upgrade --install strimzi-operator charts/strimzi-operator -n strimzi-operator -f charts/strimzi-operator/values-generic.yaml
+#
+# For clusters whose topology is not known ahead of time (EKS/GKE/AKS/on-prem).
+# This overlay is mostly documentation — it carries two facts that are easy to
+# get wrong and silently break the operator.
+#
+# 1. THE DNS DOMAIN MUST BE INJECTED BY THE CALLER.
+#    Upstream only emits KUBERNETES_SERVICE_DNS_DOMAIN when the value differs
+#    from cluster.local. So on a default cluster, omitting it is invisible —
+#    and on a cluster with a custom domain, omitting it silently produces a
+#    broken operator that cannot resolve its operands. scripts/deploy-kafka-generic.sh
+#    detects the domain (get_cluster_domain) and must pass it through:
+#
+#      --set strimzi-kafka-operator.kubernetesServiceDnsDomain="${CLUSTER_DOMAIN}"
+#
+#    It is NOT set here: a hardcoded value in an overlay would defeat detection.
+#
+# 2. REGISTRY REDIRECTION IS defaultImageRegistry, NOT global.imageRegistry.
+#    The upstream chart contains zero `.Values.global` references and ignores
+#    global.imageRegistry entirely — setting it leaves the operator image at
+#    quay.io/strimzi/operator with no warning. This chart therefore does not
+#    declare a `global` block at all, so `--set global.imageRegistry=...` fails
+#    loudly against the schema instead of being silently dropped. Use:
+#
+#      strimzi-kafka-operator:
+#        defaultImageRegistry: registry.example.com
+#        defaultImageRepository: strimzi
+
+strimzi-kafka-operator:
+  # Unknown clusters may or may not run Grafana with a dashboard sidecar, and
+  # these ConfigMaps collide with kafka-cluster's dashboards block.
+  dashboards:
+    enabled: false

--- a/charts/strimzi-operator/values-kind.yaml
+++ b/charts/strimzi-operator/values-kind.yaml
@@ -1,0 +1,12 @@
+# Strimzi Operator — kind Overlay
+# Usage: helm dependency build charts/strimzi-operator && helm upgrade --install strimzi-operator charts/strimzi-operator -n strimzi-operator -f charts/strimzi-operator/values-kind.yaml
+
+strimzi-kafka-operator:
+  # Local kind nodes are memory-constrained; 768Mi is sized for a real cluster.
+  resources:
+    limits:
+      memory: 384Mi
+    requests:
+      memory: 384Mi
+  podDisruptionBudget:
+    enabled: false

--- a/charts/strimzi-operator/values-prod.yaml
+++ b/charts/strimzi-operator/values-prod.yaml
@@ -1,0 +1,81 @@
+# Strimzi Operator — Production Overlay (UPLIFT, NOT current behavior)
+# Usage: helm dependency build charts/strimzi-operator && helm upgrade --install strimzi-operator charts/strimzi-operator -n strimzi-operator -f charts/strimzi-operator/values-prod.yaml
+#
+# READ BEFORE ENABLING. These settings have NEVER been applied to any cluster.
+# They were stranded in config/kafka/strimzi-values.yaml, whose header claimed
+# deploy-kafka.sh passed it with -f — it never did. Proof: the live operator
+# runs STRIMZI_FULL_RECONCILIATION_INTERVAL_MS=120000 (the upstream default),
+# not the 60000 that file specifies.
+#
+# So this overlay is a REAL BEHAVIOR CHANGE, not a restatement of the status
+# quo. Measured against this chart: it takes the operator from 17 to 19
+# resources (+1 NetworkPolicy, +1 PodDisruptionBudget), tightens the
+# reconciliation loop, and flips the operator to a read-only root filesystem.
+# Enabling dashboards below would add 9 more ConfigMaps. Roll it out
+# deliberately, not as a default.
+
+strimzi-kafka-operator:
+  # ── Hardening ──────────────────────────────────────────────────────────────
+  podSecurityContext:
+    runAsNonRoot: true
+    fsGroup: 1001
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: ["ALL"]
+
+  # ── Availability ───────────────────────────────────────────────────────────
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+    unhealthyPodEvictionPolicy: IfHealthyBudget
+  priorityClassName: system-cluster-critical
+
+  # ── Reconciliation ─────────────────────────────────────────────────────────
+  # Tighter loop than the 120000 default — more responsive, more API traffic.
+  fullReconciliationIntervalMs: 60000
+
+  # ── Network ────────────────────────────────────────────────────────────────
+  # Restricts access to the OPERATOR deployment only. Does NOT control the
+  # NetworkPolicies the operator generates for Kafka operands.
+  operatorNetworkPolicy:
+    enabled: true
+
+  # ── Resources ──────────────────────────────────────────────────────────────
+  # 768Mi is what runs live today. Do NOT lower this to the 512Mi that
+  # config/kafka/strimzi-values.yaml specified — that would REGRESS production
+  # below its current allocation. Memory only; cpu inherits upstream defaults.
+  resources:
+    limits:
+      memory: 768Mi
+    requests:
+      memory: 768Mi
+
+  # ── Dashboards: left OFF deliberately ──────────────────────────────────────
+  # Upstream creates 9 Grafana ConfigMaps whose names are independent of the
+  # release name, and charts/kafka-cluster/values.yaml has its own dashboards
+  # block targeting the `kafka` namespace. Enabling this without resolving
+  # ownership produces colliding ConfigMaps. Decide who owns the dashboards
+  # first, then enable on ONE side.
+  dashboards:
+    enabled: false
+
+# ── Airgapped / restricted-egress clusters ───────────────────────────────────
+# The CRD hook needs egress to the bundle URL on EVERY install AND upgrade —
+# it is a pre-upgrade gate, so if the URL is unreachable the upgrade aborts and
+# the release is left in pending-upgrade. Mirror the bundle internally and
+# point the hook at it:
+#
+# crdUpgrade:
+#   url: "https://mirror.internal/strimzi-crds-1.1.0.yaml"
+#
+# Separately, `helm dependency build` needs egress to quay.io to pull the
+# operator subchart. Registry redirection for the operator IMAGE is
+# strimzi-kafka-operator.defaultImageRegistry (NOT global.imageRegistry, which
+# upstream ignores entirely):
+#
+# strimzi-kafka-operator:
+#   defaultImageRegistry: registry.internal

--- a/charts/strimzi-operator/values.schema.json
+++ b/charts/strimzi-operator/values.schema.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "strimzi-operator values",
+  "description": "DELIBERATE DEVIATION: additionalProperties is false at the top level, unlike every other chart in this repo. Justification: (a) it catches the leaderElection.enabled typo class that silently no-op'd in the old CLI call site, and (b) it forces the one-time values-namespace migration to be explicit rather than leaving stale flat keys (watchAnyNamespace, replicas, resources, ...) in the release record forever, where `helm get values` displays config that looks live but is ignored. COST, one-time: bare `helm upgrade` reuses the previous release's stored values and will FAIL validation until --reset-values (or -f <overlay>) is passed once. It does NOT prevent a watch-scope collapse — the chart default supplies '*' for that.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "commonLabels": { "type": "object" },
+    "commonAnnotations": { "type": "object" },
+    "strimziVersion": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Strimzi version used to build the CRD bundle URL. Must equal Chart.yaml appVersion and the dependency version."
+    },
+    "testImages": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "kubectl": {
+          "type": "string",
+          "minLength": 1,
+          "description": "kubectl image for the CRD-upgrade hook Job and Helm tests."
+        }
+      }
+    },
+    "crdUpgrade": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "url": {
+          "type": "string",
+          "description": "Override the CRD bundle URL. Empty derives it from strimziVersion. Point this at an internal mirror for airgapped clusters."
+        },
+        "backoffLimit": { "type": "integer", "minimum": 0 },
+        "ttlSecondsAfterFinished": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "strimzi-kafka-operator": {
+      "type": "object",
+      "description": "Upstream subchart values. additionalProperties stays TRUE here on purpose: upstream exposes ~40 keys that drift every release, and enumerating them would turn each Strimzi bump into a schema chore.",
+      "additionalProperties": true,
+      "properties": {
+        "replicas": { "type": "integer", "minimum": 1 },
+        "watchAnyNamespace": { "type": "boolean" },
+        "watchNamespaces": { "type": "array" },
+        "kubernetesServiceDnsDomain": { "type": "string", "minLength": 1 },
+        "operationTimeoutMs": { "type": "integer", "minimum": 1 },
+        "fullReconciliationIntervalMs": { "type": "integer", "minimum": 1 },
+        "createGlobalResources": { "type": "boolean" },
+        "createAggregateRoles": { "type": "boolean" },
+        "defaultImageRegistry": {
+          "type": "string",
+          "description": "Registry redirection for operator and operand images. This — NOT global.imageRegistry — is the key upstream honors."
+        },
+        "defaultImageRepository": { "type": "string" },
+        "defaultImageTag": { "type": "string" },
+        "logLevel": { "type": "string" },
+        "priorityClassName": { "type": "string" },
+        "serviceAccount": { "type": "string", "minLength": 1 },
+        "serviceAccountCreate": { "type": "boolean" },
+        "rbac": {
+          "type": "object",
+          "properties": {
+            "create": { "type": "boolean" }
+          }
+        },
+        "leaderElection": {
+          "type": "object",
+          "description": "additionalProperties is FALSE here on purpose: the upstream key is `enable`, and the retired CLI call site set a misspelled `enabled` that Helm silently ignored for the lifetime of the release. This makes that typo class unrepeatable.",
+          "additionalProperties": false,
+          "properties": {
+            "enable": { "type": "boolean" }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu": { "type": ["string", "integer"] },
+                "memory": { "type": "string" }
+              }
+            },
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu": { "type": ["string", "integer"] },
+                "memory": { "type": "string" }
+              }
+            }
+          }
+        },
+        "podDisruptionBudget": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "minAvailable": { "type": ["integer", "string"] },
+            "maxUnavailable": { "type": ["integer", "string", "null"] },
+            "unhealthyPodEvictionPolicy": {
+              "type": "string",
+              "enum": ["IfHealthyBudget", "AlwaysAllow"]
+            }
+          }
+        },
+        "operatorNetworkPolicy": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "ingress": { "type": ["array", "null"] },
+            "egress": { "type": ["array", "null"] }
+          }
+        },
+        "dashboards": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "namespace": { "type": ["string", "null"] },
+            "label": { "type": "string" },
+            "labelValue": { "type": "string" }
+          }
+        },
+        "podSecurityContext": { "type": "object" },
+        "securityContext": { "type": "object" }
+      }
+    }
+  }
+}

--- a/charts/strimzi-operator/values.yaml
+++ b/charts/strimzi-operator/values.yaml
@@ -1,0 +1,151 @@
+# Strimzi Operator — Default Values
+#
+# Wraps the upstream strimzi-kafka-operator chart with the kates defaults that
+# were previously duplicated (and drifting) across three ad-hoc `helm` call
+# sites. The defaults below reproduce what is LIVE today — not what any single
+# call site intended.
+#
+# FOUR THINGS TO KNOW BEFORE YOU EDIT THIS FILE:
+#
+# 1. CRD LIFECYCLE. The upstream chart ships its CRDs in `crds/`, so `helm
+#    install` creates them, `helm upgrade` NEVER updates them, and `helm
+#    uninstall` never deletes them. The `crdUpgrade` hook below closes that
+#    gap. Disable it and your CRDs freeze at the version first installed.
+#
+# 2. NESTING IS MANDATORY. Every operator setting MUST live under the
+#    `strimzi-kafka-operator:` key. A top-level `watchAnyNamespace: true` is
+#    silently ignored by Helm — values.schema.json rejects it deliberately so
+#    the mistake is loud instead of silent.
+#
+# 3. THIS CHART HAS A SUBCHART. Run `helm dependency build charts/strimzi-operator`
+#    before install/upgrade/template or it will not render at all.
+#
+# 4. REGISTRY REDIRECTION is `strimzi-kafka-operator.defaultImageRegistry`.
+#    NOT `global.imageRegistry` — upstream contains zero `.Values.global`
+#    references and ignores it entirely, so this chart does not declare it.
+
+nameOverride: ""
+fullnameOverride: ""
+
+# -- Extra labels added to every resource this chart renders
+commonLabels: {}
+# -- Extra annotations added to every resource this chart renders
+commonAnnotations: {}
+
+# ── Strimzi version ──────────────────────────────────────────────────────────
+# -- Strimzi version used to build the CRD bundle URL for the crdUpgrade hook.
+# MUST equal Chart.yaml's appVersion, the dependency version, and versions.env
+# STRIMZI_VERSION — otherwise the hook applies CRDs for a different operator
+# than the one being installed. Enforced by scripts/check-versions.sh.
+strimziVersion: "1.1.0"
+
+# ── Image sources ────────────────────────────────────────────────────────────
+# -- Images used by this chart's OWN resources (the CRD-upgrade hook and Helm
+# tests). The operator's own image comes from the subchart.
+testImages:
+  # -- kubectl image used by the CRD-upgrade hook Job and the Helm tests
+  kubectl: "ghcr.io/bmscomp/kates-tester:1.17.0"
+
+# ── CRD lifecycle ────────────────────────────────────────────────────────────
+# Closes the gap Helm leaves: crds/ is applied on install and never on upgrade.
+# This hook runs pre-install AND pre-upgrade, so CRDs are current before the
+# operator Deployment is patched.
+crdUpgrade:
+  # -- Apply the Strimzi CRD bundle via a pre-install/pre-upgrade hook Job
+  enabled: true
+  # -- Override the CRD bundle URL (empty = derive from strimziVersion).
+  # Set this to an internal mirror for airgapped clusters — see values-prod.yaml.
+  url: ""
+  # -- Job retry budget before the install/upgrade is aborted
+  backoffLimit: 3
+  # -- Seconds to retain a FAILED Job for log inspection. This never applies to
+  # the success path: the hook carries `hook-delete-policy: hook-succeeded`, so
+  # Helm deletes the Job the moment it succeeds and there is nothing left for
+  # the TTL to govern. On failure the Job survives, and this is its retention.
+  ttlSecondsAfterFinished: 300
+
+# ── Upstream Strimzi operator (subchart) ─────────────────────────────────────
+# The ONLY place operator settings take effect. Full key reference:
+#   https://github.com/strimzi/strimzi-kafka-operator/blob/main/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+#
+# Only FOUR keys below deviate from stock upstream; everything else is pinned
+# for safety or is an explicit restatement of an upstream default.
+strimzi-kafka-operator:
+  # -- Operator replicas. All three previous call sites set 1.
+  replicas: 1
+
+  # -- Watch every namespace (STRIMZI_NAMESPACE="*"). All three previous call
+  # sites set this; verified live. This default is what makes the retired
+  # top-level `--set watchAnyNamespace=true` harmless rather than dangerous.
+  watchAnyNamespace: true
+
+  # -- Cluster DNS domain. Upstream only emits KUBERNETES_SERVICE_DNS_DOMAIN
+  # when this differs from cluster.local, so callers on non-default domains
+  # MUST inject the detected value (see values-generic.yaml).
+  kubernetesServiceDnsDomain: cluster.local
+
+  # -- Reconciliation operation timeout. Upstream default is 300000; 900000 is
+  # what the CLI set and what runs live, so it is the behavior-preserving value.
+  operationTimeoutMs: 900000
+
+  # -- Full reconciliation interval. Upstream default; verified live. NOT the
+  # 60000 in config/kafka/strimzi-values.yaml, which was never applied.
+  fullReconciliationIntervalMs: 120000
+
+  # -- Operator resources. MEMORY ONLY: 768Mi is what runs live (upstream
+  # default is 384Mi). cpu is deliberately NOT set — upstream already defaults
+  # it to limits 1000m / requests 200m, and duplicating that here would create
+  # a second source of truth for a value nobody overrode.
+  resources:
+    limits:
+      memory: 768Mi
+    requests:
+      memory: 768Mi
+
+  # -- Leader election. `enable` is the correct upstream key and defaults to
+  # true. The old CLI passed a misspelled `leaderElection.enabled=false` that
+  # Helm silently ignored — leader election has never actually been off, so
+  # true is behavior-preserving. Setting false here would be a NEW change.
+  leaderElection:
+    enable: true
+
+  # ── Pinned for safety (restating upstream defaults on purpose) ─────────────
+  # -- Create the cluster-scoped ClusterRoles/ClusterRoleBindings. Setting this
+  # false leaves exactly four bindings with dangling roleRefs.
+  createGlobalResources: true
+  # -- Aggregate ClusterRoles that extend existing roles with Strimzi CRD access
+  createAggregateRoles: false
+  rbac:
+    # -- Create the operator's RBAC resources
+    create: true
+  # -- Create the operator ServiceAccount
+  serviceAccountCreate: true
+  # -- Operator ServiceAccount name. Upstream templates the RBAC subjects and
+  # the Deployment's serviceAccountName from this value, so it is genuinely
+  # overridable. What is NOT overridable is the Deployment's own name, which
+  # upstream hardcodes to `strimzi-cluster-operator` — the Helm tests key on
+  # that literal, not on this value.
+  serviceAccount: strimzi-cluster-operator
+
+  # ── Off by default — these are uplifts, enable via values-prod.yaml ────────
+  # -- PodDisruptionBudget for the operator Deployment
+  podDisruptionBudget:
+    enabled: false
+  # -- NetworkPolicy for the operator Deployment (does NOT affect operator-
+  # generated policies for Kafka operands)
+  operatorNetworkPolicy:
+    enabled: false
+  # -- Grafana dashboard ConfigMaps. Upstream names these independently of the
+  # release, so they collide with kafka-cluster's dashboards block. Resolve
+  # ownership before enabling.
+  dashboards:
+    enabled: false
+
+  # -- Pod-level security context for the operator. Empty = live behavior;
+  # hardening is an opt-in uplift in values-prod.yaml.
+  podSecurityContext: {}
+  # -- Container-level security context for the operator. Empty = live behavior.
+  securityContext: {}
+
+  # NOTE: defaultImageTag is deliberately NOT pinned — upstream defaults it to
+  # its own appVersion, so pinning would duplicate the version pin.

--- a/cli/cmd/deploy_components.go
+++ b/cli/cmd/deploy_components.go
@@ -22,10 +22,12 @@ func deployGroupA(dc *deployContext) error {
 	// ---------------------------------------------------------
 	// GROUP A: Operators & CRDs (Parallel)
 	// ---------------------------------------------------------
-	deployStrimzi := false
-	if deployWithStrimzi {
-		deployStrimzi = !isHelmReleaseDeployedFn(ctx, "strimzi-operator", "strimzi-operator")
-	}
+	// Strimzi is reconciled unconditionally. `helm upgrade --install` converges,
+	// and charts/strimzi-operator's pre-upgrade hook is what keeps the CRDs
+	// current — skipping when the release already exists means the hook never
+	// fires on an existing cluster and the CRDs silently freeze at whatever
+	// version first installed them.
+	deployStrimzi := deployWithStrimzi
 	deployCertMgr := false
 	if deployWithCertManager {
 		deployCertMgr = !isHelmReleaseDeployedFn(ctx, "cert-manager", "cert-manager")
@@ -53,15 +55,27 @@ kind: Namespace
 metadata:
   name: strimzi-operator`)
 			clusterDomain := dc.resolveClusterDomain()
-			err := runHelmFn(gCtx, "upgrade", "--install", "strimzi-operator", "oci://quay.io/strimzi-helm/strimzi-kafka-operator", "--version", "1.1.0", "-n", "strimzi-operator",
-				"--set", "watchAnyNamespace=true",
-				"--set", "kubernetesServiceDnsDomain="+clusterDomain,
-				"--set", "replicas=1",
-				"--set", "resources.limits.memory=768Mi",
-				"--set", "resources.requests.memory=768Mi",
-				"--set", "leaderElection.enabled=false",
-				"--set", "operationTimeoutMs=900000",
-				"--timeout", "5m")
+			// The wrapper chart does not render until its subchart is fetched.
+			// `build` (not `update`) resolves from Chart.lock, so the pinned
+			// Strimzi version cannot drift.
+			if err := runHelmFn(gCtx, "dependency", "build", "charts/strimzi-operator"); err != nil {
+				return err
+			}
+			// Everything this call site used to --set is now pinned in the
+			// chart's values.yaml; only the cluster domain is environment-
+			// specific. The old leaderElection.enabled=false is gone on
+			// purpose: `enabled` was a typo for the upstream key `enable`, so
+			// Helm silently ignored it and leader election has always been on.
+			// Dropping it preserves that behavior; turning it off is a separate
+			// decision, not a side effect of this refactor.
+			//
+			// --reset-values: pre-chart releases stored flat upstream keys that
+			// now live under the subchart key, and the schema rejects them.
+			err := runHelmFn(gCtx, "upgrade", "--install", "strimzi-operator", "charts/strimzi-operator", "-n", "strimzi-operator",
+				"--reset-values",
+				"-f", dc.chartOverlay("charts/strimzi-operator"),
+				"--set", "strimzi-kafka-operator.kubernetesServiceDnsDomain="+clusterDomain,
+				"--timeout", "10m")
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/deploy_test.go
+++ b/cli/cmd/deploy_test.go
@@ -237,11 +237,27 @@ func TestDeployCommand_Idempotency(t *testing.T) {
 		t.Fatalf("runDeploy failed: %v", err)
 	}
 
-	// Because everything is already deployed, no `helm upgrade` should be called.
+	// Everything already deployed => no `helm upgrade`, with ONE deliberate
+	// exception: the Strimzi operator is always reconciled.
+	//
+	// Skipping is not idempotency — `helm upgrade --install` converges, which is
+	// the real thing. Skipping strimzi-operator when its release exists means
+	// charts/strimzi-operator's pre-upgrade CRD hook never fires on an existing
+	// cluster, so the CRDs freeze at whatever version first installed them while
+	// the API server silently prunes fields the newer operator needs.
+	var strimziUpgraded bool
 	for _, cmd := range executedCommands {
-		if strings.Contains(cmd, "helm upgrade") {
-			t.Errorf("Expected no helm upgrade commands to run due to idempotency, got: %s", cmd)
+		if !strings.Contains(cmd, "helm upgrade") {
+			continue
 		}
+		if strings.Contains(cmd, "strimzi-operator") {
+			strimziUpgraded = true
+			continue
+		}
+		t.Errorf("Expected no helm upgrade commands to run due to idempotency, got: %s", cmd)
+	}
+	if !strimziUpgraded {
+		t.Error("Expected strimzi-operator to be reconciled unconditionally, but no helm upgrade ran for it")
 	}
 }
 

--- a/cli/pkg/detect/remediation.go
+++ b/cli/pkg/detect/remediation.go
@@ -21,8 +21,13 @@ func GenerateRemediation(report *DetectReport) []Remediation {
 			Check:    "Strimzi CRDs installed",
 			Severity: "critical",
 			Summary:  "Strimzi Custom Resource Definitions are not installed",
+			// Must match the release name and namespace the deploy paths use.
+			// The operator is a cluster singleton — its RBAC and lease names are
+			// hardcoded upstream — so a differently-named release does not
+			// install a second operator, it collides with the first.
 			Commands: []string{
-				"helm install strimzi oci://quay.io/strimzi-helm/strimzi-kafka-operator --namespace kafka --create-namespace",
+				"helm dependency build charts/strimzi-operator",
+				"helm upgrade --install strimzi-operator charts/strimzi-operator --namespace strimzi-operator --create-namespace",
 			},
 			DocURL: "https://strimzi.io/docs/operators/latest/deploying",
 		})

--- a/docs/book/_quarto.yml
+++ b/docs/book/_quarto.yml
@@ -49,6 +49,7 @@ book:
 
     - part: "Part V — Deployment & Operations"
       chapters:
+        - deploying-strimzi-operator.md
         - 20-installation-guide.md
         - 15-kafka-deployment.md
         - 12-deployment.md

--- a/docs/book/appendix-d-versions.md
+++ b/docs/book/appendix-d-versions.md
@@ -24,6 +24,7 @@ Every version the platform pins, in one place. This table is generated from the 
 | `kates` chart | 0.4.4 (app 1.20.0) | `charts/kates/Chart.yaml` |
 | `minio` chart | 17.0.21 (app 2025.7.23) | `charts/minio/Chart.yaml` |
 | `monitoring` chart | 1.0.0 (app 82.4.3) | `charts/monitoring/Chart.yaml` |
+| `strimzi-operator` chart | 0.1.0 (app 1.1.0) | `charts/strimzi-operator/Chart.yaml` |
 | `velero` chart | 11.3.2 (app 1.17.1) | `charts/velero/Chart.yaml` |
 <!-- version-matrix:end -->
 

--- a/docs/book/deploying-strimzi-operator.md
+++ b/docs/book/deploying-strimzi-operator.md
@@ -1,0 +1,567 @@
+# Deploying the Strimzi Operator
+
+Every Kafka cluster in this repository is a custom resource, and a custom resource is inert without two things: the CRD that defines its schema, and an operator that reconciles it into pods. The `strimzi-operator` chart owns both. It is the first thing installed on a new cluster and the last thing to touch casually on a running one — the operator's version decides which Kafka versions exist at all, and its CRDs are the only reason your `Kafka` resources are still in etcd.
+
+> **Scope**: installing, migrating to, upgrading, and rolling back the `charts/strimzi-operator` release. For the engineering rationale behind the cluster it manages — node pools, listeners, certificates — see [Kafka Deployment Engineering](15-kafka-deployment.md). For the Kafka cluster install that follows this one, see [Installing Kafka with the kafka-cluster Helm Chart](20-installation-guide.md).
+
+After this chapter, you can:
+
+- Install the operator from the chart and prove the watch scope, the CRDs, and the operand images took effect
+- Explain why the operator is a separate Helm release from `kafka-cluster`, and why its CRDs live in `crds/` rather than `templates/`
+- Migrate the existing ad-hoc `oci://` release onto the chart without recreating a single resource — and defer the data-plane roll that adoption triggers
+- Recognize the two operations that would delete every Kafka custom resource in the cluster, and the one flag that keeps upgrades failing loudly instead of silently
+
+## What the Chart Deploys
+
+`charts/strimzi-operator` is a thin wrapper. It declares the upstream `strimzi-kafka-operator` chart as a subchart dependency, vendors none of its templates, and adds three things the upstream chart does not provide: a CRD-upgrade hook, a strict values schema, and Helm tests. It also pins the kates defaults that were previously scattered across `--set` flags at each call site.
+
+The release is small, and its shape is the single most important thing to understand about it:
+
+| Scope | Resources |
+|-------|-----------|
+| Cluster-scoped | `ClusterRole`: `strimzi-cluster-operator-namespaced`, `-global`, `-leader-election`, `-watched`, `strimzi-kafka-broker`, `strimzi-entity-operator`, `strimzi-kafka-client` · `ClusterRoleBinding`: `strimzi-cluster-operator-namespaced`, `strimzi-cluster-operator`, `-watched`, `-kafka-broker-delegation`, `-entity-operator-delegation`, `-kafka-client-delegation` |
+| Namespaced | `ServiceAccount`, `ConfigMap`, and `Deployment` named `strimzi-cluster-operator`, plus the `RoleBinding` `strimzi-cluster-operator-leader-election` |
+
+Thirteen of those seventeen resources are cluster-scoped, and every name in the table is hardcoded upstream — none of them derive from the Helm release name. That makes this chart a **cluster singleton**: two releases cannot coexist, cannot be distinguished, and cannot arbitrate between themselves. There is no parallel install-then-cutover, and no blue-green. Every procedure in this chapter follows from that constraint.
+
+## Why a Separate Release
+
+The operator is not a subchart of `kafka-cluster`, and it never becomes one. The reason is a chicken-and-egg problem in Helm's own validation order:
+
+```mermaid
+graph TB
+    subgraph Release1["Release: strimzi-operator (namespace: strimzi-operator)"]
+        CRD["Strimzi CRDs<br/>(crds/ — applied on install)"]
+        OP["Cluster Operator<br/>Deployment"]
+    end
+
+    subgraph Release2["Release: kafka-cluster (namespace: kafka)"]
+        K["Kafka CR: krafter"]
+        NP["KafkaNodePool CRs"]
+        KU["KafkaUser / KafkaTopic CRs"]
+    end
+
+    CRD -->|"schema must exist<br/>BEFORE these validate"| K
+    CRD --> NP
+    CRD --> KU
+    OP -->|"reconciles into<br/>StrimziPodSets, Pods, Secrets"| K
+```
+
+Helm validates a manifest against the API server before it creates anything. A `Kafka` resource whose CRD does not yet exist is rejected outright — Helm cannot install a CRD and a resource that depends on that CRD in the same pass reliably, because CRD establishment is asynchronous. Splitting them into two releases makes the ordering explicit and enforceable: the operator release completes, its CRDs reach `Established`, and only then does the cluster release have a schema to validate against.
+
+The split has a second benefit that matters more day to day. The operator is cluster-wide (it watches every namespace), while `kafka-cluster` is a per-cluster, per-namespace artifact. Folding a singleton into a chart you might install twice is how you get two operators fighting over the same `StrimziPodSet` writes.
+
+## The CRD Lifecycle Gap
+
+This is the mechanical fact that shapes the chart. The upstream chart ships its CRDs in `crds/`, not `templates/` — ten of them: `kafkas`, `kafkaconnects`, `kafkatopics`, `kafkausers`, `kafkanodepools`, `kafkabridges`, `kafkaconnectors`, `kafkamirrormaker2s`, and `kafkarebalances` in the `kafka.strimzi.io` group, plus `strimzipodsets` in `core.strimzi.io`. Helm treats that directory unlike anything else, and `helm upgrade --help` states the behavior plainly:
+
+> `--skip-crds`: if set, no CRDs will be installed when an upgrade is performed with install flag enabled. By default, CRDs are installed if not already present, when an upgrade is performed with install flag enabled
+
+Read that carefully — *installed if not already present*. There is no update path. The consequences:
+
+| Helm operation | What happens to `crds/` |
+|----------------|-------------------------|
+| `helm install` | Applied, once |
+| `helm upgrade` | **Never updated** — already present, so skipped |
+| `helm uninstall` | **Never deleted** — Helm does not track them |
+| `helm get manifest` | They do not appear — Helm does not know they exist |
+
+Left alone, the CRDs freeze at whatever version was first installed while the operator moves on. That failure is silent in the worst way: the API server accepts a `Kafka` resource carrying fields the frozen schema does not know about, then **prunes them**. No error, no event, no rejection — the field simply vanishes between `kubectl apply` and etcd.
+
+The chart closes the gap with a `pre-install`/`pre-upgrade` hook Job in `charts/strimzi-operator/templates/crd-upgrade.yaml`. It runs before the operator Deployment is patched, so the schema is always current before the controller that depends on it starts. The Job fetches the pinned CRD bundle and validates it three ways before mutating anything: the download must succeed (`curl -f`, so an HTTP error is an error rather than a 404 body written to disk), the bundle must contain exactly ten `CustomResourceDefinition` documents, and a `kubectl apply --server-side --dry-run=server` must pass. Only then does it apply for real, with `--force-conflicts` — Helm 4 applies server-side by default, so its field manager co-owns these CRDs and would otherwise conflict.
+
+::: {.callout-note}
+The hook needs egress to the CRD bundle URL on **every** install and upgrade, not just the first. Because it is a `pre-upgrade` gate, an unreachable URL aborts the upgrade and leaves the release in `pending-upgrade`. On restricted-egress clusters, mirror the bundle and point `crdUpgrade.url` at it — `charts/strimzi-operator/values-prod.yaml` documents the pattern.
+:::
+
+### Why the CRDs Stay in `crds/`
+
+Moving them into `templates/` would look tidier and would be a serious mistake, for two independent reasons.
+
+The first is adoption: the CRDs on a running cluster carry no Helm ownership metadata, so templating them makes the very first upgrade fail with an ownership error.
+
+The second is the one that matters:
+
+::: {.callout-caution}
+Templating the CRDs would hand `helm uninstall` the power to delete every Kafka custom resource in the cluster. Kubernetes garbage collection cascades along the whole chain — `CRD → Kafka / KafkaNodePool → StrimziPodSet → Pods`. Deleting a Strimzi CRD deletes every resource of that kind cluster-wide, and the operator then tears down the workloads behind them. Today Helm cannot do this, because it does not know the CRDs exist. Keep it that way: the CRDs stay in the subchart's `crds/`, and nothing in this chart templates them.
+:::
+
+## Deploying the Operator
+
+### Prerequisites
+
+The chart declares a subchart, so the dependency must be fetched **before** any Helm operation — template, lint, install, or upgrade:
+
+```bash
+helm dependency build charts/strimzi-operator
+```
+
+Skip it and every command fails before it ever contacts the cluster:
+
+Output:
+
+```text
+Error: an error occurred while checking for chart dependencies. You may need to run 'helm dependency build' to fetch missing dependencies: found in Chart.yaml, but missing in charts/ directory: strimzi-kafka-operator
+```
+
+::: {.callout-warning}
+`helm lint` only **warns** about a missing dependency and still reports `0 chart(s) failed`. A green lint does not mean a deployable chart — the failure surfaces at deploy time. Any CI job or script that renders this chart must run `helm dependency build` first.
+:::
+
+The dependency build pulls from `quay.io`, and the CRD hook fetches from `github.com`. Both are required egress paths; the first one is not new, since the ad-hoc install this chart replaces already pulled the same chart from the same registry.
+
+### Fresh Install
+
+```bash
+helm dependency build charts/strimzi-operator
+
+helm upgrade --install strimzi-operator charts/strimzi-operator \
+  --namespace strimzi-operator --create-namespace \
+  --timeout 5m --wait
+```
+
+That is the whole install. No `--version` flag and no `--set` flags: the version is pinned in `Chart.yaml`, and the defaults already reproduce what runs in production.
+
+### Environment Overlays
+
+Four overlays ship with the chart. All of them are overrides only — they layer on top of the defaults rather than restating them.
+
+| Overlay | What it changes | When to use it |
+|---------|-----------------|----------------|
+| `values-kind.yaml` | Lowers operator memory to fit a laptop; PDB off | Local `panda` Kind cluster |
+| `values-dev.yaml` | `logLevel: DEBUG`, lower memory request | Debugging operand reconciliation |
+| `values-prod.yaml` | Hardening, PDB, NetworkPolicy, tighter reconciliation loop | Production — **read the header first** |
+| `values-generic.yaml` | Dashboards off; documents DNS-domain injection | Clusters whose topology is not known ahead of time (EKS/GKE/AKS/on-prem) |
+
+```bash
+helm upgrade --install strimzi-operator charts/strimzi-operator \
+  --namespace strimzi-operator --create-namespace \
+  -f charts/strimzi-operator/values-prod.yaml \
+  --timeout 5m --wait
+```
+
+::: {.callout-warning}
+`values-prod.yaml` is an **uplift, not a description of current behavior**. Its settings were stranded in `config/kafka/strimzi-values.yaml`, whose header claimed a deploy script passed it with `-f` — it never did. Applying it is a real behavior change: it adds a NetworkPolicy and a PodDisruptionBudget, tightens the reconciliation interval, and flips the operator to a read-only root filesystem. Roll it out deliberately, in a window, not as a default.
+:::
+
+### The Values That Matter
+
+Every operator setting nests under the `strimzi-kafka-operator:` key, because that is the subchart's name. A top-level `watchAnyNamespace: true` is not an override — Helm silently ignores it. The schema rejects it deliberately so the mistake is loud:
+
+```bash
+helm template strimzi-operator charts/strimzi-operator -n strimzi-operator \
+  --set watchAnyNamespace=true
+```
+
+Output:
+
+```text
+Error: values don't meet the specifications of the schema(s) in the following chart(s):
+strimzi-operator:
+- at '': additional properties 'watchAnyNamespace' not allowed
+```
+
+The handful of keys worth knowing:
+
+| Key | Default | Why it matters |
+|-----|---------|----------------|
+| `strimzi-kafka-operator.watchAnyNamespace` | `true` | Sets `STRIMZI_NAMESPACE="*"`. Turn it off and every Kafka cluster outside the operator's own namespace goes unmanaged — the CRs stay, nothing reconciles them. |
+| `strimzi-kafka-operator.kubernetesServiceDnsDomain` | `cluster.local` | Upstream emits `KUBERNETES_SERVICE_DNS_DOMAIN` **only** when this differs from the default. Omitting it is invisible on a default cluster and silently breaks the operator on a custom domain — callers must inject the detected value. |
+| `strimzi-kafka-operator.leaderElection.enable` | `true` | `enable`, not `enabled`. See the troubleshooting section — the misspelling was live for a full release cycle. |
+| `strimzi-kafka-operator.resources` | memory only | The chart pins memory and lets cpu inherit upstream's defaults rather than duplicating them. |
+| `strimzi-kafka-operator.defaultImageRegistry` | unset | Registry redirection. **Not** `global.imageRegistry` — upstream contains zero `.Values.global` references and ignores it entirely, so this chart does not declare `global` at all and `--set global.*` fails loudly. |
+| `crdUpgrade.enabled` | `true` | Disable it and your CRDs freeze. Only do this if another applier demonstrably owns them. |
+| `crdUpgrade.url` | derived | Override for airgapped mirrors. |
+
+## Migrating from the Ad-Hoc Install
+
+The operator was previously installed by direct `helm upgrade --install ... oci://quay.io/strimzi-helm/strimzi-kafka-operator` calls duplicated across the deploy scripts and the `kates` CLI. Those copies had drifted: different memory limits, different timeouts, and one flag that never did anything. Migration folds them onto one chart.
+
+The good news first: **adoption is a pure in-place patch**. The release name, the namespace, and every resource name are identical across the old chart and the new one, so Helm patches fields rather than recreating objects. Nothing is deleted.
+
+### Step 0 — Pre-Flight
+
+All of these are blocking.
+
+```bash
+# Record the current state — this is your rollback reference
+helm list -n strimzi-operator
+helm get values strimzi-operator -n strimzi-operator > /tmp/pre-migration-values.yaml
+
+# Back up the CRDs. Helm does not manage them, so neither `helm rollback` nor
+# `helm uninstall` can restore them — this file is the only way back.
+kubectl get crd -l strimzi.io/crd-install=true -o yaml > /tmp/pre-migration-crds.yaml
+
+# The chart will not render without this
+helm dependency build charts/strimzi-operator
+```
+
+The CRD backup is the one artifact you cannot reconstruct after the fact. The label selects every Strimzi CRD, including `strimzipodsets.core.strimzi.io`, which lives outside the `kafka.strimzi.io` group and is easy to miss when selecting by name.
+
+**The version gate.** The operator's supported Kafka range moves with every release, and a Kafka version that the target operator has never heard of leaves its cluster orphaned. Every `Kafka` resource's version must appear in the target's image map:
+
+```bash
+# What every cluster runs today
+kubectl get kafka -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}: {.spec.kafka.version}{"\n"}{end}'
+
+# What the target operator supports — read it out of the rendered Deployment
+helm template strimzi-operator charts/strimzi-operator -n strimzi-operator \
+  | grep -A5 STRIMZI_KAFKA_IMAGES
+```
+
+Every version on the left must appear on the right. If one does not, stop and upgrade that cluster's Kafka version first.
+
+**The roll-survivability gate.** Adoption rolls every broker (the next section explains why), so the cluster must survive losing one at a time. Read the replication settings from inside the cluster, not from `KafkaTopic` resources — a cluster with no `KafkaTopic` resources still has topics, and it is the real topics that must survive:
+
+```bash
+BROKER=$(kubectl get pods -n kafka -l strimzi.io/broker-role=true -o name | head -1)
+
+kubectl exec -n kafka "${BROKER}" -- \
+  /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --describe \
+  | grep -E 'ReplicationFactor:\s*1\b'
+```
+
+Expect no output. Any topic with a replication factor of 1 goes offline the moment its broker restarts. Confirm `min.insync.replicas` is strictly below `default.replication.factor`, that no partition is under-replicated, and that every broker pool has more than one replica or a replication factor that spans pools.
+
+**The condition gate.** Check conditions by name rather than eyeballing for green:
+
+```bash
+kubectl get kafka krafter -n kafka -o jsonpath='{range .status.conditions[*]}{.type}={.status} {.reason}{"\n"}{end}'
+```
+
+`Ready=True` is the bar. A `Warning=True` with reason `KafkaMetadataVersion` may also be present — it means the `metadataVersion` in the CR trails the running Kafka version and an earlier upgrade never finished. That is pre-existing debt: this migration neither causes it nor fixes it, and waiting for it to clear on its own will not work. Record it, decide separately whether to complete that metadata upgrade, and do not treat it as a blocker for the operator work.
+
+Finally, record the baseline watch scope (expect `*`) and take a maintenance window.
+
+### Step 1 — Verify Adoptability Without Mutating
+
+::: {.callout-important}
+Pass `--reset-values`. Bare `helm upgrade` **is** `--reuse-values`: when you supply no values, Helm copies the previous release's stored config forward. That stored config is the stale flat keys from the retired call sites, and this chart's schema rejects them. This is a one-time cost — after the first adoption the stored config is clean and later bare upgrades pass.
+:::
+
+```bash
+helm upgrade strimzi-operator charts/strimzi-operator \
+  --namespace strimzi-operator \
+  --reset-values --dry-run=server
+```
+
+Expect a clean render with no ownership error and no schema error. Confirm `helm list -n strimzi-operator` still shows the old revision — a server dry-run does not mutate the release.
+
+Omit `--reset-values` and you get this instead, which is the error most people hit first:
+
+Output:
+
+```text
+Error: UPGRADE FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
+strimzi-operator:
+- at '': additional properties 'kubernetesServiceDnsDomain', 'leaderElection', 'replicas', 'resources', 'watchAnyNamespace', 'operationTimeoutMs' not allowed
+```
+
+Those are exactly the keys the old ad-hoc call sites set. The schema is telling you they moved under `strimzi-kafka-operator:`, and that leaving them at the top level would have been silently ignored.
+
+### Step 2 — Diff the Operator Environment
+
+Compare what runs against what the chart renders, before committing. Two variables decide whether this migration is safe, and they are expected to behave in opposite ways.
+
+The watch scope **must not change** — expect `*` from both sides:
+
+```bash
+# Live
+kubectl get deploy strimzi-cluster-operator -n strimzi-operator \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="STRIMZI_NAMESPACE")].value}'
+
+# Rendered
+helm template strimzi-operator charts/strimzi-operator -n strimzi-operator \
+  | grep -A1 'name: STRIMZI_NAMESPACE'
+```
+
+The operand image map **is expected to change** — this is the version bump itself, and the reason Step 3 is a three-part procedure rather than one command:
+
+```bash
+# Live
+kubectl get deploy strimzi-cluster-operator -n strimzi-operator \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="STRIMZI_KAFKA_IMAGES")].value}'
+
+# Rendered
+helm template strimzi-operator charts/strimzi-operator -n strimzi-operator \
+  | grep -A4 'name: STRIMZI_KAFKA_IMAGES'
+```
+
+Every Kafka version on the live side must still be present on the rendered side — that is the version gate from Step 0, restated against the actual artifact. The image each version maps to changes, because the operand tag embeds the operator version.
+
+### Step 3 — Adopt, in Three Movements
+
+::: {.callout-caution}
+Adoption rolls the entire Kafka data plane. The operand image tag embeds the operator version — the operator's image map reads `<kafka-version>=quay.io/strimzi/kafka:<operator-version>-kafka-<kafka-version>` — so the same Kafka version resolves to a different image after the bump. No node pool pins an image, so every broker and every controller restarts. This is not optional and it is not avoidable — pinning `.spec.kafka.image` to dodge it is not supported by Strimzi. It can only be **deferred**, which is what the three movements below do — the roll itself is sequenced by the operator, not by you. Take a maintenance window.
+:::
+
+**Step 3a — Pause reconciliation:** annotate the Kafka resource so the new operator adopts the cluster without touching it.
+
+Pause the `Kafka` resource, and only the `Kafka` resource:
+
+```bash
+kubectl annotate kafka krafter -n kafka strimzi.io/pause-reconciliation=true --overwrite
+
+# Confirm the pause took effect BEFORE upgrading anything
+kubectl get kafka krafter -n kafka \
+  -o jsonpath='{.status.conditions[?(@.type=="ReconciliationPaused")].status}'
+```
+
+This must report `True`. Do not proceed otherwise.
+
+::: {.callout-important}
+Do not try to pause node pools. Strimzi runs no assembly operator for `KafkaNodePool` — the pause annotation is honored on the `Kafka` resource and on the other top-level resources that have their own operator, and nowhere else. Annotating a pool writes an annotation nothing reads: the pool reports no `ReconciliationPaused` condition, so a gate that waits for one never passes.
+
+Pausing the parent is sufficient precisely because pools have no independent reconciliation. They are reconciled as part of the `Kafka` resource, so the parent's pause is what stops the roll.
+:::
+
+Listing the pools is still worthwhile — it sizes the roll you are deferring, and names the pods that restart in Step 3c:
+
+```bash
+kubectl get kafkanodepool -n kafka
+```
+
+**Step 3b — Upgrade the control plane only:** this is the real checkpoint, and the only place where rollback is cheap.
+
+```bash
+helm upgrade strimzi-operator charts/strimzi-operator \
+  --namespace strimzi-operator \
+  --reset-values --timeout 10m --wait
+```
+
+The `pre-upgrade` hook applies the target CRDs before the Deployment is patched. Verify in isolation — the data plane has not moved yet:
+
+```bash
+# Operator image is the new version
+kubectl get deploy strimzi-cluster-operator -n strimzi-operator \
+  -o jsonpath='{.spec.template.spec.containers[0].image}'
+
+# The canary: if this is not "*", STOP and roll back
+kubectl get deploy strimzi-cluster-operator -n strimzi-operator \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="STRIMZI_NAMESPACE")].value}'
+
+# All ten CRDs Established
+kubectl get crd -l strimzi.io/crd-install=true
+
+# Leader election acquired, no errors
+kubectl logs deployment/strimzi-cluster-operator -n strimzi-operator --tail=50 | grep -iE 'error|leader'
+```
+
+**Step 3c — Unpause and let the operator sequence the roll:** pausing deferred the roll; this is where it happens.
+
+Unpausing the `Kafka` resource releases the whole data plane at once. There is no per-pool staging — the pause lives on the parent, so lifting it resumes reconciliation for every pool together:
+
+```bash
+kubectl annotate kafka krafter -n kafka strimzi.io/pause-reconciliation-
+
+# The roll starts immediately; watch it proceed
+kubectl get pods -n kafka -w
+```
+
+You do not sequence this roll — the operator does, and its guarantees are stronger than manual staging would be. Strimzi's roller restarts **one node at a time** and refuses to restart a node when doing so would break the cluster:
+
+- **Controllers** are gated on a KRaft quorum check — a controller is not restarted if the quorum could not tolerate losing it.
+- **Brokers** are gated on an availability check that determines whether the broker can be rolled without affecting `acks=all` producers publishing to topics with `min.insync.replicas`.
+- The **active controller restarts last**, after every other node has been verified.
+
+This is why Step 0's replication gate is the real safety mechanism: the roller can only honor what your replication factors permit. On a topic with `min.insync.replicas` equal to its replication factor, there is no safe moment to roll and the operator stalls rather than breaking the topic.
+
+Watch the cluster converge:
+
+```bash
+kubectl get kafka krafter -n kafka -o jsonpath='{range .status.conditions[*]}{.type}={.status}{"\n"}{end}'
+```
+
+Then run the chart's tests:
+
+```bash
+helm test strimzi-operator -n strimzi-operator
+```
+
+### Step 4 — Cut the Old Paths Over
+
+Retarget every remaining ad-hoc install in the same change: the deploy scripts, the `kates` CLI's deploy path, its remediation hints, and `charts/kafka-cluster/INSTALL.md`. Any one of them left behind re-creates the drift this chart exists to remove — and because the chart is a cluster singleton, a stray `helm install strimzi ...` with a different release name produces a colliding second operator that nothing detects and nothing cleans up.
+
+## Upgrading the Operator
+
+Once adopted, a version bump is a values change plus an upgrade. The pin lives in five places that must agree, which `scripts/check-versions.sh` enforces — it runs in CI on every chart change, and locally via `make check-versions`:
+
+| Pin | Purpose |
+|-----|---------|
+| `Chart.yaml` `dependencies[].version` | Which operator chart is pulled |
+| `Chart.yaml` `appVersion` | What the chart claims to deploy |
+| `values.yaml` `strimziVersion` | Builds the CRD bundle URL |
+| `versions.env` `STRIMZI_VERSION` | The repo-wide pin |
+| `charts/kafka-cluster/values.yaml` `strimziVersion` | The Helm-test Kafka client image |
+
+The last one is easy to overlook: `kafka-cluster` no longer installs the operator, but it still builds a `strimzi/kafka:<strimziVersion>-kafka-<kafkaVersion>` image for its Helm tests, so the pin stays load-bearing there.
+
+The pairing that matters most is the CRD bundle URL against the dependency version. If those two drift, the hook applies the CRDs of one operator version while installing another — and nothing else in the repo would notice.
+
+```bash
+scripts/check-versions.sh
+helm dependency build charts/strimzi-operator
+```
+
+If `strimziVersion` drifts from the dependency version, the hook applies CRDs for a different operator than the one being installed — the worst failure this design can produce, and a silent one. Run the check before the upgrade, not after.
+
+From there the procedure is Step 0 through Step 3 above, unchanged. Every operator upgrade rolls the data plane for the same reason adoption does, so every operator upgrade needs the pause-and-sequence treatment and a window. The [Upgrade Playbook](18-upgrade-playbook.md)'s golden rule still holds: upgrade the operator before Kafka, and run `make gameday` afterwards.
+
+## Rollback
+
+Because names are identical across chart versions, a rollback is a plain field patch:
+
+```bash
+helm history strimzi-operator -n strimzi-operator
+helm rollback strimzi-operator <revision> -n strimzi-operator
+
+# Re-verify the canary
+kubectl get deploy strimzi-cluster-operator -n strimzi-operator \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="STRIMZI_NAMESPACE")].value}'
+```
+
+Two caveats decide whether rollback is cheap or expensive:
+
+- **Rollback does not revert the CRDs.** The hook applied the target schema, and rolling the release back leaves it in place. Helm never owned the CRDs, so `helm rollback` cannot touch them. For an additive schema change this is harmless — the older operator ignores fields it does not know. When it is not additive, restore the Step 0 backup by hand:
+
+  ```bash
+  kubectl apply --server-side --force-conflicts -f /tmp/pre-migration-crds.yaml
+  ```
+
+  Restoring an older schema over resources that already use newer fields drops those fields. Roll the operator back first, so nothing is writing the fields you are about to remove.
+- **Rollback re-rolls the data plane.** Rolling back at Step 3b, while the `Kafka` resource is still paused, is free. Rolling back after Step 3c means every broker restarts a second time.
+
+::: {.callout-caution}
+Never migrate or roll back by uninstalling. `helm uninstall strimzi-operator` leaves the CRDs behind — and those orphaned CRDs are the only thing keeping every `Kafka`, `KafkaNodePool`, `KafkaTopic`, and `KafkaUser` resource alive while no operator is running. Deleting them by hand to "clean up" cascades through `CRD → Kafka / KafkaNodePool → StrimziPodSet → Pods` and destroys every cluster the operator manages, in every namespace. The two operations to never perform on a live cluster are `kubectl delete crd` on anything matching `*.strimzi.io`, and an uninstall-then-reinstall cycle. Use `helm upgrade` and `helm rollback` — both are in-place patches.
+:::
+
+::: {.callout-tip}
+**Try it**
+
+On a scratch cluster, install the operator and prove all three of the chart's claims — the watch scope, the CRDs, and the operand mapping — without deploying a single Kafka broker:
+
+```bash
+helm dependency build charts/strimzi-operator
+
+helm upgrade --install strimzi-operator charts/strimzi-operator \
+  --namespace strimzi-operator --create-namespace \
+  -f charts/strimzi-operator/values-kind.yaml \
+  --timeout 5m --wait
+
+# 1. The watch scope did not collapse
+kubectl get deploy strimzi-cluster-operator -n strimzi-operator \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="STRIMZI_NAMESPACE")].value}'
+
+# 2. The hook applied the CRDs — and they are Established
+kubectl get crd -l strimzi.io/crd-install=true \
+  -o jsonpath='{range .items[*]}{.metadata.name}: {.status.conditions[?(@.type=="Established")].status}{"\n"}{end}'
+
+# 3. Which Kafka versions this operator can actually run
+kubectl get deploy strimzi-cluster-operator -n strimzi-operator \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="STRIMZI_KAFKA_IMAGES")].value}'
+
+# All of the above, as an assertion
+helm test strimzi-operator -n strimzi-operator
+```
+
+The watch scope prints `*`, all ten CRDs report `Established: True`, and the image map shows each supported Kafka version pointing at an operand image tagged with the operator's own version — the coupling that makes every operator upgrade a data-plane roll, made visible before it costs you a window.
+
+The hook's own log is deliberately not part of this check. Helm deletes a successful hook Job as soon as it succeeds, so there is no pod left to read logs from on the happy path. The CRDs themselves are the evidence that the hook ran; the log survives only when the hook *fails*, which is exactly when you need it.
+:::
+
+## Troubleshooting
+
+### `found in Chart.yaml, but missing in charts/ directory: strimzi-kafka-operator`
+
+**Symptom:** every `helm` command against the chart fails immediately, before touching the cluster.
+
+**Cause:** the subchart has not been fetched. `helm lint` only warns about this, so CI can be green while deploys fail.
+
+**Fix:** `helm dependency build charts/strimzi-operator`. Add it to any script or workflow that renders the chart.
+
+### `at '': additional properties 'watchAnyNamespace', 'replicas', ... not allowed`
+
+**Symptom:** `helm upgrade` fails schema validation on keys you did not pass.
+
+**Cause:** you passed no values, so Helm reused the previous release's stored ones — the stale flat keys from the retired ad-hoc install. Bare `helm upgrade` is `--reuse-values`.
+
+**Fix:** pass `--reset-values` once (or `-f <overlay>`). Afterwards the stored config is clean.
+
+### `at '/strimzi-kafka-operator/leaderElection': additional properties 'enabled' not allowed`
+
+**Symptom:** a `--set strimzi-kafka-operator.leaderElection.enabled=false` that used to be accepted is now rejected.
+
+**Cause:** the upstream key is `enable`, not `enabled`. The retired CLI call site set `enabled=false` for the lifetime of the release and Helm silently ignored it — leader election was never actually off. The schema now makes that typo class impossible.
+
+**Fix:** use `leaderElection.enable`. Note that setting it to `false` is a **new** behavior change, not a restoration of the old intent — the intent never took effect.
+
+### `invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by"`
+
+**Symptom:** adoption fails with a message like:
+
+```text
+invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name"
+```
+
+or, when a resource belongs to a different release:
+
+```text
+annotation validation error: key "meta.helm.sh/release-name" must equal "X": current value is "Y"
+```
+
+**Cause:** a resource the chart wants to own exists but was not created by this Helm release — usually a leftover from a hand-run `kubectl apply` or a differently-named release.
+
+**Fix:** label and annotate the offending resource, then retry:
+
+```bash
+kubectl label <kind>/<name> app.kubernetes.io/managed-by=Helm --overwrite
+kubectl annotate <kind>/<name> meta.helm.sh/release-name=strimzi-operator --overwrite
+kubectl annotate <kind>/<name> meta.helm.sh/release-namespace=strimzi-operator --overwrite
+```
+
+### CRD Hook Job Fails and the Release Is Stuck in `pending-upgrade`
+
+**Symptom:** the upgrade aborts; `helm list` shows `pending-upgrade`.
+
+**Cause:** the hook is a `pre-upgrade` gate, so a failed fetch blocks the upgrade by design. Read the Job's log — it self-diagnoses, printing the resolved URL and the HTTP status:
+
+```bash
+kubectl logs -n strimzi-operator -l app=crd-upgrade --tail=30
+```
+
+A `✗ Download FAILED` line means no egress to the bundle URL. A `✗ Expected 10 CustomResourceDefinitions, found N` line means something answered that was not the bundle — usually a proxy interstitial returning HTTP 200 with HTML.
+
+**Fix:** restore egress, or mirror the bundle and set `crdUpgrade.url`. Then `helm rollback` to clear the pending state and retry.
+
+### Kafka Clusters Stop Reconciling After an Upgrade
+
+**Symptom:** the operator is `Running`, but resources in other namespaces are never picked up.
+
+**Cause:** the watch scope collapsed — `STRIMZI_NAMESPACE` is the operator's own namespace instead of `*`. With this chart the default supplies `*`, so this means something explicitly overrode it, or a typo landed inside the `strimzi-kafka-operator:` block (which keeps `additionalProperties: true`, because upstream exposes dozens of keys that drift each release).
+
+**Fix:** check the scope, then `helm get values` to find the override:
+
+```bash
+kubectl get deploy strimzi-cluster-operator -n strimzi-operator \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="STRIMZI_NAMESPACE")].value}'
+helm get values strimzi-operator -n strimzi-operator
+```
+
+`helm test strimzi-operator -n strimzi-operator` asserts this automatically — it is the reason the watch-scope test exists.
+
+For the symptom-by-symptom index across the whole book, see the [Troubleshooting Index](appendix-b-troubleshooting.md).
+
+## Versions
+
+The Strimzi operator version, the chart version, and the Kafka versions each operator release supports are tracked centrally in the [Version & Compatibility Matrix](appendix-d-versions.md), generated from `versions.env`. Two notes specific to this chapter: the operator version and the operand image tag are coupled (the image tag embeds the operator version, which is why an operator bump rolls the data plane), and this chart pins that version in five places which `scripts/check-versions.sh` asserts agree, in CI and via `make check-versions`.
+
+## Summary
+
+- The operator is a separate Helm release because CRDs must exist and be `Established` before any `Kafka` resource can validate — and because a cluster-wide singleton has no business inside a chart you might install twice.
+- Helm applies `crds/` on install and never again; the chart's `pre-install`/`pre-upgrade` hook is what keeps the schema current, and without it the API server silently prunes fields the frozen CRDs do not know about.
+- The CRDs deliberately stay untemplated: Helm does not know they exist, which is the only reason `helm uninstall` cannot cascade through `CRD → Kafka → StrimziPodSet → Pods` and destroy every cluster.
+- Adoption is a pure in-place patch — identical names, nothing recreated — but it rolls every broker and controller, because the operand image tag embeds the operator version. Pause the `Kafka` resource, upgrade the control plane, verify, then unpause and let the operator sequence the roll.
+- Bare `helm upgrade` is `--reuse-values`: pass `--reset-values` once during adoption, or the schema rejects the stale flat keys the ad-hoc install left in the release record.
+- Every operator setting nests under `strimzi-kafka-operator:`; a top-level key is silently ignored by Helm, and the schema rejects it so the mistake is loud rather than invisible.
+
+With the operator running, its CRDs current, and its watch scope proven, the cluster it manages is next: [Installing Kafka with the kafka-cluster Helm Chart](20-installation-guide.md) walks the `krafter` Kafka cluster install step by step.

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Assert the Strimzi version pins agree across every place that declares one.
+#
+# WHY THIS EXISTS: charts/strimzi-operator pins the Strimzi version in THREE
+# places, versions.env declares a fourth, and charts/kafka-cluster a fifth:
+#
+#   1. Chart.yaml  dependencies[strimzi-kafka-operator].version  → which operator chart is pulled
+#   2. Chart.yaml  appVersion                                    → what the chart claims to deploy
+#   3. values.yaml strimziVersion                                → builds the CRD bundle URL
+#   4. versions.env STRIMZI_VERSION                              → the repo-wide pin
+#   5. charts/kafka-cluster/values.yaml strimziVersion           → the Helm-test Kafka client image
+#
+# (5) is easy to miss: kafka-cluster no longer installs the operator, but its
+# _helpers.tpl still builds `strimzi/kafka:<strimziVersion>-kafka-<kafkaVersion>`
+# for the Helm tests, so the pin stays load-bearing there.
+#
+# Nothing else ties these together: gen-version-matrix.sh reads Chart.yaml but
+# never compares it to versions.env. If (3) drifts from (1), the pre-upgrade
+# hook applies CRDs for a DIFFERENT version than the operator being installed —
+# the worst failure this chart can produce, and it fails silently.
+#
+# Usage:
+#   scripts/check-versions.sh    Verify all five agree. Exits non-zero on drift.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+CHART_DIR="charts/strimzi-operator"
+CHART_YAML="${CHART_DIR}/Chart.yaml"
+VALUES_YAML="${CHART_DIR}/values.yaml"
+KAFKA_VALUES_YAML="charts/kafka-cluster/values.yaml"
+
+fail=0
+
+env_val() { grep -E "^$1=" versions.env | head -1 | sed -E 's/^[^=]+="?//; s/"$//'; }
+
+# appVersion: "1.1.0" — single unanchored line in Chart.yaml
+chart_app_version=$(grep -E '^appVersion:' "$CHART_YAML" | head -1 | sed -E 's/^appVersion:[[:space:]]*"?([^"]+)"?[[:space:]]*$/\1/')
+
+# The dependency version: the `version:` line inside the strimzi-kafka-operator
+# dependency entry.
+chart_dep_version=$(awk '
+  /^dependencies:/        { in_deps = 1; next }
+  in_deps && /^[a-z]/     { in_deps = 0 }
+  in_deps && /name: strimzi-kafka-operator/ { found = 1; next }
+  found && /version:/     { gsub(/^[[:space:]]*version:[[:space:]]*"?/, ""); gsub(/"?[[:space:]]*$/, ""); print; exit }
+' "$CHART_YAML")
+
+# strimziVersion: "1.1.0" — top-level key in values.yaml
+values_strimzi_version=$(grep -E '^strimziVersion:' "$VALUES_YAML" | head -1 | sed -E 's/^strimziVersion:[[:space:]]*"?([^"]+)"?[[:space:]]*$/\1/')
+
+env_strimzi_version=$(env_val STRIMZI_VERSION)
+
+# kafka-cluster no longer installs the operator, but _helpers.tpl still uses
+# this pin to build the Helm-test Kafka client image.
+kafka_chart_strimzi_version=$(grep -E '^strimziVersion:' "$KAFKA_VALUES_YAML" | head -1 | sed -E 's/^strimziVersion:[[:space:]]*"?([^"]+)"?[[:space:]]*$/\1/')
+
+echo "Strimzi version pins:"
+printf '  %-46s %s\n' "${CHART_YAML} appVersion:"              "${chart_app_version:-<unset>}"
+printf '  %-46s %s\n' "${CHART_YAML} dependency version:"      "${chart_dep_version:-<unset>}"
+printf '  %-46s %s\n' "${VALUES_YAML} strimziVersion:"         "${values_strimzi_version:-<unset>}"
+printf '  %-46s %s\n' "versions.env STRIMZI_VERSION:"          "${env_strimzi_version:-<unset>}"
+printf '  %-46s %s\n' "${KAFKA_VALUES_YAML} strimziVersion:"   "${kafka_chart_strimzi_version:-<unset>}"
+echo
+
+for pair in \
+  "chart_app_version:${CHART_YAML} appVersion" \
+  "chart_dep_version:${CHART_YAML} dependency version" \
+  "values_strimzi_version:${VALUES_YAML} strimziVersion" \
+  "env_strimzi_version:versions.env STRIMZI_VERSION" \
+  "kafka_chart_strimzi_version:${KAFKA_VALUES_YAML} strimziVersion"; do
+  var="${pair%%:*}"
+  label="${pair#*:}"
+  if [[ -z "${!var}" ]]; then
+    echo "ERROR: could not read ${label}" >&2
+    fail=1
+  fi
+done
+
+if [[ "$fail" -eq 0 ]]; then
+  if [[ "$chart_app_version" == "$chart_dep_version" && \
+        "$chart_app_version" == "$values_strimzi_version" && \
+        "$chart_app_version" == "$env_strimzi_version" && \
+        "$chart_app_version" == "$kafka_chart_strimzi_version" ]]; then
+    echo "OK: all five Strimzi pins agree (${chart_app_version})."
+    exit 0
+  fi
+
+  echo "DRIFT: Strimzi version pins disagree." >&2
+  echo >&2
+  echo "  The CRD-upgrade hook builds its bundle URL from ${VALUES_YAML}" >&2
+  echo "  strimziVersion, while the operator itself comes from the Chart.yaml" >&2
+  echo "  dependency version. If those differ, the hook applies CRDs for a" >&2
+  echo "  different operator than the one being installed." >&2
+  echo >&2
+  echo "  Set all five to the same value, then re-run:" >&2
+  echo "    scripts/gen-version-matrix.sh --check" >&2
+  fail=1
+fi
+
+exit "$fail"

--- a/scripts/deploy-kafka-generic.sh
+++ b/scripts/deploy-kafka-generic.sh
@@ -142,40 +142,33 @@ info "Step 4/6: Deploying Kafka cluster..."
 # Ensure namespace exists
 kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f - > /dev/null 2>&1
 
-# Install Strimzi Operator if not present (separate release required to avoid CRD chicken-and-egg)
-# Skip if the detect output already confirmed Strimzi is running
+# Reconcile the Strimzi Operator (a separate release from kafka-cluster, to
+# avoid the CRD chicken-and-egg). The only opt-out is an explicit
+# strimziOperator.enabled=false from `kates detect`, meaning the pipeline
+# manages the operator itself.
 if grep -A1 'strimziOperator:' "${DETECTED_VALUES}" 2>/dev/null | grep -q 'enabled: false'; then
     info "  Strimzi Operator already managed by pipeline — skipping"
 else
-    # Check if Strimzi CRD is missing OR if the operator deployment is missing
-    operator_exists=false
-    if kubectl get deployment -A -o custom-columns=NAME:.metadata.name 2>/dev/null | grep -q "strimzi-cluster-operator"; then
-        operator_exists=true
-    elif kubectl get deployment -n kafka -o custom-columns=NAME:.metadata.name 2>/dev/null | grep -q "strimzi-cluster-operator"; then
-        operator_exists=true
-    elif kubectl get deployment -n strimzi-operator -o custom-columns=NAME:.metadata.name 2>/dev/null | grep -q "strimzi-cluster-operator"; then
-        operator_exists=true
-    fi
+    # Unconditional by design. `helm upgrade --install` is idempotent and
+    # converges, and the chart's pre-upgrade hook is what keeps the CRDs current
+    # — so gating this on "is the operator already there?" would mean the hook
+    # never fires on an existing cluster and the CRDs silently freeze at
+    # whatever version first installed them.
+    info "  Reconciling Strimzi Kafka Operator (charts/strimzi-operator)..."
+    ensure_namespace "strimzi-operator"
 
-    if ! kubectl get crd kafkas.kafka.strimzi.io &>/dev/null || [ "$operator_exists" = false ]; then
-        if [ "$operator_exists" = false ] && kubectl get crd kafkas.kafka.strimzi.io &>/dev/null; then
-            warn "  Strimzi CRDs are present, but Strimzi Operator deployment is not running!"
-            info "  Installing Strimzi Kafka Operator to manage existing CRDs..."
-        else
-            info "  Strimzi CRDs not found. Installing Strimzi Kafka Operator in strimzi-operator namespace..."
-        fi
-        kubectl create namespace "strimzi-operator" --dry-run=client -o yaml | kubectl apply -f - > /dev/null 2>&1
-        helm upgrade --install strimzi-operator oci://quay.io/strimzi-helm/strimzi-kafka-operator \
-            --version 1.1.0 \
-            --namespace "strimzi-operator" \
-            --set watchAnyNamespace=true \
-            --set replicas=1 \
-            --set kubernetesServiceDnsDomain="${CLUSTER_DOMAIN}" \
-            --timeout 5m --wait
-        kubectl wait --for=condition=Established crd kafkas.kafka.strimzi.io --timeout=60s
-    else
-        info "  Strimzi CRDs and Operator deployment already present"
-    fi
+    # The wrapper chart does not render until its subchart is fetched.
+    helm dependency build "${ROOT_DIR}/charts/strimzi-operator"
+
+    # --reset-values: the pre-chart releases stored flat upstream keys
+    # (watchAnyNamespace, replicas, ...) which now live under the subchart key.
+    # A bare upgrade reuses them and the values schema rejects them.
+    helm upgrade --install strimzi-operator "${ROOT_DIR}/charts/strimzi-operator" \
+        --namespace "strimzi-operator" \
+        --reset-values \
+        --set "strimzi-kafka-operator.kubernetesServiceDnsDomain=${CLUSTER_DOMAIN}" \
+        --timeout 10m --wait
+    kubectl wait --for=condition=Established crd kafkas.kafka.strimzi.io --timeout=60s
 fi
 
 # Adopt pre-existing Kafka resources into Helm release

--- a/scripts/deploy-kafka.sh
+++ b/scripts/deploy-kafka.sh
@@ -15,17 +15,29 @@ info "Deploying Kafka cluster (env=${ENV})..."
 
 ensure_namespace "${NAMESPACE}"
 
-# Install Strimzi Operator if not present (separate release required to avoid CRD chicken-and-egg)
-if ! kubectl get crd kafkas.kafka.strimzi.io &>/dev/null; then
-    info "Strimzi CRDs not found. Installing Strimzi Kafka Operator in strimzi-operator namespace..."
-    ensure_namespace "strimzi-operator"
-    helm upgrade --install strimzi-operator oci://quay.io/strimzi-helm/strimzi-kafka-operator \
-        --version 1.1.0 \
-        --namespace "strimzi-operator" \
-        --set watchAnyNamespace=true \
-        --set replicas=1 \
-        --timeout 5m --wait
-fi
+# Reconcile the Strimzi Operator (a separate release from kafka-cluster, to
+# avoid the CRD chicken-and-egg).
+#
+# Unconditional by design. `helm upgrade --install` is idempotent and converges,
+# and the chart's pre-upgrade hook is what keeps the CRDs current — gating this
+# on "are the CRDs already there?" would mean the hook never fires on an
+# existing cluster and the CRDs silently freeze at whatever version first
+# installed them.
+info "Reconciling Strimzi Kafka Operator (charts/strimzi-operator)..."
+ensure_namespace "strimzi-operator"
+
+# The wrapper chart does not render until its subchart is fetched. `build`
+# resolves from Chart.lock, so the pinned Strimzi version cannot drift.
+helm dependency build "${ROOT_DIR}/charts/strimzi-operator"
+
+# --reset-values: pre-chart releases stored flat upstream keys (watchAnyNamespace,
+# replicas, ...) which now live under the subchart key. A bare upgrade reuses
+# them and the values schema rejects them.
+helm upgrade --install strimzi-operator "${ROOT_DIR}/charts/strimzi-operator" \
+    --namespace "strimzi-operator" \
+    --reset-values \
+    --timeout 10m --wait
+kubectl wait --for=condition=Established crd kafkas.kafka.strimzi.io --timeout=60s
 
 # Build Helm dependencies (SeaweedFS subchart)
 info "Building Helm chart dependencies..."


### PR DESCRIPTION
## Why

The Strimzi operator is installed by ad-hoc `helm upgrade --install ... oci://` calls duplicated across two scripts and the Go CLI, with flags that have **drifted apart**. Nothing owns the operator, so its configuration is not version-controlled, and CRD upgrades are handled by a hook living in the `kafka-cluster` chart — the wrong home.

This adds `charts/strimzi-operator` (a wrapper around the upstream chart, pinned to 1.1.0) and retargets every install path onto it.

> **Note on the branch name.** This branch is named `refactor/kates-cli-over-scripts`, but it carries the operator-chart work, not the script purge. It was split off #74 late: #74 merged at 11:06 and this commit landed after, so it missed that PR. The script refactor is a separate, unstarted change. Happy to rename the branch if that's cleaner.

## What this fixes

**A live bug: the CLI's `leaderElection.enabled=false` is a typo.** The upstream key is `leaderElection.enable`. Helm silently ignored the misspelling for the entire lifetime of the release, so leader election has **never actually been disabled**. Proven:

- `--set leaderElection.enabled=false` renders `STRIMZI_LEADER_ELECTION_ENABLED="true"` (no effect)
- `--set leaderElection.enable=false` renders `"false"`

The flag is **dropped rather than fixed** — leader election stays on, which is what has always been running. Turning it off is a separate decision, not a side effect of a refactor. The chart's `values.schema.json` now rejects unknown keys so this class of typo fails loudly, and CI asserts it.

**The CRD-upgrade gap.** Helm installs `crds/` once and **never updates them on upgrade**. CRDs froze at whatever version first installed them while the API server silently pruned fields newer operators need. The chart owns a pre-install/pre-upgrade hook that applies the pinned bundle, with a hardened fetch (`curl -fsSL --retry`, since plain `curl -sL` exits 0 on a 404 and writes the error body) and a `--dry-run=server` gate before mutating.

**Skipping is not idempotency.** Both call sites skipped the operator install when the release already existed, which meant the pre-upgrade CRD hook would *never fire on an existing cluster* — the exact freeze this chart prevents. `helm upgrade --install` converges; the install is now unconditional.

**A dangerous remediation hint.** `cli/pkg/detect/remediation.go` told users to install release `strimzi` into namespace `kafka`. The operator is a **cluster singleton** (13 of its 17 rendered objects are cluster-scoped with hardcoded names), so that command collides with the existing operator rather than creating a second one.

**Version-pin drift.** The Strimzi version is declared in **five** places. If `values.yaml`'s `strimziVersion` drifts from the `Chart.yaml` dependency, the hook applies CRDs for a different operator than the one installed — silently. `scripts/check-versions.sh` asserts all five agree, wired into CI and `make check-versions`. The fifth pin is easy to miss: `kafka-cluster` no longer installs the operator but still builds its Helm-test Kafka image from `strimziVersion`.

## Verification

- Rendered Deployment differs from the live one by **exactly the image tag** (`operator:1.0.0` → `1.1.0`) — replicas, watch scope, leader election, and operation timeout all identical. No unintended drift.
- A bare `helm upgrade` **fails** against the real release (`additional properties 'watchAnyNamespace', ... not allowed`), confirming `--reset-values` is mandatory on first adoption; both call sites pass it.
- `helm lint` clean; `helm template` renders under all four overlays; `go build` + `go test ./cmd/... ./pkg/detect/...` pass; `check-book-style.sh`, `gen-version-matrix.sh --check`, `gen-chart-table.sh --check`, and `check-versions.sh` all green.
- `helm dependency build` verified on a simulated fresh clone with no `Chart.lock` (falls back to pull, exit 0, same digest), so CI is not broken by the ignored lock.

## The book chapter

`docs/book/deploying-strimzi-operator.md` covers deployment and the migration off the ad-hoc calls. Two claims were verified against Strimzi 1.1.0 source rather than assumed:

- **`KafkaNodePool` cannot be paused.** There is no `KafkaNodePool*Operator`; only Kafka/KafkaBridge/KafkaConnect/KafkaMirrorMaker2/KafkaRebalance assembly operators honor `strimzi.io/pause-reconciliation`. An earlier draft told readers to pause pools and gate on a condition that would never appear — it would have hung forever.
- **The roll is sequenced by the operator, not by you.** `KafkaRoller` restarts one node at a time, gates controllers on the KRaft quorum check and brokers on `KafkaAvailability.canRoll` (*"without affecting producers with acks=all publishing to topics with a min.in.sync.replicas"*), and restarts the active controller last. That makes Step 0's replication gate the real safety mechanism.

## Reviewer notes

- `values.schema.json` sets `additionalProperties: false` at the top level, deviating from every other chart here. It earns it by catching the `leaderElection` typo class and forcing stale flat keys out of the release record. The cost is real and one-time: bare `helm upgrade` fails until `--reset-values` is passed once.
- **Deferred deliberately:** `charts/kafka-cluster`'s CRD hook stays in place. Deleting it now would leave existing clusters with *no* CRD applier. It should be removed only after the new hook's field manager is confirmed on every environment.