### PR TITLE
feat(cli): detect and choose the target cluster before deploying

### DIFF
--- a/cli/cmd/cluster_gate.go
+++ b/cli/cmd/cluster_gate.go
@@ -23,6 +23,7 @@ var (
 	probeEnvironmentFn  = cluster.ProbeEnvironment
 	createKindFn        = cluster.CreateKind
 	kindClusterExistsFn = cluster.KindClusterExists
+	configExistsFn      = cluster.ConfigExists
 
 	// interactiveFn reports whether we may prompt. Overridden in tests.
 	interactiveFn = isInteractive
@@ -123,12 +124,34 @@ func resolveCluster() (string, error) {
 func offerKind(d cluster.Decision) (string, error) {
 	printNoCluster(d)
 
+	// A dry run must not build a cluster. --dry-run is checked much later in
+	// runDeploy, so without this the plan preview would create real
+	// infrastructure on the way to telling you it changes nothing.
+	if deployDryRun {
+		fmt.Println("  " + gateDim.Render(fmt.Sprintf(
+			"would offer to create a local %d-zone kind cluster (skipped: --dry-run)",
+			len(cluster.KindZones))))
+		return "", fmt.Errorf("no reachable Kubernetes cluster to plan against.\n" +
+			"  Re-run without --dry-run to create a local kind cluster.")
+	}
+
 	if !interactiveFn() {
 		return "", fmt.Errorf("no reachable Kubernetes cluster.\n"+
 			"  Docker and kind are available — a local %d-zone cluster can be created.\n"+
 			"  Re-run in a terminal to be prompted, or create it directly:\n"+
 			"    kind create cluster --config %s --name %s",
 			len(cluster.KindZones), cluster.DefaultKindConfig, cluster.DefaultKindClusterName)
+	}
+
+	// The topology config is repo-relative. Offering to build a cluster we
+	// cannot describe would fail inside `kind create` with a bare "no such
+	// file"; say so now instead.
+	if !configExistsFn(cluster.DefaultKindConfig) {
+		return "", fmt.Errorf("no reachable Kubernetes cluster, and the kind topology %s is not readable from here.\n"+
+			"  The %d-zone config lives in the kates repo — run from the repo root, or create the cluster yourself:\n"+
+			"    kind create cluster --config <path-to>/%s --name %s",
+			cluster.DefaultKindConfig, len(cluster.KindZones),
+			cluster.DefaultKindConfig, cluster.DefaultKindClusterName)
 	}
 
 	if kindClusterExistsFn(defaultExecutor, cluster.DefaultKindClusterName) {

--- a/cli/cmd/cluster_gate.go
+++ b/cli/cmd/cluster_gate.go
@@ -1,0 +1,217 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"golang.org/x/term"
+
+	"github.com/bmscomp/kates/cli/pkg/cluster"
+)
+
+// The cluster gate runs before anything in `kates deploy` that assumes a
+// reachable cluster. It answers one question — which cluster are we deploying
+// to? — and, when there is no answer, offers to build one.
+//
+// Seams for tests. These mirror the runExecFn/runHelmFn style already used by
+// deploy_test.go so the gate can be driven without a cluster, Docker, or a TTY.
+var (
+	listContextsFn      = cluster.ListContexts
+	checkAllReachableFn = cluster.CheckAllReachable
+	probeEnvironmentFn  = cluster.ProbeEnvironment
+	createKindFn        = cluster.CreateKind
+	kindClusterExistsFn = cluster.KindClusterExists
+
+	// interactiveFn reports whether we may prompt. Overridden in tests.
+	interactiveFn = isInteractive
+
+	// confirmFn asks a yes/no question. Overridden in tests.
+	confirmFn = confirmPrompt
+
+	// pickContextFn presents the picker. Overridden in tests.
+	pickContextFn = pickContext
+
+	// resolveClusterFn is the gate as runDeploy sees it. The deploy
+	// orchestration tests stub this out — they assume a cluster and are not
+	// testing gate behavior, which cluster_gate_test.go covers directly.
+	resolveClusterFn = resolveCluster
+)
+
+// isInteractive reports whether prompting is allowed.
+//
+// This is the load-bearing guard of the whole feature. `kates deploy` is called
+// directly by deploy_test.go and may run in CI or a pipe; a prompt or a
+// bubbletea program in any of those hangs forever instead of failing. Every
+// interactive path must be behind this.
+func isInteractive() bool {
+	if isTesting || deployYes {
+		return false
+	}
+	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+// styles reused from the repo's lipgloss vocabulary.
+var (
+	gateTitle  = lipgloss.NewStyle().Bold(true)
+	gateDim    = lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280"))
+	gateOK     = lipgloss.NewStyle().Foreground(lipgloss.Color("#10B981"))
+	gateWarn   = lipgloss.NewStyle().Foreground(lipgloss.Color("#F59E0B"))
+	gateErr    = lipgloss.NewStyle().Foreground(lipgloss.Color("#EF4444"))
+	gateAccent = lipgloss.NewStyle().Foreground(lipgloss.Color("#6366F1"))
+)
+
+// resolveCluster is the gate. It returns the context name to deploy into, or an
+// error explaining precisely what is missing.
+func resolveCluster() (string, error) {
+	contexts, err := listContextsFn(defaultExecutor)
+	if err != nil {
+		return "", fmt.Errorf("could not read kubeconfig: %w", err)
+	}
+
+	if len(contexts) > 0 {
+		fmt.Println(gateDim.Render(fmt.Sprintf("  Probing %s…", plural(len(contexts), "context", "contexts"))))
+		contexts = checkAllReachableFn(defaultExecutor, contexts)
+	}
+
+	env := probeEnvironmentFn(defaultExecutor)
+	decision := cluster.Resolve(contexts, env)
+
+	switch decision.Outcome {
+	case cluster.UseContext:
+		c := decision.Candidates[0]
+		fmt.Println("  " + gateOK.Render("✓") + " Cluster: " + gateAccent.Render(c.Name) + gateDim.Render(describeContext(c)))
+		return c.Name, nil
+
+	case cluster.ChooseContext:
+		if !interactiveFn() {
+			// Never guess. Picking silently is how you deploy to prod by
+			// accident.
+			return "", fmt.Errorf(
+				"%d reachable clusters found (%s) — cannot choose without a terminal.\n"+
+					"  Select one first:  kubectl config use-context <name>",
+				len(decision.Candidates), strings.Join(contextNames(decision.Candidates), ", "))
+		}
+		return pickContextFn(decision.Candidates)
+
+	case cluster.OfferKind:
+		return offerKind(decision)
+
+	case cluster.NeedKind:
+		printNoCluster(decision)
+		return "", fmt.Errorf("Docker is running but kind is not installed.\n" +
+			"  Install it:  brew install kind   (or see https://kind.sigs.k8s.io/docs/user/quick-start/#installation)\n" +
+			"  Then re-run: kates deploy")
+
+	case cluster.NeedDockerRunning:
+		printNoCluster(decision)
+		return "", fmt.Errorf("Docker is installed but the daemon is not running.\n" +
+			"  Start Docker Desktop (or `sudo systemctl start docker`), then re-run: kates deploy")
+
+	default: // NeedDocker
+		printNoCluster(decision)
+		return "", fmt.Errorf("no Docker and no reachable Kubernetes cluster.\n" +
+			"  Kates needs one of:\n" +
+			"    • a reachable Kubernetes cluster (check: kubectl cluster-info)\n" +
+			"    • Docker, so a local 3-zone kind cluster can be created for you\n" +
+			"  Install Docker: https://docs.docker.com/get-docker/")
+	}
+}
+
+// offerKind asks whether to build the local 3-AZ cluster, then builds it.
+func offerKind(d cluster.Decision) (string, error) {
+	printNoCluster(d)
+
+	if !interactiveFn() {
+		return "", fmt.Errorf("no reachable Kubernetes cluster.\n"+
+			"  Docker and kind are available — a local %d-zone cluster can be created.\n"+
+			"  Re-run in a terminal to be prompted, or create it directly:\n"+
+			"    kind create cluster --config %s --name %s",
+			len(cluster.KindZones), cluster.DefaultKindConfig, cluster.DefaultKindClusterName)
+	}
+
+	if kindClusterExistsFn(defaultExecutor, cluster.DefaultKindClusterName) {
+		// The cluster exists but nothing was reachable — recreating would
+		// silently destroy it, so stop and let a human decide.
+		return "", fmt.Errorf("a kind cluster named %q already exists but is not reachable.\n"+
+			"  Inspect it:  kubectl cluster-info --context kind-%s\n"+
+			"  Or remove it and re-run: kind delete cluster --name %s",
+			cluster.DefaultKindClusterName, cluster.DefaultKindClusterName, cluster.DefaultKindClusterName)
+	}
+
+	fmt.Println()
+	fmt.Println("  " + gateTitle.Render("Create a local Kubernetes cluster?"))
+	fmt.Println("  " + gateDim.Render(fmt.Sprintf("kind · %s · zones %s · takes a few minutes",
+		cluster.DefaultKindClusterName, strings.Join(cluster.KindZones, "/"))))
+	fmt.Println()
+
+	ok, err := confirmFn("Create it now?")
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("no cluster to deploy to, and kind cluster creation was declined")
+	}
+
+	fmt.Println()
+	err = createKindFn(defaultExecutor, cluster.KindOptions{
+		Progress: func(step string) {
+			fmt.Println("  " + gateAccent.Render("→") + " " + step)
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("creating the kind cluster: %w", err)
+	}
+
+	// kind names the context kind-<cluster>.
+	ctxName := "kind-" + cluster.DefaultKindClusterName
+	fmt.Println("  " + gateOK.Render("✓") + " Cluster ready: " + gateAccent.Render(ctxName))
+	return ctxName, nil
+}
+
+// printNoCluster explains what was found. It distinguishes "no contexts at all"
+// from "contexts exist but none answered" — a stale kubeconfig is the common
+// laptop case and reporting it as "no clusters found" is simply untrue.
+func printNoCluster(d cluster.Decision) {
+	fmt.Println()
+	if len(d.Unreachable) > 0 {
+		fmt.Println("  " + gateWarn.Render("!") + " " +
+			gateTitle.Render(fmt.Sprintf("%s configured, none reachable",
+				plural(len(d.Unreachable), "context", "contexts"))))
+		for _, c := range d.Unreachable {
+			fmt.Println("    " + gateErr.Render("✗") + " " + c.Name + gateDim.Render(describeContext(c)))
+		}
+	} else {
+		fmt.Println("  " + gateWarn.Render("!") + " " + gateTitle.Render("No Kubernetes context configured"))
+	}
+}
+
+func describeContext(c cluster.Context) string {
+	var bits []string
+	if c.Cluster != "" && c.Cluster != c.Name {
+		bits = append(bits, c.Cluster)
+	}
+	if c.Namespace != "" {
+		bits = append(bits, "ns:"+c.Namespace)
+	}
+	if len(bits) == 0 {
+		return ""
+	}
+	return "  (" + strings.Join(bits, " · ") + ")"
+}
+
+func contextNames(cs []cluster.Context) []string {
+	out := make([]string, 0, len(cs))
+	for _, c := range cs {
+		out = append(out, c.Name)
+	}
+	return out
+}
+
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, one)
+	}
+	return fmt.Sprintf("%d %s", n, many)
+}

--- a/cli/cmd/cluster_gate_test.go
+++ b/cli/cmd/cluster_gate_test.go
@@ -25,6 +25,9 @@ type stubGate struct {
 	// kindExists simulates a pre-existing kind cluster. Left false, tests are
 	// independent of whatever clusters the developer's machine happens to have.
 	kindExists bool
+	// configMissing simulates running outside the repo, where the kind topology
+	// config is not readable.
+	configMissing bool
 
 	createCalled  bool
 	createErr     error
@@ -62,11 +65,14 @@ func (s *stubGate) install(t *testing.T) {
 		return s.picked, s.pickErr
 	}
 	kindClusterExistsFn = func(detect.CommandExecutor, string) bool { return s.kindExists }
+	origConfig := configExistsFn
+	configExistsFn = func(string) bool { return !s.configMissing }
 
 	t.Cleanup(func() {
 		listContextsFn, checkAllReachableFn, probeEnvironmentFn, createKindFn = origList, origReach, origProbe, origCreate
 		interactiveFn, confirmFn, pickContextFn = origInteractive, origConfirm, origPick
 		kindClusterExistsFn = origExists
+		configExistsFn = origConfig
 	})
 }
 
@@ -276,6 +282,50 @@ func TestResolveCluster_ExistingUnreachableKindIsNotClobbered(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "kind delete cluster") {
 		t.Errorf("error should offer the way out, got: %v", err)
+	}
+}
+
+// A plan preview must not build real infrastructure. --dry-run is checked far
+// later in runDeploy, so the gate has to refuse on its own.
+func TestResolveCluster_DryRunNeverCreatesACluster(t *testing.T) {
+	origDry := deployDryRun
+	deployDryRun = true
+	t.Cleanup(func() { deployDryRun = origDry })
+
+	s := &stubGate{contexts: nil, env: dockerReady, tty: true, confirm: true}
+	s.install(t)
+
+	_, err := resolveCluster()
+	if err == nil {
+		t.Fatal("a dry run with no cluster should report, not proceed")
+	}
+	if s.createCalled {
+		t.Error("--dry-run must NEVER create a kind cluster")
+	}
+	if s.confirmCalled {
+		t.Error("--dry-run must not even ask — there is nothing to consent to")
+	}
+}
+
+// The kind topology config is repo-relative, so an installed binary run from
+// elsewhere cannot read it. Offering anyway fails inside `kind create` with a
+// bare "no such file".
+func TestResolveCluster_MissingTopologyConfigIsExplained(t *testing.T) {
+	s := &stubGate{
+		contexts: nil, env: dockerReady, tty: true, confirm: true,
+		configMissing: true,
+	}
+	s.install(t)
+
+	_, err := resolveCluster()
+	if err == nil {
+		t.Fatal("want an error when the topology config is unreadable")
+	}
+	if s.createCalled {
+		t.Error("must not attempt creation without the topology config")
+	}
+	if !strings.Contains(err.Error(), cluster.DefaultKindConfig) {
+		t.Errorf("error should name the missing config, got: %v", err)
 	}
 }
 

--- a/cli/cmd/cluster_gate_test.go
+++ b/cli/cmd/cluster_gate_test.go
@@ -1,0 +1,361 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/bmscomp/kates/cli/pkg/cluster"
+	"github.com/bmscomp/kates/cli/pkg/detect"
+)
+
+// stubGate replaces every seam and restores them on cleanup, so each test states
+// only the state it cares about and cannot leak into the next.
+type stubGate struct {
+	contexts   []cluster.Context
+	listErr    error
+	env        cluster.Environment
+	tty        bool
+	confirm    bool
+	confirmErr error
+	picked     string
+	pickErr    error
+
+	// kindExists simulates a pre-existing kind cluster. Left false, tests are
+	// independent of whatever clusters the developer's machine happens to have.
+	kindExists bool
+
+	createCalled  bool
+	createErr     error
+	pickCalled    bool
+	confirmCalled bool
+}
+
+func (s *stubGate) install(t *testing.T) {
+	t.Helper()
+
+	origList, origReach, origProbe, origCreate := listContextsFn, checkAllReachableFn, probeEnvironmentFn, createKindFn
+	origInteractive, origConfirm, origPick := interactiveFn, confirmFn, pickContextFn
+	origExists := kindClusterExistsFn
+
+	listContextsFn = func(detect.CommandExecutor) ([]cluster.Context, error) {
+		return s.contexts, s.listErr
+	}
+	// Reachability is decided by the fixture, not probed.
+	checkAllReachableFn = func(_ detect.CommandExecutor, c []cluster.Context) []cluster.Context { return c }
+	probeEnvironmentFn = func(detect.CommandExecutor) cluster.Environment { return s.env }
+	createKindFn = func(_ detect.CommandExecutor, o cluster.KindOptions) error {
+		s.createCalled = true
+		if o.Progress != nil {
+			o.Progress("stub")
+		}
+		return s.createErr
+	}
+	interactiveFn = func() bool { return s.tty }
+	confirmFn = func(string) (bool, error) {
+		s.confirmCalled = true
+		return s.confirm, s.confirmErr
+	}
+	pickContextFn = func([]cluster.Context) (string, error) {
+		s.pickCalled = true
+		return s.picked, s.pickErr
+	}
+	kindClusterExistsFn = func(detect.CommandExecutor, string) bool { return s.kindExists }
+
+	t.Cleanup(func() {
+		listContextsFn, checkAllReachableFn, probeEnvironmentFn, createKindFn = origList, origReach, origProbe, origCreate
+		interactiveFn, confirmFn, pickContextFn = origInteractive, origConfirm, origPick
+		kindClusterExistsFn = origExists
+	})
+}
+
+func reachable(name string) cluster.Context {
+	return cluster.Context{Name: name, Reachable: true, Probed: true}
+}
+func unreachable(name string) cluster.Context {
+	return cluster.Context{Name: name, Reachable: false, Probed: true}
+}
+
+var dockerReady = cluster.Environment{Docker: cluster.DockerRunning, KindInstalled: true}
+
+// ── The wiring ─────────────────────────────────────────────────────────────
+
+// The gate must actually gate: if it fails, deploy stops before touching
+// anything. Without this, deploy_test.go's stub could mask a broken wiring.
+func TestRunDeploy_AbortsWhenClusterGateFails(t *testing.T) {
+	orig := resolveClusterFn
+	t.Cleanup(func() { resolveClusterFn = orig })
+
+	var helmCalled bool
+	origHelm := runHelmFn
+	runHelmFn = func(_ context.Context, _ ...string) error { helmCalled = true; return nil }
+	t.Cleanup(func() { runHelmFn = origHelm })
+
+	resolveClusterFn = func() (string, error) {
+		return "", errors.New("no reachable Kubernetes cluster")
+	}
+
+	err := runDeploy(deployCmd, []string{})
+	if err == nil {
+		t.Fatal("deploy must abort when no cluster can be resolved")
+	}
+	if !strings.Contains(err.Error(), "no reachable") {
+		t.Errorf("the gate's reason must reach the user, got: %v", err)
+	}
+	if helmCalled {
+		t.Error("deploy must not run helm when there is no cluster to deploy to")
+	}
+}
+
+// ── The happy path ─────────────────────────────────────────────────────────
+
+func TestResolveCluster_SingleContextNeverPrompts(t *testing.T) {
+	s := &stubGate{contexts: []cluster.Context{reachable("kind-panda")}, env: dockerReady, tty: true}
+	s.install(t)
+
+	got, err := resolveCluster()
+	if err != nil {
+		t.Fatalf("resolveCluster: %v", err)
+	}
+	if got != "kind-panda" {
+		t.Errorf("got %q, want kind-panda", got)
+	}
+	// The 90% case: one cluster, no question asked.
+	if s.pickCalled || s.confirmCalled {
+		t.Error("a single reachable cluster must not prompt")
+	}
+}
+
+func TestResolveCluster_MultipleContextsPrompt(t *testing.T) {
+	s := &stubGate{
+		contexts: []cluster.Context{reachable("kind-panda"), reachable("prod-eu")},
+		env:      dockerReady, tty: true, picked: "prod-eu",
+	}
+	s.install(t)
+
+	got, err := resolveCluster()
+	if err != nil {
+		t.Fatalf("resolveCluster: %v", err)
+	}
+	if !s.pickCalled {
+		t.Error("several reachable clusters must present the picker")
+	}
+	if got != "prod-eu" {
+		t.Errorf("got %q, want the picked context", got)
+	}
+}
+
+// ── The non-TTY guard: the load-bearing safety property ────────────────────
+
+// Ambiguity without a terminal must FAIL, never guess. Silently picking is how
+// you deploy to prod by accident.
+func TestResolveCluster_MultipleContextsNonTTYFailsRatherThanGuessing(t *testing.T) {
+	s := &stubGate{
+		contexts: []cluster.Context{reachable("kind-panda"), reachable("prod-eu")},
+		env:      dockerReady, tty: false,
+	}
+	s.install(t)
+
+	_, err := resolveCluster()
+	if err == nil {
+		t.Fatal("must fail when several clusters are reachable and we cannot ask")
+	}
+	if s.pickCalled {
+		t.Error("must not launch a TUI without a terminal — it would hang")
+	}
+	// The error has to tell the user how to resolve it.
+	if !strings.Contains(err.Error(), "use-context") {
+		t.Errorf("error should say how to choose, got: %v", err)
+	}
+}
+
+func TestResolveCluster_OfferKindNonTTYFailsWithoutPrompting(t *testing.T) {
+	s := &stubGate{contexts: nil, env: dockerReady, tty: false}
+	s.install(t)
+
+	_, err := resolveCluster()
+	if err == nil {
+		t.Fatal("must fail when there is no cluster and we cannot ask")
+	}
+	if s.confirmCalled {
+		t.Error("must not prompt without a terminal — it would hang")
+	}
+	if s.createCalled {
+		t.Error("must never create a cluster without explicit consent")
+	}
+	// It should still tell the user what it would have done.
+	if !strings.Contains(err.Error(), "kind create cluster") {
+		t.Errorf("error should give the manual command, got: %v", err)
+	}
+}
+
+// isInteractive is the single guard everything else relies on.
+func TestIsInteractive_FalseUnderTestAndYes(t *testing.T) {
+	origTesting, origYes := isTesting, deployYes
+	t.Cleanup(func() { isTesting, deployYes = origTesting, origYes })
+
+	isTesting, deployYes = true, false
+	if isInteractive() {
+		t.Error("isTesting must disable prompting — deploy_test.go calls runDeploy directly")
+	}
+
+	isTesting, deployYes = false, true
+	if isInteractive() {
+		t.Error("--yes must disable prompting")
+	}
+}
+
+// ── The kind offer ─────────────────────────────────────────────────────────
+
+func TestResolveCluster_OfferKindAcceptedCreates(t *testing.T) {
+	s := &stubGate{contexts: nil, env: dockerReady, tty: true, confirm: true}
+	s.install(t)
+
+	got, err := resolveCluster()
+	if err != nil {
+		t.Fatalf("resolveCluster: %v", err)
+	}
+	if !s.confirmCalled {
+		t.Error("must ask before creating a cluster")
+	}
+	if !s.createCalled {
+		t.Error("accepting must create the cluster")
+	}
+	// kind names the context kind-<name>; deploying to the wrong name would fail.
+	if got != "kind-"+cluster.DefaultKindClusterName {
+		t.Errorf("got %q, want kind-%s", got, cluster.DefaultKindClusterName)
+	}
+}
+
+func TestResolveCluster_OfferKindDeclinedCreatesNothing(t *testing.T) {
+	s := &stubGate{contexts: nil, env: dockerReady, tty: true, confirm: false}
+	s.install(t)
+
+	_, err := resolveCluster()
+	if err == nil {
+		t.Fatal("declining leaves no cluster to deploy to — must error")
+	}
+	if s.createCalled {
+		t.Error("declining must not create anything")
+	}
+}
+
+func TestResolveCluster_KindCreateFailurePropagates(t *testing.T) {
+	s := &stubGate{
+		contexts: nil, env: dockerReady, tty: true, confirm: true,
+		createErr: errors.New("port 6443 already in use"),
+	}
+	s.install(t)
+
+	_, err := resolveCluster()
+	if err == nil {
+		t.Fatal("want error when creation fails")
+	}
+	if !strings.Contains(err.Error(), "already in use") {
+		t.Errorf("underlying cause must survive, got: %v", err)
+	}
+}
+
+// A kind cluster that exists but does not answer is a broken cluster, not an
+// absent one. Recreating would silently destroy it, so we stop and let a human
+// decide.
+func TestResolveCluster_ExistingUnreachableKindIsNotClobbered(t *testing.T) {
+	s := &stubGate{
+		contexts: nil, env: dockerReady, tty: true, confirm: true,
+		kindExists: true,
+	}
+	s.install(t)
+
+	_, err := resolveCluster()
+	if err == nil {
+		t.Fatal("want an error rather than silently recreating a broken cluster")
+	}
+	if s.createCalled {
+		t.Error("must NOT recreate over an existing kind cluster — that destroys it")
+	}
+	if !strings.Contains(err.Error(), "kind delete cluster") {
+		t.Errorf("error should offer the way out, got: %v", err)
+	}
+}
+
+// ── The blocked states (R3) ────────────────────────────────────────────────
+
+// Each state needs its own advice: installing Docker, starting Docker, and
+// installing kind are three different actions.
+func TestResolveCluster_BlockedStatesGiveDistinctAdvice(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      cluster.Environment
+		wantHint string
+	}{
+		{
+			name:     "no docker at all",
+			env:      cluster.Environment{Docker: cluster.DockerNotInstalled},
+			wantHint: "get-docker",
+		},
+		{
+			name:     "docker installed but stopped",
+			env:      cluster.Environment{Docker: cluster.DockerInstalledNotRunning, KindInstalled: true},
+			wantHint: "not running",
+		},
+		{
+			name:     "docker running but kind missing",
+			env:      cluster.Environment{Docker: cluster.DockerRunning, KindInstalled: false},
+			wantHint: "kind is not installed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &stubGate{contexts: nil, env: tt.env, tty: true}
+			s.install(t)
+
+			_, err := resolveCluster()
+			if err == nil {
+				t.Fatal("want an error explaining what is missing")
+			}
+			if !strings.Contains(err.Error(), tt.wantHint) {
+				t.Errorf("error should mention %q, got: %v", tt.wantHint, err)
+			}
+			if s.createCalled || s.confirmCalled {
+				t.Error("must not offer to create a cluster that cannot be created")
+			}
+		})
+	}
+}
+
+// The stale-kubeconfig case: contexts exist but none answer. This must not be
+// reported as "no clusters found", and must still offer kind.
+func TestResolveCluster_ContextsExistButNoneReachable(t *testing.T) {
+	s := &stubGate{
+		contexts: []cluster.Context{unreachable("stale"), unreachable("older")},
+		env:      dockerReady, tty: true, confirm: true,
+	}
+	s.install(t)
+
+	got, err := resolveCluster()
+	if err != nil {
+		t.Fatalf("resolveCluster: %v", err)
+	}
+	if !s.createCalled {
+		t.Error("unreachable contexts should still lead to the kind offer")
+	}
+	if got != "kind-"+cluster.DefaultKindClusterName {
+		t.Errorf("got %q", got)
+	}
+}
+
+// A broken kubectl must surface, not be mistaken for "no clusters".
+func TestResolveCluster_KubeconfigErrorPropagates(t *testing.T) {
+	s := &stubGate{listErr: errors.New("permission denied"), env: dockerReady, tty: true}
+	s.install(t)
+
+	_, err := resolveCluster()
+	if err == nil {
+		t.Fatal("a kubeconfig read failure must surface")
+	}
+	if s.createCalled {
+		t.Error("must not create a cluster because kubectl is broken")
+	}
+}

