### PR TITLE
feat(cli): terminal-compat foundations — glyph table, one width, no raw escapes (UX plan wave 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,13 @@ jobs:
       - name: Run Go tests
         working-directory: cli
         run: go test -p 1 ./... -v -race -count=1
+
+      # Runs the REAL binary under the conditions scripts and CI use it in:
+      # piped stdout, NO_COLOR, TERM=dumb, --plain, KATES_ASCII, unset locale,
+      # and TUI commands with no TTY. This is what catches "escape codes in
+      # CI logs" class regressions — unit tests never see the raw bytes.
+      - name: CLI terminal-compatibility checks
+        run: bash scripts/check-cli-compat.sh
         env:
           GOMEMLIMIT: 2GiB
           GOGC: 50

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,11 @@ all: check-prerequisites
 check-versions: ## Verify the Strimzi version pins agree
 	@./scripts/check-versions.sh
 
+# Terminal-compatibility gate: runs the real binary piped, with NO_COLOR,
+# TERM=dumb, --plain, KATES_ASCII, and no TTY. Also run in CI (CLI Tests job).
+check-cli-compat: ## Verify CLI output degrades correctly across terminals
+	@./scripts/check-cli-compat.sh
+
 # Check prerequisites — only kubectl and helm are strictly required for generic clusters
 check-prerequisites:
 	@echo "🔍 Checking prerequisites..."

--- a/cli/cmd/clean.go
+++ b/cli/cmd/clean.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/bmscomp/kates/cli/output"
 	"os"
 	"os/exec"
 	"strings"
@@ -74,7 +75,7 @@ var (
 
 func cleanRunDefault(ctx context.Context, name string, args ...string) error {
 	if cleanVerbose {
-		fmt.Printf("    \033[2m$ %s %s\033[0m\n", name, strings.Join(args, " "))
+		fmt.Printf("    %s\n", output.DimStyle.Render("$ "+name+" "+strings.Join(args, " ")))
 	}
 	cmd := exec.CommandContext(ctx, name, args...)
 	if cleanVerbose {
@@ -86,7 +87,7 @@ func cleanRunDefault(ctx context.Context, name string, args ...string) error {
 
 func cleanRunOutputDefault(ctx context.Context, name string, args ...string) ([]byte, error) {
 	if cleanVerbose {
-		fmt.Printf("    \033[2m$ %s %s\033[0m\n", name, strings.Join(args, " "))
+		fmt.Printf("    %s\n", output.DimStyle.Render("$ "+name+" "+strings.Join(args, " ")))
 	}
 	cmd := exec.CommandContext(ctx, name, args...)
 	out, err := cmd.CombinedOutput()

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -332,7 +332,7 @@ func runExecDefault(ctx context.Context, name string, args ...string) error {
 
 	if deployVerbose {
 		// Show the command being run
-		dl.Printf("    \033[2m$ %s %s\033[0m\n", name, strings.Join(args, " "))
+		dl.Printf("    %s\n", output.DimStyle.Render("$ "+name+" "+strings.Join(args, " ")))
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		return cmd.Run()
@@ -349,7 +349,7 @@ func runExecDefault(ctx context.Context, name string, args ...string) error {
 			errMsg = strings.TrimSpace(outBuf.String())
 		}
 		if errMsg != "" {
-			dl.Printf("    \033[31m%s\033[0m\n", errMsg)
+			dl.Printf("    %s\n", output.ErrorStyle.Render(errMsg))
 			return fmt.Errorf("%w: %s", err, errMsg)
 		}
 		return err
@@ -374,7 +374,7 @@ func runExecStdinDefault(ctx context.Context, name string, args []string, stdinD
 	defer execMutex.Unlock()
 
 	if deployVerbose {
-		dl.Printf("    \033[2m$ %s %s\033[0m\n", name, strings.Join(args, " "))
+		dl.Printf("    %s\n", output.DimStyle.Render("$ "+name+" "+strings.Join(args, " ")))
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		return cmd.Run()
@@ -389,7 +389,7 @@ func runExecStdinDefault(ctx context.Context, name string, args []string, stdinD
 			errMsg = strings.TrimSpace(outBuf.String())
 		}
 		if errMsg != "" {
-			dl.Printf("    \033[31m%s\033[0m\n", errMsg)
+			dl.Printf("    %s\n", output.ErrorStyle.Render(errMsg))
 			return fmt.Errorf("%w: %s", runErr, errMsg)
 		}
 		return runErr

--- a/cli/cmd/deploy_view.go
+++ b/cli/cmd/deploy_view.go
@@ -8,9 +8,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bmscomp/kates/cli/output"
+	"github.com/bmscomp/kates/cli/pkg/theme"
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/bmscomp/kates/cli/pkg/theme"
 	"github.com/mattn/go-runewidth"
 	"golang.org/x/term"
 )
@@ -65,12 +66,11 @@ func RenderDeployDashboard(ctx context.Context, entries []DeploySummaryEntry, el
 	}
 
 	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(clrCyan)
-	termW := 72
-	if w, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && w > 0 {
-		termW = w - 4
-		if termW > 80 {
-			termW = 80
-		}
+	// Width comes from the one shared helper; the -4 margin and 80 cap are
+	// this view's layout choices, not a third opinion on terminal size.
+	termW := output.TermWidth() - 4
+	if termW > 80 {
+		termW = 80
 	}
 	sepLine := lipgloss.NewStyle().Foreground(clrDim).Render(strings.Repeat("─", termW))
 

--- a/cli/cmd/helpers.go
+++ b/cli/cmd/helpers.go
@@ -2,11 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/bmscomp/kates/cli/output"
-	"golang.org/x/term"
 )
 
 var componentGroupNames = map[string]string{
@@ -118,12 +116,12 @@ func padLeftN(s string, n int) string {
 	return strings.Repeat(" ", n-len(s)) + s
 }
 
+// termWidth delegates to the single shared width helper. Three copies of this
+// existed with three different fallbacks (120, 80, and 72-capped-80), so the
+// same terminal state produced three different layouts depending on which
+// command you ran.
 func termWidth() int {
-	w, _, err := term.GetSize(int(os.Stdout.Fd()))
-	if err != nil || w == 0 {
-		return 80
-	}
-	return w
+	return output.TermWidth()
 }
 
 func describeType(t string) string {

--- a/cli/output/glyphs.go
+++ b/cli/output/glyphs.go
@@ -1,0 +1,102 @@
+package output
+
+import (
+	"os"
+	"strings"
+)
+
+// GlyphSet is the CLI's glyph vocabulary. Every status mark, arrow, and bar
+// segment renders through one of these two sets — never as a scattered
+// literal — so the ASCII fallback is complete by construction.
+type GlyphSet struct {
+	Check  string
+	Cross  string
+	Warn   string
+	Arrow  string
+	Bullet string
+	// Status ring variants: running, degraded, off.
+	DotOn   string
+	Diamond string
+	Ring    string
+	// Bar segments for progress bars.
+	BarFull  string
+	BarEmpty string
+	// Rules: thin table/section separators and the heavy header bar.
+	Rule      string
+	HeavyRule string
+	// Spark holds the sparkline ramp from lowest to highest.
+	Spark []rune
+}
+
+var utf8Glyphs = GlyphSet{
+	Check:     "✓",
+	Cross:     "✖",
+	Warn:      "⚠",
+	Arrow:     "▸",
+	Bullet:    "●",
+	DotOn:     "◉",
+	Diamond:   "◈",
+	Ring:      "○",
+	BarFull:   "█",
+	BarEmpty:  "░",
+	Rule:      "─",
+	HeavyRule: "━",
+	Spark:     []rune{'▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'},
+}
+
+var asciiGlyphs = GlyphSet{
+	Check:     "+",
+	Cross:     "x",
+	Warn:      "!",
+	Arrow:     ">",
+	Bullet:    "*",
+	DotOn:     "*",
+	Diamond:   "!",
+	Ring:      "o",
+	BarFull:   "#",
+	BarEmpty:  "-",
+	Rule:      "-",
+	HeavyRule: "=",
+	Spark:     []rune{'.', ':', '-', '=', '+', '*', '#', '@'},
+}
+
+// asciiForced is the environment's standing request for ASCII, computed once.
+// plainMode is consulted live in Glyphs() because SetPlain runs after init.
+var asciiForced = detectASCIIEnv(os.Getenv)
+
+// detectASCIIEnv decides whether the environment positively asks for ASCII.
+//
+// The polarity matters: UTF-8 is the default, and ASCII engages only on
+// explicit evidence — KATES_ASCII, or a locale EXPLICITLY set to a non-UTF-8
+// value. An unset locale is NOT evidence of a limited terminal: containers,
+// CI, and Windows commonly run with no locale set and render UTF-8 fine.
+// Treating "unset" as "limited" would strip glyphs exactly where most output
+// is read.
+func detectASCIIEnv(getenv func(string) string) bool {
+	if v := getenv("KATES_ASCII"); v == "1" || strings.EqualFold(v, "true") {
+		return true
+	}
+	// First set locale variable wins, mirroring libc precedence.
+	for _, key := range []string{"LC_ALL", "LC_CTYPE", "LANG"} {
+		v := getenv(key)
+		if v == "" {
+			continue
+		}
+		lower := strings.ToLower(v)
+		if strings.Contains(lower, "utf-8") || strings.Contains(lower, "utf8") {
+			return false
+		}
+		// "C" and "POSIX" are explicit ASCII declarations.
+		return true
+	}
+	return false
+}
+
+// Glyphs returns the active glyph set. --plain implies ASCII: plain output is
+// a statement that a machine (or the most limited terminal) is reading.
+func Glyphs() GlyphSet {
+	if plainMode || asciiForced {
+		return asciiGlyphs
+	}
+	return utf8Glyphs
+}

--- a/cli/output/glyphs_test.go
+++ b/cli/output/glyphs_test.go
@@ -1,0 +1,74 @@
+package output
+
+import "testing"
+
+func env(m map[string]string) func(string) string {
+	return func(k string) string { return m[k] }
+}
+
+func TestDetectASCIIEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		vars map[string]string
+		want bool
+	}{
+		// The polarity rule: ASCII only on POSITIVE evidence. An unset locale
+		// is how containers, CI, and Windows normally run — and they render
+		// UTF-8 fine. Treating "unset" as "limited" would strip glyphs exactly
+		// where most output is read.
+		{"no env at all stays UTF-8", map[string]string{}, false},
+		{"utf-8 locale stays UTF-8", map[string]string{"LANG": "en_US.UTF-8"}, false},
+		{"lowercase utf8 spelling stays UTF-8", map[string]string{"LC_ALL": "C.utf8"}, false},
+
+		// Explicit requests engage ASCII.
+		{"KATES_ASCII=1", map[string]string{"KATES_ASCII": "1"}, true},
+		{"KATES_ASCII=true", map[string]string{"KATES_ASCII": "true"}, true},
+		{"C locale is an explicit ASCII declaration", map[string]string{"LANG": "C"}, true},
+		{"POSIX locale", map[string]string{"LC_ALL": "POSIX"}, true},
+		{"latin1 locale", map[string]string{"LANG": "en_US.ISO-8859-1"}, true},
+
+		// libc precedence: LC_ALL wins over LANG.
+		{"LC_ALL=utf8 beats LANG=C", map[string]string{"LC_ALL": "C.UTF-8", "LANG": "C"}, false},
+		{"LC_ALL=C beats LANG=utf8", map[string]string{"LC_ALL": "C", "LANG": "en_US.UTF-8"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectASCIIEnv(env(tt.vars)); got != tt.want {
+				t.Errorf("detectASCIIEnv(%v) = %v, want %v", tt.vars, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGlyphs_PlainModeForcesASCII(t *testing.T) {
+	origPlain, origForced := plainMode, asciiForced
+	t.Cleanup(func() { plainMode, asciiForced = origPlain, origForced })
+
+	plainMode, asciiForced = false, false
+	if Glyphs().Check != "✓" {
+		t.Errorf("default must be UTF-8, got check=%q", Glyphs().Check)
+	}
+
+	plainMode = true
+	if Glyphs().Check != "+" {
+		t.Errorf("--plain must force ASCII, got check=%q", Glyphs().Check)
+	}
+}
+
+// Every ASCII glyph must actually be ASCII — the fallback existing is not the
+// same as the fallback being complete.
+func TestASCIIGlyphsAreASCII(t *testing.T) {
+	g := asciiGlyphs
+	for name, s := range map[string]string{
+		"Check": g.Check, "Cross": g.Cross, "Warn": g.Warn, "Arrow": g.Arrow,
+		"Bullet": g.Bullet, "DotOn": g.DotOn, "Diamond": g.Diamond, "Ring": g.Ring,
+		"BarFull": g.BarFull, "BarEmpty": g.BarEmpty, "Spark": string(g.Spark),
+	} {
+		for _, r := range s {
+			if r > 127 {
+				t.Errorf("asciiGlyphs.%s contains non-ASCII rune %q", name, r)
+			}
+		}
+	}
+}

--- a/cli/output/output.go
+++ b/cli/output/output.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/bmscomp/kates/cli/pkg/theme"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/mattn/go-runewidth"
 	"github.com/muesli/termenv"
 	"golang.org/x/term"
@@ -130,22 +130,22 @@ func StatusBadge(status string) string {
 	upper := strings.ToUpper(status)
 	switch upper {
 	case "UP", "DONE", "PASS", "COMPLETED", "ENABLED":
-		return SuccessStyle.Bold(true).Render("● " + upper)
+		return SuccessStyle.Bold(true).Render(Glyphs().Bullet + " " + upper)
 	case "RUNNING", "PENDING":
-		return AccentStyle.Bold(true).Render("◉ " + upper)
+		return AccentStyle.Bold(true).Render(Glyphs().DotOn + " " + upper)
 	case "DEGRADED", "STOPPING":
-		return WarningStyle.Bold(true).Render("◈ " + upper)
+		return WarningStyle.Bold(true).Render(Glyphs().Diamond + " " + upper)
 	case "DOWN", "FAILED", "ERROR", "FAIL":
-		return ErrorStyle.Render("✖ " + upper)
+		return ErrorStyle.Render(Glyphs().Cross + " " + upper)
 	case "DISABLED":
-		return DimStyle.Render("○ " + upper)
+		return DimStyle.Render(Glyphs().Ring + " " + upper)
 	default:
-		return DimStyle.Render("○ " + status)
+		return DimStyle.Render(Glyphs().Ring + " " + status)
 	}
 }
 
 func Header(text string) {
-	bar := lipgloss.NewStyle().Foreground(Purple).Render("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	bar := lipgloss.NewStyle().Foreground(Purple).Render(strings.Repeat(Glyphs().HeavyRule, 42))
 	title := lipgloss.NewStyle().Bold(true).Foreground(HeaderColor).Render("  " + text)
 	fmt.Fprintln(Out)
 	fmt.Fprintln(Out, bar)
@@ -155,7 +155,7 @@ func Header(text string) {
 
 func SubHeader(text string) {
 	fmt.Fprintln(Out)
-	fmt.Fprintln(Out, SubHeaderStyle.Render("▸ "+text))
+	fmt.Fprintln(Out, SubHeaderStyle.Render(Glyphs().Arrow+" "+text))
 }
 
 func KeyValue(key, value string) {
@@ -168,15 +168,15 @@ func KeyValueIndent(key, value string, indent int) {
 }
 
 func Success(msg string) {
-	fmt.Fprintln(Out, SuccessStyle.Render("  ✓ "+msg))
+	fmt.Fprintln(Out, SuccessStyle.Render("  "+Glyphs().Check+" "+msg))
 }
 
 func Warn(msg string) {
-	fmt.Fprintln(Out, WarningStyle.Render("  ⚠ "+msg))
+	fmt.Fprintln(Out, WarningStyle.Render("  "+Glyphs().Warn+" "+msg))
 }
 
 func Error(msg string) {
-	fmt.Fprintln(Err, ErrorStyle.Render("  ✖ "+msg))
+	fmt.Fprintln(Err, ErrorStyle.Render("  "+Glyphs().Cross+" "+msg))
 }
 
 func Hint(msg string) {
@@ -231,7 +231,7 @@ func Table(headers []string, rows [][]string) {
 		headerLine += "  " + headerFg.Render(PadRight(h, widths[i]))
 	}
 	for i := range headers {
-		sepLine += "  " + sepFg.Render(strings.Repeat("─", widths[i]))
+		sepLine += "  " + sepFg.Render(strings.Repeat(Glyphs().Rule, widths[i]))
 	}
 
 	fmt.Fprintln(Out, headerLine)
@@ -306,7 +306,7 @@ func MetricBar(label string, value, max float64) {
 		filled = 0
 	}
 
-	bar := strings.Repeat("█", filled) + strings.Repeat("░", barWidth-filled)
+	bar := strings.Repeat(Glyphs().BarFull, filled) + strings.Repeat(Glyphs().BarEmpty, barWidth-filled)
 
 	barColor := Green
 	ratio := value / max
@@ -324,7 +324,7 @@ func Sparkline(values []float64) string {
 	if len(values) == 0 {
 		return ""
 	}
-	blocks := []rune{'▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'}
+	blocks := Glyphs().Spark
 	min, max := values[0], values[0]
 	for _, v := range values {
 		if v < min {
@@ -356,7 +356,7 @@ func SparklineColored(values []float64, higherIsBetter bool) string {
 	if len(values) == 0 {
 		return ""
 	}
-	blocks := []rune{'▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'}
+	blocks := Glyphs().Spark
 	min, max := values[0], values[0]
 	for _, v := range values {
 		if v < min {
@@ -431,9 +431,9 @@ func ConfigList(title string, entries []ConfigEntry) {
 		}
 	}
 
-	titleStyled := lipgloss.NewStyle().Bold(true).Foreground(Indigo).Render("▸ " + title)
+	titleStyled := lipgloss.NewStyle().Bold(true).Foreground(Indigo).Render(Glyphs().Arrow + " " + title)
 	countStyled := lipgloss.NewStyle().Foreground(Gray).Render(fmt.Sprintf("  (%d)", len(entries)))
-	sep := lipgloss.NewStyle().Foreground(SeparatorColor).Render(strings.Repeat("─", 50))
+	sep := lipgloss.NewStyle().Foreground(SeparatorColor).Render(strings.Repeat(Glyphs().Rule, 50))
 
 	fmt.Fprintln(Out)
 	fmt.Fprintln(Out, titleStyled+countStyled)

--- a/cli/tui/lab.go
+++ b/cli/tui/lab.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"time"
 
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/bmscomp/kates/cli/client"
 	"github.com/bmscomp/kates/cli/pkg/theme"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 type labParam struct {
@@ -471,6 +471,12 @@ func (m LabModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m LabModel) View() string {
 	if m.quitting {
 		return ""
+	}
+
+	// Below the supported floor, render the shared card instead of a layout
+	// that clips into garbage.
+	if TooSmall(m.width, m.height) {
+		return TooSmallCard(m.width, m.height)
 	}
 
 	w := m.width

--- a/cli/tui/toosmall.go
+++ b/cli/tui/toosmall.go
@@ -1,0 +1,71 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+)
+
+// MinTUIWidth/MinTUIHeight are the floor every kates full-screen TUI supports.
+// 80x24 is the classic terminal default and the smallest size the layouts are
+// designed against.
+const (
+	MinTUIWidth  = 80
+	MinTUIHeight = 24
+)
+
+// TooSmallCard is the one shared "terminal too small" screen. Every full-screen
+// TUI renders this instead of its normal View when the window is below minimum,
+// rather than each view clipping, wrapping, or panicking in its own way.
+func TooSmallCard(width, height int) string {
+	msg := fmt.Sprintf("Terminal too small: %dx%d (need at least %dx%d)",
+		width, height, MinTUIWidth, MinTUIHeight)
+	hint := "Enlarge the window, or press q to quit."
+
+	var b strings.Builder
+	// Vertical centering within whatever height we do have.
+	pad := (height - 4) / 2
+	if pad < 0 {
+		pad = 0
+	}
+	b.WriteString(strings.Repeat("\n", pad))
+	b.WriteString(centerLine(msg, width) + "\n\n")
+	b.WriteString(centerLine(dimStyle.Render(hint), width) + "\n")
+	return b.String()
+}
+
+// TooSmall reports whether a window is below the supported floor.
+func TooSmall(width, height int) bool {
+	// Zero means "no WindowSizeMsg yet" — do not flash the card during the
+	// first frame before the real size arrives.
+	if width == 0 || height == 0 {
+		return false
+	}
+	return width < MinTUIWidth || height < MinTUIHeight
+}
+
+func centerLine(s string, width int) string {
+	pad := (width - len(stripAnsiPlain(s))) / 2
+	if pad < 0 {
+		pad = 0
+	}
+	return strings.Repeat(" ", pad) + s
+}
+
+// stripAnsiPlain removes SGR sequences for width measurement.
+func stripAnsiPlain(s string) string {
+	var b strings.Builder
+	inEsc := false
+	for _, r := range s {
+		switch {
+		case inEsc:
+			if r == 'm' {
+				inEsc = false
+			}
+		case r == '\x1b':
+			inEsc = true
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/cli/tui/tui.go
+++ b/cli/tui/tui.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bmscomp/kates/cli/client"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/bmscomp/kates/cli/client"
 )
 
 type tab int
@@ -201,6 +201,10 @@ func (m Model) handleFilter(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m Model) View() string {
 	if m.quitting {
 		return ""
+	}
+
+	if TooSmall(m.width, m.height) {
+		return TooSmallCard(m.width, m.height)
 	}
 
 	tabBar := m.renderTabs()

--- a/scripts/check-cli-compat.sh
+++ b/scripts/check-cli-compat.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Terminal-compatibility gate for the kates CLI.
+#
+# WHY THIS EXISTS: the CLI once forced TrueColor on every run, writing raw
+# 38;2 escape sequences into pipes and CI logs and silently ignoring NO_COLOR.
+# Nothing caught it, because nothing asserted on the raw bytes the binary
+# emits. This script is that assertion. Every check here runs the REAL binary
+# under the exact conditions CI and scripts use it in.
+#
+# Usage:
+#   scripts/check-cli-compat.sh          Build the CLI and run every check.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+BIN="$(mktemp -d)/kates"
+trap 'rm -rf "$(dirname "$BIN")"' EXIT
+
+echo "Building CLI..."
+(cd cli && go build -o "$BIN" .)
+
+fail=0
+
+# has_escapes FILE — true when the file contains any ESC byte.
+has_escapes() { LC_ALL=C grep -q $'\x1b' "$1"; }
+# has_nonascii FILE — true when the file contains bytes outside printable ASCII
+# plus whitespace.
+has_nonascii() { LC_ALL=C grep -q '[^ -~\t\r]' "$1"; }
+
+check() {
+  local name="$1"; shift
+  if "$@"; then
+    echo "  ok   $name"
+  else
+    echo "  FAIL $name"
+    fail=1
+  fi
+}
+
+out="$(mktemp)"
+
+# ── Piped output carries no escape codes ────────────────────────────────────
+# stdout is a pipe here, exactly like `kates ... | tee` or a CI log.
+"$BIN" version > "$out" 2>&1
+check "piped 'version' is escape-free" bash -c "! LC_ALL=C grep -q \$'\x1b' '$out'"
+
+"$BIN" --help > "$out" 2>&1
+check "piped '--help' is escape-free" bash -c "! LC_ALL=C grep -q \$'\x1b' '$out'"
+
+# ── NO_COLOR and TERM=dumb are honored ──────────────────────────────────────
+NO_COLOR=1 "$BIN" version > "$out" 2>&1
+check "NO_COLOR is honored" bash -c "! LC_ALL=C grep -q \$'\x1b' '$out'"
+
+TERM=dumb "$BIN" version > "$out" 2>&1
+check "TERM=dumb is honored" bash -c "! LC_ALL=C grep -q \$'\x1b' '$out'"
+
+# ── --plain and KATES_ASCII produce pure ASCII ──────────────────────────────
+# Plain mode is a statement that the most limited consumer is reading: no
+# escapes AND no multibyte glyphs.
+"$BIN" --plain version > "$out" 2>&1
+check "--plain has no escapes"   bash -c "! LC_ALL=C grep -q \$'\x1b' '$out'"
+check "--plain is pure ASCII"    bash -c "! LC_ALL=C grep -q '[^ -~\t\r]' '$out'"
+
+KATES_ASCII=1 "$BIN" version > "$out" 2>&1
+check "KATES_ASCII glyphs are ASCII" bash -c "! LC_ALL=C grep -q '[^ -~\t\r]' '$out'"
+
+# ── Unset locale keeps UTF-8 glyphs (the polarity rule) ─────────────────────
+# Containers and CI run with no locale set and render UTF-8 fine; stripping
+# glyphs there would degrade exactly where most output is read. This asserts
+# the ASCII fallback does NOT engage on absence of evidence.
+env -u LANG -u LC_ALL -u LC_CTYPE "$BIN" version > "$out" 2>&1
+check "unset locale keeps UTF-8 glyphs" bash -c "LC_ALL=C grep -q '[^ -~\t\r]' '$out'"
+
+# ── TUIs refuse politely without a terminal ─────────────────────────────────
+# These must exit non-zero fast with a readable message — not hang, not crash
+# with a raw bubbletea error, not dump alt-screen sequences.
+set +e
+"$BIN" lab < /dev/null > "$out" 2>&1
+rc=$?
+set -e
+check "'lab' without TTY exits non-zero" test "$rc" -ne 0
+check "'lab' refusal mentions the terminal" grep -qi "terminal" "$out"
+check "'lab' refusal is escape-free... " bash -c "! LC_ALL=C grep -q \$'\x1b' '$out'"
+
+rm -f "$out"
+
+if [[ "$fail" -ne 0 ]]; then
+  echo
+  echo "Terminal-compatibility regressions found." >&2
+  exit 1
+fi
+echo "OK: CLI terminal-compatibility checks pass"


### PR DESCRIPTION
## Why

Wave 2 of the CLI experience plan (Wave 1: #77). These are the foundations later restyling builds on — **no visual redesign**: UTF-8 output is byte-identical; what changes is that the degraded modes (`--plain`, ASCII, piped, dumb terminals) are now *complete and enforced* rather than best-effort.

## The glyph table — and its polarity rule

Every status mark, arrow, rule, bar segment, and sparkline ramp now renders through one table (`cli/output/glyphs.go`) with two sets: UTF-8 and ASCII. Adopted at the `cli/output` choke points (StatusBadge, headers, Success/Warn/Error, progress bars, sparklines, separators), so ~70 consumer files inherit it without edits.

The rule worth reviewing: **ASCII engages only on positive evidence** — `--plain`, `KATES_ASCII`, or a locale *explicitly set* to a non-UTF-8 value. An unset locale is not evidence of a limited terminal: containers, CI, and Windows run without one and render UTF-8 fine. Treating "unset" as "limited" would strip glyphs exactly where most output is read. There's a test asserting `LC_ALL=C` beats `LANG=en_US.UTF-8` (libc precedence) and one asserting every ASCII glyph is actually ASCII — a fallback existing is not the same as it being complete.

## One width helper

Three copies of `term.GetSize` existed with three different fallbacks (120, 80, and 72-capped-80), so the same terminal produced three different layouts depending on which command ran. All width now flows through `output.TermWidth`.

## Raw escapes out of clean.go and deploy.go

The `\033[2m` / `\033[31m` literals are replaced with the styled helpers — which also means those lines now degrade with the color profile instead of hardcoding SGR into pipes. `deploy_view.go`'s `\x1b[31G` cursor-column codes are deliberately **left in place**: the wave-3 summary rewrite replaces that rendering wholesale, and restyling it twice is dead work.

## Shared "terminal too small" card

Below 80×24, the lab and the Kafka explorer now render one consistent card (`cli/tui/toosmall.go`) instead of each layout clipping into garbage. Zero-size (pre-`WindowSizeMsg`) deliberately doesn't trigger it, so the card never flashes on startup.

## The CI harness — which already caught its first bug

`scripts/check-cli-compat.sh` (wired into the CLI Tests job and `make check-cli-compat`) runs the **real binary** piped, with `NO_COLOR`, `TERM=dumb`, `--plain`, `KATES_ASCII`, an explicitly unset locale, and TUI commands without a TTY — asserting on the raw bytes. Unit tests never see those bytes, which is how the forced-TrueColor bug (fixed in #77) lived so long.

Proof it works: on its first run it **failed this very branch** — `--plain` still emitted UTF-8 `━`/`─` rules because the separators were outside the glyph table. They're in it now. That's the harness doing exactly its job, before the commit ever left the machine.

## Verification

- 12/12 harness checks pass against the built binary.
- New unit tests: locale-detection polarity table, libc precedence, plain-mode forcing, ASCII-set completeness.
- Full suite green (`go test ./cmd/... ./pkg/... ./output/ ./tui/`), `go vet` clean, `ci.yml` parses.
- Diff kept to the 13 intentionally-changed files — gofmt churn in untouched files was reverted, same policy as #77.