--- a/cli/cmd/cluster_picker.go
+++ b/cli/cmd/cluster_picker.go
@@ -1,0 +1,154 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/bmscomp/kates/cli/pkg/cluster"
+)
+
+// pickerModel is a minimal bubbletea list for choosing a context.
+//
+// It is deliberately small: the choice is "which of these few clusters", and a
+// heavier component would add scrolling, filtering, and pagination for a list
+// that is almost always 2-4 items long.
+type pickerModel struct {
+	contexts []cluster.Context
+	cursor   int
+	chosen   string
+	aborted  bool
+}
+
+func (m pickerModel) Init() tea.Cmd { return nil }
+
+func (m pickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+
+	switch key.String() {
+	case "up", "k":
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case "down", "j":
+		if m.cursor < len(m.contexts)-1 {
+			m.cursor++
+		}
+	case "enter":
+		m.chosen = m.contexts[m.cursor].Name
+		return m, tea.Quit
+	// Aborting must be explicit and always available: this is the last gate
+	// before we start writing to a cluster.
+	case "q", "esc", "ctrl+c":
+		m.aborted = true
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m pickerModel) View() string {
+	if m.chosen != "" || m.aborted {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("\n  " + gateTitle.Render("Select a cluster to deploy to") + "\n\n")
+
+	for i, c := range m.contexts {
+		cursor := "  "
+		name := c.Name
+		if i == m.cursor {
+			cursor = gateAccent.Render("▸ ")
+			name = gateAccent.Bold(true).Render(name)
+		} else {
+			name = lipgloss.NewStyle().Render(name)
+		}
+
+		line := "  " + cursor + name
+		// The current kubeconfig context is worth marking: it is what every
+		// other kubectl command in this shell is already pointing at.
+		if c.Current {
+			line += gateDim.Render(" (current)")
+		}
+		line += gateDim.Render(describeContext(c))
+		b.WriteString(line + "\n")
+	}
+
+	b.WriteString("\n  " + gateDim.Render("↑/↓ move · enter select · q abort") + "\n")
+	return b.String()
+}
+
+// pickContext runs the picker. Callers must ensure a TTY first — see
+// isInteractive.
+func pickContext(contexts []cluster.Context) (string, error) {
+	// Start on the current context: it is the likeliest intent, and it means
+	// enter-without-reading picks what kubectl would have picked.
+	start := 0
+	for i, c := range contexts {
+		if c.Current {
+			start = i
+			break
+		}
+	}
+
+	m, err := tea.NewProgram(pickerModel{contexts: contexts, cursor: start}).Run()
+	if err != nil {
+		return "", fmt.Errorf("cluster picker: %w", err)
+	}
+
+	final := m.(pickerModel)
+	if final.aborted || final.chosen == "" {
+		return "", fmt.Errorf("no cluster selected")
+	}
+
+	fmt.Println("  " + gateOK.Render("✓") + " Cluster: " + gateAccent.Render(final.chosen))
+	return final.chosen, nil
+}
+
+// confirmModel is a yes/no prompt.
+type confirmModel struct {
+	question string
+	yes      bool
+	answered bool
+}
+
+func (m confirmModel) Init() tea.Cmd { return nil }
+
+func (m confirmModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+	switch key.String() {
+	case "y", "Y":
+		m.yes, m.answered = true, true
+		return m, tea.Quit
+	// Default to no on anything else that ends the prompt: creating a cluster
+	// should never happen because someone hit the wrong key.
+	case "n", "N", "enter", "q", "esc", "ctrl+c":
+		m.yes, m.answered = false, true
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m confirmModel) View() string {
+	if m.answered {
+		return ""
+	}
+	return "  " + m.question + gateDim.Render(" [y/N] ")
+}
+
+// confirmPrompt asks a yes/no question. Callers must ensure a TTY first.
+func confirmPrompt(question string) (bool, error) {
+	m, err := tea.NewProgram(confirmModel{question: question}).Run()
+	if err != nil {
+		return false, fmt.Errorf("confirm prompt: %w", err)
+	}
+	return m.(confirmModel).yes, nil
+}

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -11,9 +11,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/bmscomp/kates/cli/output"
 	"github.com/bmscomp/kates/cli/pkg/detect"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 )
 
@@ -61,6 +61,7 @@ var (
 	deployPortForward        bool
 	deployDryRun             bool
 	deployWithKafkaUI        bool
+	deployYes                bool
 )
 
 func init() {
@@ -89,6 +90,7 @@ func init() {
 	deployCmd.Flags().BoolVar(&deployVerbose, "verbose", false, "Show every kubectl/helm command as it runs")
 	deployCmd.Flags().BoolVarP(&deployPortForward, "port-forward", "P", false, "After deploy, start port-forwards for all services and keep running until Ctrl+C")
 	deployCmd.Flags().BoolVar(&deployDryRun, "dry-run", false, "Show the deployment plan without executing anything")
+	deployCmd.Flags().BoolVarP(&deployYes, "yes", "y", false, "Assume yes and never prompt (fails instead of asking)")
 
 	rootCmd.AddCommand(deployCmd)
 }
@@ -100,7 +102,11 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	dl = &DashboardController{}
 
 	// ── Interactive Forms ────────────────────────────────────────────────
-	if deployInteractive || cmd.Flags().NFlag() == 0 {
+	// Guarded by isInteractive: the forms open /dev/tty directly, so without a
+	// terminal they fail with "could not open a new TTY" rather than falling
+	// back to the flag defaults. Piped or scripted runs should just use the
+	// defaults.
+	if (deployInteractive || cmd.Flags().NFlag() == 0) && isInteractive() {
 		if err := runInteractiveForms(); err != nil {
 			return err
 		}
@@ -113,39 +119,21 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	printComponentSelection()
 
 	// 3. Cluster Detection
-	PrintPhaseHeader(3, "Running Cluster Introspection (Pre-flight)")
+	PrintPhaseHeader(3, "Selecting Target Cluster")
 	executor := defaultExecutor
+
+	// Resolve which cluster we are deploying to before anything assumes one
+	// exists. When nothing is reachable this offers to build the local 3-zone
+	// kind cluster; when several are reachable it asks rather than guessing.
+	if _, err := resolveClusterFn(); err != nil {
+		return err
+	}
+
+	PrintPhaseHeader(3, "Running Cluster Introspection (Pre-flight)")
 	collector := detect.NewCollector(executor)
-
 	if err := collector.Preflight(); err != nil {
-		fmt.Println("⚠️  Kubernetes cluster is unreachable.")
-
-		// Check if docker is running
-		if dockerCheck := exec.Command("docker", "info"); dockerCheck.Run() == nil {
-			fmt.Print("🐳 Docker is running. Would you like to automatically create a local Kind cluster? [y/N]: ")
-			var response string
-			fmt.Scanln(&response)
-			if strings.ToLower(response) == "y" || strings.ToLower(response) == "yes" {
-				fmt.Println("📦 Creating Kind cluster via 'make cluster'...")
-				cmd := exec.Command("make", "cluster")
-				cmd.Stdout = os.Stdout
-				cmd.Stderr = os.Stderr
-				if err := cmd.Run(); err != nil {
-					return fmt.Errorf("failed to create Kind cluster: %w", err)
-				}
-				fmt.Println("✅ Kind cluster created successfully! Retrying preflight...")
-
-				// Re-run preflight
-				if err := collector.Preflight(); err != nil {
-					return fmt.Errorf("preflight failed even after cluster creation: %w", err)
-				}
-			} else {
-				return fmt.Errorf("cluster is unreachable and user opted out of auto-creation")
-			}
-		} else {
-			output.Error(fmt.Sprintf("Preflight failed: %v", err))
-			return err
-		}
+		output.Error(fmt.Sprintf("Preflight failed: %v", err))
+		return err
 	}
 
 	// ── Kind storage bootstrap ────────────────────────────────────────────────

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -101,6 +101,17 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 
 	dl = &DashboardController{}
 
+	// ── Target cluster ───────────────────────────────────────────────────
+	// This runs FIRST, before the wizard. There is no point asking eight
+	// questions about a deployment and only then discovering there is nowhere
+	// to deploy it. When nothing is reachable this offers to build the local
+	// 3-zone kind cluster; when several are reachable it asks rather than
+	// guessing.
+	PrintPhaseHeader(1, "Selecting Target Cluster")
+	if _, err := resolveClusterFn(); err != nil {
+		return err
+	}
+
 	// ── Interactive Forms ────────────────────────────────────────────────
 	// Guarded by isInteractive: the forms open /dev/tty directly, so without a
 	// terminal they fail with "could not open a new TTY" rather than falling
@@ -112,23 +123,13 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// 1. Resolve Topology
+	// Resolve Topology
 	printTopologyResolution()
 
-	// 2. Component Selection
+	// Component Selection
 	printComponentSelection()
 
-	// 3. Cluster Detection
-	PrintPhaseHeader(3, "Selecting Target Cluster")
 	executor := defaultExecutor
-
-	// Resolve which cluster we are deploying to before anything assumes one
-	// exists. When nothing is reachable this offers to build the local 3-zone
-	// kind cluster; when several are reachable it asks rather than guessing.
-	if _, err := resolveClusterFn(); err != nil {
-		return err
-	}
-
 	PrintPhaseHeader(3, "Running Cluster Introspection (Pre-flight)")
 	collector := detect.NewCollector(executor)
 	if err := collector.Preflight(); err != nil {

--- a/cli/cmd/deploy_test.go
+++ b/cli/cmd/deploy_test.go
@@ -9,6 +9,11 @@ import (
 
 func init() {
 	isTesting = true
+	// These tests exercise deploy orchestration and assume a cluster already
+	// exists. The cluster gate is a real precondition of runDeploy, but its own
+	// behavior (picking, the kind offer, the blocked states) is covered directly
+	// in cluster_gate_test.go — stubbing it here keeps that concern in one place.
+	resolveClusterFn = func() (string, error) { return "test-context", nil }
 }
 
 type MockExecutor struct{}

--- a/cli/pkg/cluster/cluster.go
+++ b/cli/pkg/cluster/cluster.go
@@ -1,0 +1,193 @@
+// Package cluster discovers Kubernetes contexts and, when none is usable,
+// works out whether a local Kind cluster can be created instead.
+//
+// Everything here goes through detect.CommandExecutor rather than os/exec so
+// the whole decision tree is testable without a real cluster or a real Docker
+// daemon.
+package cluster
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bmscomp/kates/cli/pkg/detect"
+)
+
+// Context is one kubeconfig context.
+type Context struct {
+	Name      string
+	Cluster   string
+	Namespace string
+	Current   bool // the kubeconfig's current-context
+	Reachable bool // set by CheckReachable; false until then
+	// Probed records whether reachability was actually tested. Without it,
+	// "unreachable" and "not yet checked" are indistinguishable — the bug that
+	// makes a picker silently present dead clusters as live ones.
+	Probed bool
+}
+
+// DockerState distinguishes the failure modes a user must be told apart:
+// a missing binary needs an install, a stopped daemon needs a start.
+type DockerState int
+
+const (
+	DockerNotInstalled DockerState = iota
+	DockerInstalledNotRunning
+	DockerRunning
+)
+
+func (d DockerState) String() string {
+	switch d {
+	case DockerRunning:
+		return "running"
+	case DockerInstalledNotRunning:
+		return "installed but not running"
+	default:
+		return "not installed"
+	}
+}
+
+// Environment is what we can tell about the local machine's ability to host a
+// Kind cluster.
+type Environment struct {
+	Docker        DockerState
+	KindInstalled bool
+}
+
+// CanCreateKind reports whether a Kind cluster could actually be created here.
+func (e Environment) CanCreateKind() bool {
+	return e.Docker == DockerRunning && e.KindInstalled
+}
+
+// reachabilityTimeout bounds every reachability probe. kubectl will otherwise
+// block on a dead endpoint until its own long default elapses, which would
+// stall the picker for seconds per stale context — the common case on a laptop
+// with an old kubeconfig.
+const reachabilityTimeout = "5s"
+
+// ListContexts returns every context in the kubeconfig, marking the current
+// one. Reachability is NOT probed here; call CheckReachable.
+//
+// An empty list and a nil error is a valid, expected result: it means there is
+// no kubeconfig, or it defines no contexts.
+func ListContexts(exec detect.CommandExecutor) ([]Context, error) {
+	// Custom columns rather than -o name: we want the cluster and namespace
+	// too, and get-contexts is the only kubectl call that reports the current
+	// context marker.
+	out, err := exec.Exec("kubectl", "config", "get-contexts",
+		"--no-headers",
+		"-o", "name")
+	if err != nil {
+		// A kubeconfig that does not exist is not an error for our purposes —
+		// it is simply "no contexts", which is the state the caller handles.
+		if isMissingKubeconfig(err, out) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("listing kubeconfig contexts: %w", err)
+	}
+
+	current, _ := exec.Exec("kubectl", "config", "current-context")
+	current = strings.TrimSpace(current)
+
+	var contexts []Context
+	for _, line := range strings.Split(out, "\n") {
+		name := strings.TrimSpace(line)
+		if name == "" {
+			continue
+		}
+		contexts = append(contexts, Context{
+			Name:      name,
+			Cluster:   contextField(exec, name, "{.context.cluster}"),
+			Namespace: contextField(exec, name, "{.context.namespace}"),
+			Current:   name == current,
+		})
+	}
+	return contexts, nil
+}
+
+// contextField reads one jsonpath field for a named context. A failure here is
+// cosmetic — the context is still selectable — so errors degrade to "".
+func contextField(exec detect.CommandExecutor, name, jsonpath string) string {
+	out, err := exec.Exec("kubectl", "config", "view",
+		"-o", fmt.Sprintf("jsonpath={.contexts[?(@.name==%q)]%s}", name, strings.TrimPrefix(jsonpath, "{")))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(out)
+}
+
+// isMissingKubeconfig reports whether the error means "no kubeconfig" rather
+// than "kubectl is broken". Both surface as a non-zero exit, but only the
+// former is a normal state we should handle silently.
+func isMissingKubeconfig(err error, out string) bool {
+	hay := strings.ToLower(out + " " + err.Error())
+	for _, s := range []string{
+		"no such file or directory",
+		"stat .*kubeconfig",
+		"error loading config file",
+		"no configuration has been provided",
+	} {
+		if strings.Contains(hay, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckReachable probes one context with a bounded timeout and returns a copy
+// with Reachable and Probed set.
+func CheckReachable(exec detect.CommandExecutor, c Context) Context {
+	_, err := exec.Exec("kubectl", "cluster-info",
+		"--context", c.Name,
+		"--request-timeout", reachabilityTimeout)
+	c.Reachable = err == nil
+	c.Probed = true
+	return c
+}
+
+// CheckAllReachable probes every context. It is sequential on purpose: the
+// bounded timeout keeps the worst case small, and concurrent kubectl processes
+// against a hanging endpoint buy little for the added complexity.
+func CheckAllReachable(exec detect.CommandExecutor, contexts []Context) []Context {
+	out := make([]Context, 0, len(contexts))
+	for _, c := range contexts {
+		out = append(out, CheckReachable(exec, c))
+	}
+	return out
+}
+
+// Reachable filters to contexts that were probed and answered.
+func Reachable(contexts []Context) []Context {
+	var out []Context
+	for _, c := range contexts {
+		if c.Reachable {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// ProbeEnvironment determines whether this machine can host a Kind cluster.
+//
+// The docker-not-installed vs docker-installed-but-stopped distinction is the
+// point: the two need different advice, and collapsing them into "docker is
+// unavailable" tells the user nothing actionable.
+func ProbeEnvironment(exec detect.CommandExecutor) Environment {
+	env := Environment{Docker: DockerNotInstalled}
+
+	if _, err := exec.LookPath("docker"); err == nil {
+		// `docker info` talks to the daemon; `docker version` alone would
+		// succeed against a stopped daemon and misreport it as running.
+		if _, err := exec.Exec("docker", "info"); err == nil {
+			env.Docker = DockerRunning
+		} else {
+			env.Docker = DockerInstalledNotRunning
+		}
+	}
+
+	if _, err := exec.LookPath("kind"); err == nil {
+		env.KindInstalled = true
+	}
+
+	return env
+}

--- a/cli/pkg/cluster/cluster_test.go
+++ b/cli/pkg/cluster/cluster_test.go
@@ -1,0 +1,413 @@
+package cluster
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// fakeExec scripts command results by matching a prefix of the joined command
+// line, so a test states only what it cares about.
+type fakeExec struct {
+	// responses maps a command-line prefix to its output/error.
+	responses map[string]fakeResult
+	// missing are binaries LookPath should fail for.
+	missing map[string]bool
+	// calls records every command, for asserting on flags we depend on.
+	calls []string
+}
+
+type fakeResult struct {
+	out string
+	err error
+}
+
+func newFake() *fakeExec {
+	return &fakeExec{responses: map[string]fakeResult{}, missing: map[string]bool{}}
+}
+
+func (f *fakeExec) on(prefix, out string, err error) *fakeExec {
+	f.responses[prefix] = fakeResult{out: out, err: err}
+	return f
+}
+
+func (f *fakeExec) absent(bin string) *fakeExec {
+	f.missing[bin] = true
+	return f
+}
+
+func (f *fakeExec) Exec(name string, args ...string) (string, error) {
+	line := strings.TrimSpace(name + " " + strings.Join(args, " "))
+	f.calls = append(f.calls, line)
+	// Longest matching prefix wins, so a specific stub beats a general one.
+	best, bestLen := fakeResult{}, -1
+	for prefix, res := range f.responses {
+		if strings.HasPrefix(line, prefix) && len(prefix) > bestLen {
+			best, bestLen = res, len(prefix)
+		}
+	}
+	if bestLen == -1 {
+		return "", nil
+	}
+	return best.out, best.err
+}
+
+func (f *fakeExec) LookPath(file string) (string, error) {
+	if f.missing[file] {
+		return "", errors.New("not found in $PATH")
+	}
+	return "/usr/local/bin/" + file, nil
+}
+
+func (f *fakeExec) called(substr string) bool {
+	for _, c := range f.calls {
+		if strings.Contains(c, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// ── ListContexts ───────────────────────────────────────────────────────────
+
+func TestListContexts_MarksCurrent(t *testing.T) {
+	f := newFake().
+		on("kubectl config get-contexts", "kind-panda\nprod-eu\n", nil).
+		on("kubectl config current-context", "prod-eu\n", nil)
+
+	got, err := ListContexts(f)
+	if err != nil {
+		t.Fatalf("ListContexts: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 contexts, got %d: %+v", len(got), got)
+	}
+	if got[0].Name != "kind-panda" || got[0].Current {
+		t.Errorf("kind-panda should not be current: %+v", got[0])
+	}
+	if got[1].Name != "prod-eu" || !got[1].Current {
+		t.Errorf("prod-eu should be current: %+v", got[1])
+	}
+}
+
+// A machine with no kubeconfig is a normal state the flow handles, not an
+// error to propagate.
+func TestListContexts_NoKubeconfigIsEmptyNotError(t *testing.T) {
+	f := newFake().on("kubectl config get-contexts", "error loading config file",
+		errors.New("exit status 1"))
+
+	got, err := ListContexts(f)
+	if err != nil {
+		t.Fatalf("missing kubeconfig should not error, got: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("want no contexts, got %+v", got)
+	}
+}
+
+// A genuinely broken kubectl must NOT be silently swallowed as "no contexts",
+// or we would offer to build a Kind cluster over a real but broken setup.
+func TestListContexts_RealFailurePropagates(t *testing.T) {
+	f := newFake().on("kubectl config get-contexts", "permission denied",
+		errors.New("exit status 1"))
+
+	if _, err := ListContexts(f); err == nil {
+		t.Fatal("a real kubectl failure must propagate, not read as 'no contexts'")
+	}
+}
+
+// ── Reachability ───────────────────────────────────────────────────────────
+
+func TestCheckReachable_BoundsTheProbe(t *testing.T) {
+	f := newFake().on("kubectl cluster-info", "Kubernetes control plane is running", nil)
+
+	got := CheckReachable(f, Context{Name: "kind-panda"})
+	if !got.Reachable || !got.Probed {
+		t.Fatalf("want reachable+probed, got %+v", got)
+	}
+	// Without a bounded timeout the picker stalls on every dead context.
+	if !f.called("--request-timeout") {
+		t.Errorf("reachability probe must pass --request-timeout; calls: %v", f.calls)
+	}
+	if !f.called("--context kind-panda") {
+		t.Errorf("probe must target the named context; calls: %v", f.calls)
+	}
+}
+
+func TestCheckReachable_Unreachable(t *testing.T) {
+	f := newFake().on("kubectl cluster-info", "connection refused", errors.New("exit status 1"))
+
+	got := CheckReachable(f, Context{Name: "stale"})
+	if got.Reachable {
+		t.Fatal("want unreachable")
+	}
+	if !got.Probed {
+		t.Fatal("Probed must be true even when unreachable — otherwise 'not checked' and 'dead' are indistinguishable")
+	}
+}
+
+// ── ProbeEnvironment ───────────────────────────────────────────────────────
+
+func TestProbeEnvironment(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(*fakeExec)
+		wantDock DockerState
+		wantKind bool
+	}{
+		{
+			name:     "docker running, kind present",
+			setup:    func(f *fakeExec) { f.on("docker info", "Server Version: 27.0", nil) },
+			wantDock: DockerRunning,
+			wantKind: true,
+		},
+		{
+			// The distinction that matters: installed-but-stopped needs "start
+			// Docker", not "install Docker".
+			name:     "docker installed but daemon stopped",
+			setup:    func(f *fakeExec) { f.on("docker info", "Cannot connect to the Docker daemon", errors.New("exit 1")) },
+			wantDock: DockerInstalledNotRunning,
+			wantKind: true,
+		},
+		{
+			name:     "docker not installed",
+			setup:    func(f *fakeExec) { f.absent("docker") },
+			wantDock: DockerNotInstalled,
+			wantKind: true,
+		},
+		{
+			name: "docker running, kind absent",
+			setup: func(f *fakeExec) {
+				f.on("docker info", "Server Version: 27.0", nil)
+				f.absent("kind")
+			},
+			wantDock: DockerRunning,
+			wantKind: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newFake()
+			tt.setup(f)
+			env := ProbeEnvironment(f)
+			if env.Docker != tt.wantDock {
+				t.Errorf("Docker = %v, want %v", env.Docker, tt.wantDock)
+			}
+			if env.KindInstalled != tt.wantKind {
+				t.Errorf("KindInstalled = %v, want %v", env.KindInstalled, tt.wantKind)
+			}
+		})
+	}
+}
+
+// `docker version` succeeds against a stopped daemon; `docker info` does not.
+// Probing with the wrong one reports a dead daemon as running.
+func TestProbeEnvironment_UsesDockerInfoNotVersion(t *testing.T) {
+	f := newFake().on("docker info", "Server Version: 27.0", nil)
+	ProbeEnvironment(f)
+	if !f.called("docker info") {
+		t.Errorf("must probe the daemon with `docker info`; calls: %v", f.calls)
+	}
+}
+
+// ── Resolve ────────────────────────────────────────────────────────────────
+
+func ctx(name string, reachable bool) Context {
+	return Context{Name: name, Reachable: reachable, Probed: true}
+}
+
+func TestResolve(t *testing.T) {
+	dockerReady := Environment{Docker: DockerRunning, KindInstalled: true}
+
+	tests := []struct {
+		name     string
+		contexts []Context
+		env      Environment
+		want     Outcome
+	}{
+		{
+			name:     "one reachable context proceeds without asking",
+			contexts: []Context{ctx("kind-panda", true)},
+			env:      dockerReady,
+			want:     UseContext,
+		},
+		{
+			name:     "several reachable contexts require a choice",
+			contexts: []Context{ctx("kind-panda", true), ctx("prod-eu", true)},
+			env:      dockerReady,
+			want:     ChooseContext,
+		},
+		{
+			// A reachable cluster always wins; never offer to build one over it.
+			name:     "one reachable among unreachable still proceeds",
+			contexts: []Context{ctx("stale", false), ctx("kind-panda", true)},
+			env:      dockerReady,
+			want:     UseContext,
+		},
+		{
+			name:     "no contexts at all, docker+kind ready",
+			contexts: nil,
+			env:      dockerReady,
+			want:     OfferKind,
+		},
+		{
+			// The stale-kubeconfig case the user's description does not cover.
+			name:     "contexts exist but none reachable, docker+kind ready",
+			contexts: []Context{ctx("stale", false), ctx("older", false)},
+			env:      dockerReady,
+			want:     OfferKind,
+		},
+		{
+			name:     "docker running but kind missing",
+			contexts: nil,
+			env:      Environment{Docker: DockerRunning, KindInstalled: false},
+			want:     NeedKind,
+		},
+		{
+			name:     "docker installed but stopped",
+			contexts: nil,
+			env:      Environment{Docker: DockerInstalledNotRunning, KindInstalled: true},
+			want:     NeedDockerRunning,
+		},
+		{
+			name:     "no docker at all",
+			contexts: nil,
+			env:      Environment{Docker: DockerNotInstalled},
+			want:     NeedDocker,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Resolve(tt.contexts, tt.env)
+			if got.Outcome != tt.want {
+				t.Errorf("Outcome = %v, want %v (reason: %s)", got.Outcome, tt.want, got.Reason())
+			}
+		})
+	}
+}
+
+// "3 contexts, none reachable" must not be reported as "no clusters found".
+func TestResolve_KeepsUnreachableForHonestMessaging(t *testing.T) {
+	d := Resolve([]Context{ctx("a", false), ctx("b", false)},
+		Environment{Docker: DockerRunning, KindInstalled: true})
+
+	if len(d.Unreachable) != 2 {
+		t.Fatalf("want 2 unreachable retained, got %d", len(d.Unreachable))
+	}
+	if !strings.Contains(d.Reason(), "none reachable") {
+		t.Errorf("reason should distinguish stale contexts from no contexts, got: %q", d.Reason())
+	}
+}
+
+// ── Kind bootstrap ─────────────────────────────────────────────────────────
+
+func TestCreateKind_UsesThreeZoneConfigAndUntaints(t *testing.T) {
+	f := newFake().
+		on("kind create cluster", "", nil).
+		on("kubectl wait", "", nil).
+		on("kubectl get nodes", "alpha sigma gamma", nil).
+		on("kubectl taint", "", nil)
+
+	if err := CreateKind(f, KindOptions{}); err != nil {
+		t.Fatalf("CreateKind: %v", err)
+	}
+
+	if !f.called("--config " + DefaultKindConfig) {
+		t.Errorf("must create from the 3-AZ config %s; calls: %v", DefaultKindConfig, f.calls)
+	}
+	if !f.called("--name " + DefaultKindClusterName) {
+		t.Errorf("must use cluster name %s; calls: %v", DefaultKindClusterName, f.calls)
+	}
+	if !f.called("kubectl wait --for=condition=Ready node --all") {
+		t.Errorf("must wait for node readiness; calls: %v", f.calls)
+	}
+	// Without the untaint, alpha (control-plane) cannot schedule Kafka and the
+	// cluster silently has 2 usable zones, not 3.
+	for _, node := range []string{"alpha", "sigma", "gamma"} {
+		if !f.called("kubectl taint nodes " + node) {
+			t.Errorf("must untaint %s so all three zones schedule; calls: %v", node, f.calls)
+		}
+	}
+}
+
+func TestCreateKind_PropagatesCreateFailure(t *testing.T) {
+	f := newFake().on("kind create cluster", "port 6443 already in use", errors.New("exit 1"))
+
+	err := CreateKind(f, KindOptions{})
+	if err == nil {
+		t.Fatal("want error when kind create fails")
+	}
+	// The underlying reason must survive; "failed to create cluster" alone is
+	// not actionable.
+	if !strings.Contains(err.Error(), "already in use") {
+		t.Errorf("error should carry kind's output, got: %v", err)
+	}
+}
+
+// Untainting a node that carries no taint exits non-zero. That is a success for
+// our purposes and must not fail the whole bootstrap.
+func TestCreateKind_TolerantOfAbsentTaint(t *testing.T) {
+	f := newFake().
+		on("kind create cluster", "", nil).
+		on("kubectl wait", "", nil).
+		on("kubectl get nodes", "alpha sigma gamma", nil).
+		on("kubectl taint", `taint "node-role.kubernetes.io/control-plane" not found`, errors.New("exit 1"))
+
+	if err := CreateKind(f, KindOptions{}); err != nil {
+		t.Fatalf("an absent taint is not a failure, got: %v", err)
+	}
+}
+
+func TestCreateKind_ReportsProgress(t *testing.T) {
+	f := newFake().
+		on("kind create cluster", "", nil).
+		on("kubectl wait", "", nil).
+		on("kubectl get nodes", "alpha", nil)
+
+	var steps []string
+	err := CreateKind(f, KindOptions{Progress: func(s string) { steps = append(steps, s) }})
+	if err != nil {
+		t.Fatalf("CreateKind: %v", err)
+	}
+	if len(steps) < 3 {
+		t.Errorf("want progress for create/wait/untaint, got %d: %v", len(steps), steps)
+	}
+	joined := strings.Join(steps, " | ")
+	for _, zone := range KindZones {
+		if !strings.Contains(joined, zone) {
+			t.Errorf("progress should name the zones it builds (%s missing): %s", zone, joined)
+		}
+	}
+}
+
+func TestKindClusterExists(t *testing.T) {
+	f := newFake().on("kind get clusters", "panda\nother\n", nil)
+	if !KindClusterExists(f, "panda") {
+		t.Error("panda should be reported as existing")
+	}
+	if KindClusterExists(f, "absent") {
+		t.Error("absent should not be reported as existing")
+	}
+}
+
+func TestEnvironment_CanCreateKind(t *testing.T) {
+	tests := []struct {
+		env  Environment
+		want bool
+	}{
+		{Environment{Docker: DockerRunning, KindInstalled: true}, true},
+		{Environment{Docker: DockerRunning, KindInstalled: false}, false},
+		{Environment{Docker: DockerInstalledNotRunning, KindInstalled: true}, false},
+		{Environment{Docker: DockerNotInstalled, KindInstalled: true}, false},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%v/kind=%v", tt.env.Docker, tt.env.KindInstalled), func(t *testing.T) {
+			if got := tt.env.CanCreateKind(); got != tt.want {
+				t.Errorf("CanCreateKind() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/pkg/cluster/decide.go
+++ b/cli/pkg/cluster/decide.go
@@ -1,0 +1,92 @@
+package cluster
+
+import "fmt"
+
+// Outcome is what the deploy path should do next. Resolve computes it from
+// detected state alone, with no I/O and no prompting, so the whole decision
+// tree is testable and the UI stays a thin renderer over it.
+type Outcome int
+
+const (
+	// UseContext: exactly one reachable context — proceed, no questions.
+	UseContext Outcome = iota
+	// ChooseContext: several reachable contexts — the user must pick.
+	ChooseContext
+	// OfferKind: nothing reachable, but Docker and kind are both ready.
+	OfferKind
+	// NeedKind: Docker runs but kind is missing — install kind, then retry.
+	NeedKind
+	// NeedDockerRunning: Docker is installed but the daemon is stopped.
+	NeedDockerRunning
+	// NeedDocker: no Docker at all.
+	NeedDocker
+)
+
+// Decision is Resolve's result.
+type Decision struct {
+	Outcome Outcome
+	// Candidates are the reachable contexts (for UseContext / ChooseContext).
+	Candidates []Context
+	// Unreachable are contexts that exist but did not answer. Kept so the UI can
+	// say "3 contexts found, none reachable" instead of the untrue "no clusters
+	// found" — a stale kubeconfig is the normal laptop case and deserves its own
+	// message.
+	Unreachable []Context
+}
+
+// Reason renders a short human explanation of why this outcome was chosen.
+func (d Decision) Reason() string {
+	switch d.Outcome {
+	case UseContext:
+		return fmt.Sprintf("using the only reachable cluster: %s", d.Candidates[0].Name)
+	case ChooseContext:
+		return fmt.Sprintf("%d reachable clusters found", len(d.Candidates))
+	case OfferKind:
+		if len(d.Unreachable) > 0 {
+			return fmt.Sprintf("%d context(s) configured but none reachable; Docker and kind are available", len(d.Unreachable))
+		}
+		return "no Kubernetes context configured; Docker and kind are available"
+	case NeedKind:
+		return "Docker is running but kind is not installed"
+	case NeedDockerRunning:
+		return "Docker is installed but the daemon is not running"
+	default:
+		return "no Docker and no reachable Kubernetes cluster"
+	}
+}
+
+// Resolve maps detected state onto an outcome.
+//
+// Ordering matters: a reachable cluster always wins over offering to build one.
+// We never propose creating a Kind cluster while a usable cluster exists.
+func Resolve(contexts []Context, env Environment) Decision {
+	reachable := Reachable(contexts)
+
+	var unreachable []Context
+	for _, c := range contexts {
+		if !c.Reachable {
+			unreachable = append(unreachable, c)
+		}
+	}
+
+	switch {
+	case len(reachable) == 1:
+		return Decision{Outcome: UseContext, Candidates: reachable, Unreachable: unreachable}
+	case len(reachable) > 1:
+		return Decision{Outcome: ChooseContext, Candidates: reachable, Unreachable: unreachable}
+	}
+
+	// Nothing reachable — can we build one?
+	d := Decision{Unreachable: unreachable}
+	switch {
+	case env.Docker == DockerNotInstalled:
+		d.Outcome = NeedDocker
+	case env.Docker == DockerInstalledNotRunning:
+		d.Outcome = NeedDockerRunning
+	case !env.KindInstalled:
+		d.Outcome = NeedKind
+	default:
+		d.Outcome = OfferKind
+	}
+	return d
+}

--- a/cli/pkg/cluster/kind.go
+++ b/cli/pkg/cluster/kind.go
@@ -1,0 +1,107 @@
+package cluster
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bmscomp/kates/cli/pkg/detect"
+)
+
+// DefaultKindClusterName matches the Makefile's CLUSTER_NAME.
+const DefaultKindClusterName = "panda"
+
+// DefaultKindConfig is the 3-availability-zone topology: alpha (control-plane),
+// sigma and gamma (workers), each labelled topology.kubernetes.io/zone.
+const DefaultKindConfig = "config/cluster.yaml"
+
+// KindZones are the zones DefaultKindConfig creates. Exported so the UI can
+// state what it is about to build without re-parsing the YAML.
+var KindZones = []string{"alpha", "sigma", "gamma"}
+
+// KindOptions configures CreateKind.
+type KindOptions struct {
+	Name       string
+	ConfigPath string
+	// Progress, if set, is called with human-readable step descriptions.
+	Progress func(string)
+}
+
+func (o *KindOptions) withDefaults() {
+	if o.Name == "" {
+		o.Name = DefaultKindClusterName
+	}
+	if o.ConfigPath == "" {
+		o.ConfigPath = DefaultKindConfig
+	}
+	if o.Progress == nil {
+		o.Progress = func(string) {}
+	}
+}
+
+// KindClusterExists reports whether a Kind cluster of this name is already
+// present, so we offer to create rather than clobber.
+func KindClusterExists(exec detect.CommandExecutor, name string) bool {
+	out, err := exec.Exec("kind", "get", "clusters")
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.TrimSpace(line) == name {
+			return true
+		}
+	}
+	return false
+}
+
+// CreateKind creates the 3-AZ Kind cluster and makes it actually usable.
+//
+// Creating the cluster is not sufficient on its own: Kind taints the
+// control-plane node NoSchedule, and in this topology that node IS one of the
+// three zones (alpha). Left tainted, nothing schedules there and the cluster
+// silently has two usable zones instead of three — which fails the 3-AZ
+// requirement every Kafka pool in this repo is built on. So the untaint is part
+// of creation, not an optional extra.
+//
+// Zone StorageClasses are deliberately NOT applied here: the deploy path
+// already bootstraps them immediately after preflight (see setupKindStorageClasses).
+func CreateKind(exec detect.CommandExecutor, opts KindOptions) error {
+	opts.withDefaults()
+
+	opts.Progress(fmt.Sprintf("Creating Kind cluster %q with zones %s", opts.Name, strings.Join(KindZones, ", ")))
+	if out, err := exec.Exec("kind", "create", "cluster",
+		"--config", opts.ConfigPath,
+		"--name", opts.Name); err != nil {
+		return fmt.Errorf("kind create cluster: %w: %s", err, strings.TrimSpace(out))
+	}
+
+	opts.Progress("Waiting for all nodes to become Ready")
+	if out, err := exec.Exec("kubectl", "wait", "--for=condition=Ready",
+		"node", "--all", "--timeout=180s"); err != nil {
+		return fmt.Errorf("nodes did not become ready: %w: %s", err, strings.TrimSpace(out))
+	}
+
+	opts.Progress("Untainting control-plane so all three zones can schedule")
+	if err := untaintAllNodes(exec); err != nil {
+		return err
+	}
+
+	opts.Progress(fmt.Sprintf("Kind cluster %q is ready", opts.Name))
+	return nil
+}
+
+// untaintAllNodes removes the control-plane NoSchedule taint from every node.
+//
+// Removing a taint that is not present exits non-zero ("taint not found"), which
+// is a success for our purposes — we only care that no node is left tainted. So
+// per-node errors are tolerated and only a failure to enumerate nodes is fatal.
+func untaintAllNodes(exec detect.CommandExecutor) error {
+	out, err := exec.Exec("kubectl", "get", "nodes", "-o", "jsonpath={.items[*].metadata.name}")
+	if err != nil {
+		return fmt.Errorf("listing nodes to untaint: %w", err)
+	}
+	for _, node := range strings.Fields(out) {
+		_, _ = exec.Exec("kubectl", "taint", "nodes", node,
+			"node-role.kubernetes.io/control-plane:NoSchedule-")
+	}
+	return nil
+}

--- a/cli/pkg/cluster/kind.go
+++ b/cli/pkg/cluster/kind.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/bmscomp/kates/cli/pkg/detect"
@@ -36,6 +37,19 @@ func (o *KindOptions) withDefaults() {
 	if o.Progress == nil {
 		o.Progress = func(string) {}
 	}
+}
+
+// ConfigExists reports whether the topology config is readable from here.
+//
+// DefaultKindConfig is repo-relative, so an installed binary run from anywhere
+// but the repo root cannot see it. Checking up front turns a confusing failure
+// deep inside `kind create` into an explanation the caller can act on.
+func ConfigExists(path string) bool {
+	if path == "" {
+		path = DefaultKindConfig
+	}
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
 }
 
 // KindClusterExists reports whether a Kind cluster of this name is already

--- a/docs/book/10-cli-reference.md
+++ b/docs/book/10-cli-reference.md
@@ -988,7 +988,47 @@ Deploy the Kates stack (Kafka, Kates, Chaos, Schema Registry).
 ```bash
 kates deploy
 kates deploy -i
+kates deploy --yes
 ```
+
+| Flag | Description |
+|---|---|
+| `--interactive`, `-i` | Force the configuration wizard. It also opens for a bare `kates deploy` with no flags, when attached to a terminal |
+| `--yes`, `-y` | Never prompt — fail instead of asking. Use in scripts and pipelines |
+| `--dry-run` | Print the deployment plan and stop before the Helm pipeline runs |
+| `--topology` | `isolated` (a namespace per component) or `single` (default: `isolated`) |
+| `--namespace` | Target namespace when `--topology single` (default: `kates-stack`) |
+| `--ha` | Multi-AZ high availability: replicas 3, `min.insync.replicas` 2, zone spread (default: `true`) |
+| `--port-forward`, `-P` | After deploying, hold the terminal forwarding every service until Ctrl+C |
+| `--with-schema-registry` | `none`, `apicurio`, or `confluent` (default: `apicurio`) |
+| `--with-*` | Per-component toggles — `kates deploy --help` lists them, along with the per-component `*-ns` flags |
+
+::: {.callout-warning}
+`--dry-run` is not inert. It stops before the Helm pipeline, but the cluster gate, pre-flight introspection, and Kind StorageClass bootstrap all run first — the last of these writes StorageClasses into the cluster. It will not create a Kind cluster, but it is a plan preview, not a read-only mode.
+:::
+
+`deploy` works out which cluster it is deploying to before it asks you anything else — there is no point configuring a deployment that has nowhere to go. What happens next depends on what it finds:
+
+| What it finds | What it does |
+|---|---|
+| One reachable cluster | Uses it, without asking |
+| Several reachable clusters | Asks you to pick one |
+| No reachable cluster, Docker and kind available | Offers to create a local three-zone kind cluster |
+| No reachable cluster, kind missing | Explains how to install kind |
+| No reachable cluster, Docker stopped | Asks you to start Docker |
+| No Docker at all | Explains both ways forward |
+
+When nothing is reachable, any contexts you do have configured are listed by name rather than treated as absent — a kubeconfig that has gone stale looks nothing like a machine with no cluster, and the difference decides what you do about it.
+
+The kind offer has three further conditions. It is skipped under `--dry-run`, and it stops rather than proceeding when a kind cluster of that name already exists but does not answer (recreating would destroy it) or when the topology config cannot be read from the current directory. Each case prints the command that resolves it.
+
+::: {.callout-note}
+`--yes` never guesses. When several clusters are reachable and nothing can be asked, `deploy` fails and tells you to choose with `kubectl config use-context` rather than picking one for you. Selecting a cluster silently is how a deployment lands somewhere it was never meant to go.
+:::
+
+The same applies without a terminal. Piped or scripted runs take the flag defaults instead of opening the wizard, and any state that needs an answer becomes an error carrying the command that resolves it.
+
+**See also:** [Installing Kafka with the kafka-cluster Helm Chart](20-installation-guide.md) for first-time setup, and [Deployment Guide](12-deployment.md) for what the stack looks like once it is up.
 
 #### deploy status
 

--- a/docs/book/12-deployment.md
+++ b/docs/book/12-deployment.md
@@ -338,8 +338,13 @@ make cluster
 Creates a Kind cluster named `panda` with:
 - 1 control-plane node (alpha)
 - 2 worker nodes (sigma, gamma)
-- Zone labels for rack awareness
-- Local-path storage provisioner per zone
+- Zone labels for rack awareness, and a `node.kubernetes.io/local-storage` label per node
+
+The per-zone StorageClasses the Kafka chart binds to (`local-storage-alpha` and friends) are not created here — `kates deploy` applies them during pre-flight, from the zone labels above. A cluster built this way has the labels but not the classes until you deploy.
+
+You do not have to run this first. `kates deploy` resolves the target cluster before it configures anything: with one reachable cluster it proceeds, with several it asks which, and with none it offers to build this same three-zone cluster for you. Reach for `make cluster` when you want the cluster on its own, or when you are behind a proxy — it reconciles the container runtime's proxy settings and CA trust, which `kates deploy` does not.
+
+Both paths build from `config/cluster.yaml` and untaint the control-plane afterwards, so the topology is identical either way: three schedulable zones, not two. One difference worth knowing — `make cluster` resolves the config relative to itself and works from anywhere, while `kates deploy` looks for `config/cluster.yaml` relative to the working directory, so its offer only stands from the repo root. It says so rather than failing inside `kind`.
 
 ### Image Management
 


### PR DESCRIPTION
## Why

`kates deploy` assumed a cluster existed. When none did, `deploy.go` did this:

```go
if dockerCheck := exec.Command("docker", "info"); dockerCheck.Run() == nil {
    fmt.Print("🐳 Docker is running. Would you like to ... [y/N]: ")
    fmt.Scanln(&response)
    ...exec.Command("make", "cluster")
```

Raw `exec.Command` (unmockable), `fmt.Scanln` (hangs with no terminal), shells out to Make, and — the real gap — **never asks which cluster you meant**. It just used whatever kubeconfig happened to point at.

This replaces that block with a cluster gate that runs before anything assumes a cluster.

## The flow

| State | Behaviour |
|---|---|
| One reachable cluster | Proceeds silently — the common case asks nothing |
| Several reachable | Picker, starting on the current context |
| None reachable, Docker + kind ready | Asks, then builds the local 3-zone kind cluster |
| Docker running, kind missing | How to install kind |
| Docker installed, daemon stopped | Start Docker |
| No Docker | Install Docker, or point at a cluster |

Docker-missing, Docker-stopped, and kind-missing are **three different problems needing three different actions**, so they get three different messages rather than one useless "Docker is unavailable".

## Two states the old code got wrong

**Contexts configured but none reachable is not "no clusters found."** A stale kubeconfig is the normal laptop state. The flow names the dead contexts instead of pretending they don't exist.

**An existing-but-unreachable kind cluster is broken, not absent.** Recreating would silently destroy it, so we stop and hand back the commands to inspect or remove it.

## Non-interactivity is the load-bearing property

`kates deploy` is called directly by `deploy_test.go` and may run piped or in CI, where a prompt or a bubbletea program **hangs forever instead of failing**. Everything interactive sits behind `isInteractive()`: `isTesting`, the new `--yes`, and a real TTY check via `x/term` (already a direct dependency — no new deps).

**Ambiguity without a terminal fails rather than guessing.** Silently picking a context is how you deploy to prod by accident.

Verified against the built binary, not just unit tests:

```
KUBECONFIG=/dev/null kates deploy --yes < /dev/null
  → rc=1 in under a second:
    no reachable Kubernetes cluster.
      Re-run in a terminal to be prompted, or create it directly:
        kind create cluster --config config/cluster.yaml --name panda
```

## A pre-existing bug fixed on the way

The interactive forms open `/dev/tty` directly, so `kates deploy` with no flags and no terminal died with `huh: could not open a new TTY` instead of falling back to flag defaults. Now behind the same guard. My own test caught this — the existing tests only dodged it by always setting a flag.

## Testing — 30 tests, no cluster, no Docker, no TTY

Logic lives in `cli/pkg/cluster` behind `detect.CommandExecutor`; the gate's externals sit behind function seams matching the existing `runExecFn`/`runHelmFn` style. `Resolve()` is pure — state in, outcome out — so every branch is a table row.

Two bugs the tests caught in my own code, worth calling out:

- `KindClusterExists` was called directly rather than through a seam, so the test shelled out to real `kind` and found the developer's actual `panda` cluster. The test depended on machine state.
- `TestRunDeploy_AbortsWhenClusterGateFails` exists specifically so `deploy_test.go`'s stub can't mask broken wiring — it asserts helm is never reached when there's no cluster.

The 3-AZ bootstrap replicates `config/cluster.yaml` (alpha/sigma/gamma) and **untaints the control-plane**. Without that, `alpha` stays `NoSchedule` and Kafka silently gets two usable zones instead of three — a test asserts it.

## Reviewer notes

- **Naming**: this deliberately does not touch `kates ctx`, which manages Kates *server connections* (URLs/API keys), not kubeconfig contexts. Different concept, easily confused.
- **`scripts/start-cluster.sh` is untouched.** It does more than create the cluster (registry, image loading, proxy reconciliation) and remains the full-featured path. This gate covers the "I just want a cluster to deploy to" case.
- Zone StorageClasses are not applied by the bootstrap — the deploy path already does that immediately after preflight via `setupKindStorageClasses`.