### PR TITLE
feat(cli): one palette, honest meters, gated loops (UX plan wave 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,6 +266,11 @@ jobs:
       # CI logs" class regressions — unit tests never see the raw bytes.
       - name: CLI terminal-compatibility checks
         run: bash scripts/check-cli-compat.sh
+
+      # Static companion to the compat harness: no hardcoded hex colors
+      # outside the theme, no raw escape literals outside cli/output/.
+      - name: CLI style checks
+        run: bash scripts/check-cli-style.sh
         env:
           GOMEMLIMIT: 2GiB
           GOGC: 50

--- a/cli/cmd/cleanup.go
+++ b/cli/cmd/cleanup.go
@@ -35,11 +35,15 @@ var testCleanupCmd = &cobra.Command{
 
 		for _, run := range paged.Content {
 			created, err := time.Parse(time.RFC3339Nano, run.CreatedAt)
-			if err != nil {
+			// Guard the slice: a short or empty CreatedAt panicked here.
+			if err != nil && len(run.CreatedAt) >= 19 {
 				created, err = time.Parse("2006-01-02T15:04:05", run.CreatedAt[:19])
 			}
 			if err != nil {
-				stale = append(stale, run.ID)
+				// Unknown age is not proven staleness. This used to add the
+				// run to the DELETE list — destroying data because we could
+				// not read its timestamp.
+				output.Warn("Skipping " + truncID(run.ID) + ": unparseable createdAt " + fmt.Sprintf("%q", run.CreatedAt))
 				continue
 			}
 			if now.Sub(created) > staleThreshold {

--- a/cli/cmd/cluster_gate.go
+++ b/cli/cmd/cluster_gate.go
@@ -7,6 +7,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/bmscomp/kates/cli/pkg/cluster"
+	"github.com/bmscomp/kates/cli/pkg/theme"
 )
 
 // The cluster gate runs before anything in `kates deploy` that assumes a
@@ -44,11 +45,11 @@ var (
 // styles reused from the repo's lipgloss vocabulary.
 var (
 	gateTitle  = lipgloss.NewStyle().Bold(true)
-	gateDim    = lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280"))
-	gateOK     = lipgloss.NewStyle().Foreground(lipgloss.Color("#10B981"))
-	gateWarn   = lipgloss.NewStyle().Foreground(lipgloss.Color("#F59E0B"))
-	gateErr    = lipgloss.NewStyle().Foreground(lipgloss.Color("#EF4444"))
-	gateAccent = lipgloss.NewStyle().Foreground(lipgloss.Color("#6366F1"))
+	gateDim    = lipgloss.NewStyle().Foreground(theme.Muted)
+	gateOK     = lipgloss.NewStyle().Foreground(theme.Success)
+	gateWarn   = lipgloss.NewStyle().Foreground(theme.Warning)
+	gateErr    = lipgloss.NewStyle().Foreground(theme.Error)
+	gateAccent = lipgloss.NewStyle().Foreground(theme.Accent)
 )
 
 // resolveCluster is the gate. It returns the context name to deploy into, or an

--- a/cli/cmd/cluster_gate_test.go
+++ b/cli/cmd/cluster_gate_test.go
@@ -428,3 +428,18 @@ func TestResolveCluster_KubeconfigErrorPropagates(t *testing.T) {
 		t.Error("must not create a cluster because kubectl is broken")
 	}
 }
+
+// Phase numbers are generated, not literals — a reorder can no longer produce
+// the [1], [1], [2], [3], [4] sequence users saw.
+func TestDeployPhaseCounter(t *testing.T) {
+	resetDeployPhases()
+	for want := 1; want <= 5; want++ {
+		if got := nextDeployPhase(); got != want {
+			t.Fatalf("phase %d, want %d", got, want)
+		}
+	}
+	resetDeployPhases()
+	if got := nextDeployPhase(); got != 1 {
+		t.Fatalf("after reset, phase = %d, want 1", got)
+	}
+}

--- a/cli/cmd/cluster_watch.go
+++ b/cli/cmd/cluster_watch.go
@@ -58,7 +58,7 @@ var clusterWatchCmd = &cobra.Command{
 
 			hist.record(report)
 
-			fmt.Print("\033[2J\033[H")
+			output.ClearFrame(IsInteractive())
 
 			statusLabel := output.SuccessStyle.Render("● HEALTHY")
 			if report.Status == "WARNING" {

--- a/cli/cmd/cost.go
+++ b/cli/cmd/cost.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"strings"
 
+	"github.com/bmscomp/kates/cli/pkg/theme"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 )
@@ -35,20 +36,20 @@ var (
 
 	costTitleStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("#FFFFFF")).
-			Background(lipgloss.Color("#7C3AED")).
+			Foreground(theme.OnDark).
+			Background(theme.Accent).
 			Padding(0, 1)
 
 	costLabelStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#6B7280")).
+			Foreground(theme.Muted).
 			Width(18)
 
 	costValueStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#06B6D4"))
+			Foreground(theme.Info)
 
 	costTotalStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("#22C55E"))
+			Foreground(theme.Highlight)
 )
 
 var costCmd = &cobra.Command{

--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/bmscomp/kates/cli/output"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 )
 
@@ -23,7 +23,7 @@ var dashboardCmd = &cobra.Command{
 		latencyHistory := make([]float64, 0, 30)
 
 		for {
-			fmt.Print("\033[2J\033[H")
+			output.ClearFrame(IsInteractive())
 
 			health, healthErr := apiClient.Health(context.Background())
 			paged, _ := apiClient.ListTests(context.Background(), "", "", 0, 50)

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -98,6 +98,7 @@ func init() {
 func runDeploy(cmd *cobra.Command, args []string) error {
 	deployStartTime := time.Now()
 	PrintDeployBanner()
+	resetDeployPhases()
 
 	dl = &DashboardController{}
 
@@ -107,7 +108,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	// to deploy it. When nothing is reachable this offers to build the local
 	// 3-zone kind cluster; when several are reachable it asks rather than
 	// guessing.
-	PrintPhaseHeader(1, "Selecting Target Cluster")
+	PrintPhaseHeader(nextDeployPhase(), "Selecting Target Cluster")
 	if _, err := resolveClusterFn(); err != nil {
 		return err
 	}
@@ -130,7 +131,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	printComponentSelection()
 
 	executor := defaultExecutor
-	PrintPhaseHeader(3, "Running Cluster Introspection (Pre-flight)")
+	PrintPhaseHeader(nextDeployPhase(), "Running Cluster Introspection (Pre-flight)")
 	collector := detect.NewCollector(executor)
 	if err := collector.Preflight(); err != nil {
 		output.Error(fmt.Sprintf("Preflight failed: %v", err))
@@ -142,7 +143,10 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	// collector.Collect() runs. This ensures detect's matchStorageClass() finds
 	// them and writes the correct storageClass names into values-detected.yaml,
 	// so no hardcoded pool overrides are needed in values-kind.yaml.
-	if quickDetectKind() {
+	// A dry run must not write StorageClasses into the cluster. Introspection
+	// below stays (it is read-only and the plan needs its data); this is the
+	// one pre-plan step that mutates.
+	if quickDetectKind() && !deployDryRun {
 		PrintPhaseItem("Kind cluster detected — bootstrapping zone StorageClasses...")
 		if err := setupKindStorageClasses(context.Background()); err != nil {
 			output.Warn(fmt.Sprintf("StorageClass bootstrap warning: %v", err))
@@ -201,7 +205,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	}
 
 	// 4. Execution Plan (Helm)
-	PrintPhaseHeader(4, "Executing Deployment Pipeline")
+	PrintPhaseHeader(nextDeployPhase(), "Executing Deployment Pipeline")
 
 	totalSteps := countDeploySteps()
 

--- a/cli/cmd/deploy_plan.go
+++ b/cli/cmd/deploy_plan.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/charmbracelet/huh"
 	"github.com/bmscomp/kates/cli/pkg/detect"
+	"github.com/charmbracelet/huh"
 )
 
 // runInteractiveForms runs the interactive huh forms (Form 1: component selection,
@@ -157,7 +157,7 @@ func runInteractiveForms() error {
 
 // printTopologyResolution prints the resolved namespace topology (Phase 1).
 func printTopologyResolution() {
-	PrintPhaseHeader(1, fmt.Sprintf("Resolving Namespace Topology (%s mode)", deployTopology))
+	PrintPhaseHeader(nextDeployPhase(), fmt.Sprintf("Resolving Namespace Topology (%s mode)", deployTopology))
 	if deployTopology == "single" {
 		PrintPhaseItem(fmt.Sprintf("All components → %s", deployNamespace))
 	} else {
@@ -179,7 +179,7 @@ func printTopologyResolution() {
 
 // printComponentSelection prints the selected components (Phase 2).
 func printComponentSelection() {
-	PrintPhaseHeader(2, "Component Selection")
+	PrintPhaseHeader(nextDeployPhase(), "Component Selection")
 	if deployWithStrimzi {
 		PrintPhaseSuccess("Strimzi Operator")
 	}

--- a/cli/cmd/deploy_status.go
+++ b/cli/cmd/deploy_status.go
@@ -16,6 +16,8 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
+
+	"github.com/bmscomp/kates/cli/pkg/theme"
 )
 
 var (
@@ -660,7 +662,7 @@ func (m interactiveStatusModel) View() string {
 	b.WriteString("\n")
 	b.WriteString(lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("#FFFFFF")).
+		Foreground(theme.OnDark).
 		Background(clrAccent).
 		Padding(0, 1).
 		Render(" ⎈ Gathering Kates Deployment Status "))
@@ -766,7 +768,7 @@ func RenderStatusDashboard(statuses []ComponentStatus) {
 
 	banner := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("#FFFFFF")).
+		Foreground(theme.OnDark).
 		Background(clrAccent).
 		Padding(0, 1).
 		Render(" ⎈ Kates Deployment Status ")

--- a/cli/cmd/deploy_view.go
+++ b/cli/cmd/deploy_view.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -13,7 +11,6 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/mattn/go-runewidth"
-	"golang.org/x/term"
 )
 
 // ─── Color Palette ──────────────────────────────────────────
@@ -51,7 +48,7 @@ func RenderDeployDashboard(ctx context.Context, entries []DeploySummaryEntry, el
 	// ── Header ──
 	banner := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("#FFFFFF")).
+		Foreground(theme.OnDark).
 		Background(clrAccent).
 		Padding(0, 1).
 		Render(" ⎈ Kates Deployment Summary ")
@@ -74,16 +71,11 @@ func RenderDeployDashboard(ctx context.Context, entries []DeploySummaryEntry, el
 	}
 	sepLine := lipgloss.NewStyle().Foreground(clrDim).Render(strings.Repeat("─", termW))
 
-	isTTY := term.IsTerminal(int(os.Stdout.Fd()))
-	var colHeaders string
-	if isTTY {
-		colHeaders = lipgloss.NewStyle().Bold(true).Foreground(clrDim).Render("  COMPONENT\x1b[31GNAMESPACE\x1b[49GSTATUS")
-	} else {
-		colHdrName := lipgloss.NewStyle().Width(28).Render("COMPONENT")
-		colHdrNs := lipgloss.NewStyle().Width(18).Render("NAMESPACE")
-		colHdrStat := lipgloss.NewStyle().Render("STATUS")
-		colHeaders = lipgloss.NewStyle().Bold(true).Foreground(clrDim).Render(fmt.Sprintf("  %s%s%s", colHdrName, colHdrNs, colHdrStat))
-	}
+	// One layout for every terminal: runewidth-measured padding. The TTY path
+	// used CHA cursor-column jumps — which broke the moment output was
+	// captured, and meant TTY and non-TTY rows could disagree about columns.
+	colHeaders := lipgloss.NewStyle().Bold(true).Foreground(clrDim).
+		Render("  " + padCell("COMPONENT", summaryNameWidth) + padCell("NAMESPACE", summaryNsWidth) + "STATUS")
 
 	for _, g := range []string{"A", "B", "C"} {
 		if len(groups[g]) == 0 {
@@ -94,8 +86,11 @@ func RenderDeployDashboard(ctx context.Context, entries []DeploySummaryEntry, el
 		fmt.Println(colHeaders)
 		fmt.Println("  " + sepLine)
 		for _, e := range groups[g] {
-			status := getComponentStatus(ctx, e.Release, e.Namespace)
-			printRow(e.Icon, e.Name, e.Namespace, status)
+			// The status RECORDED during the deploy, not a fresh helm query.
+			// Re-querying ran `helm status` per row (up to 5s each) and could
+			// contradict what the deploy just reported — a component that
+			// failed mid-apply can still hold a "deployed" helm release.
+			printRow(e.Icon, e.Name, e.Namespace, e.Status)
 		}
 	}
 
@@ -139,49 +134,40 @@ func RenderDeployDashboard(ctx context.Context, entries []DeploySummaryEntry, el
 	fmt.Println()
 }
 
-func getComponentStatus(ctx context.Context, release, namespace string) string {
-	checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(checkCtx, "helm", "status", release, "-n", namespace)
-	if cmd.Run() == nil {
-		return "ready"
+const (
+	summaryNameWidth = 28
+	summaryNsWidth   = 18
+)
+
+// padCell pads a raw (unstyled) cell to a display width, measured with
+// runewidth so emoji and CJK count their true two cells. Padding happens
+// BEFORE styling: ANSI sequences are zero-width and must not enter the math.
+func padCell(s string, w int) string {
+	gap := w - visualWidth(s)
+	if gap < 1 {
+		gap = 1
 	}
-	return "skip"
+	return s + strings.Repeat(" ", gap)
 }
 
+// printRow renders one summary row from the status recorded during deploy
+// ("deployed", "skipped", "failed").
 func printRow(icon, name, namespace, status string) {
-	const nameWidth = 28
-	const nsWidth = 18
+	g := output.Glyphs()
+	nameCol := lipgloss.NewStyle().Bold(true).Foreground(clrText).Render(padCell(icon+" "+name, summaryNameWidth))
+	nsCol := lipgloss.NewStyle().Foreground(clrDim).Render(padCell(namespace, summaryNsWidth))
 
-	nameStr := icon + " " + name
-
-	isTTY := term.IsTerminal(int(os.Stdout.Fd()))
-
-	var nameCol, nsCol string
-	if isTTY {
-		nameCol = lipgloss.NewStyle().Bold(true).Foreground(clrText).Render(nameStr)
-		nsCol = lipgloss.NewStyle().Foreground(clrDim).Render(namespace)
-	} else {
-		nameCol = lipgloss.NewStyle().Bold(true).Foreground(clrText).Width(nameWidth).Render(nameStr)
-		nsCol = lipgloss.NewStyle().Foreground(clrDim).Width(nsWidth).Render(namespace)
-	}
-
-	// Status column
 	var statusStr string
 	switch status {
-	case "ready":
-		statusStr = lipgloss.NewStyle().Bold(true).Foreground(clrGreen).Render("✔ Ready")
-	case "fail":
-		statusStr = lipgloss.NewStyle().Bold(true).Foreground(clrRed).Render("✖ Failed")
+	case "deployed":
+		statusStr = lipgloss.NewStyle().Bold(true).Foreground(clrGreen).Render(g.Check + " Deployed")
+	case "failed":
+		statusStr = lipgloss.NewStyle().Bold(true).Foreground(clrRed).Render(g.Cross + " Failed")
 	default:
-		statusStr = lipgloss.NewStyle().Foreground(clrOrange).Render("⏭ Skipped")
+		statusStr = lipgloss.NewStyle().Foreground(clrOrange).Render(g.Ring + " Skipped")
 	}
 
-	if isTTY {
-		fmt.Printf("  %s\x1b[31G%s\x1b[49G%s\n", nameCol, nsCol, statusStr)
-	} else {
-		fmt.Printf("  %s%s%s\n", nameCol, nsCol, statusStr)
-	}
+	fmt.Printf("  %s%s%s\n", nameCol, nsCol, statusStr)
 }
 
 // visualWidth returns the true terminal display width of a string using
@@ -192,6 +178,17 @@ func visualWidth(s string) int {
 }
 
 // ─── Phase Logging ──────────────────────────────────────────
+
+// deployPhase numbers the phase headers of one runDeploy invocation. A counter
+// instead of literals: the literals drifted to [1], [1], [2], [3], [4] after a
+// reorder, and nothing noticed until a user did.
+var deployPhase int
+
+// resetDeployPhases starts the numbering over; call at the top of runDeploy.
+func resetDeployPhases() { deployPhase = 0 }
+
+// nextDeployPhase returns the next phase number.
+func nextDeployPhase() int { deployPhase++; return deployPhase }
 
 // PrintPhaseHeader prints a styled phase header.
 func PrintPhaseHeader(number int, title string) {

--- a/cli/cmd/flow.go
+++ b/cli/cmd/flow.go
@@ -7,9 +7,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/bmscomp/kates/cli/client"
 	"github.com/bmscomp/kates/cli/output"
+	"github.com/bmscomp/kates/cli/pkg/theme"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -64,24 +65,24 @@ var (
 
 	flowTitleStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("#FFFFFF")).
-			Background(lipgloss.Color("#7C3AED")).
+			Foreground(theme.OnDark).
+			Background(theme.Accent).
 			Padding(0, 1)
 
 	flowStepStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("#06B6D4"))
+			Foreground(theme.Info)
 
 	flowPassStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("#22C55E"))
+			Foreground(theme.Success)
 
 	flowFailStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("#EF4444"))
+			Foreground(theme.Error)
 
 	flowDimStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#6B7280"))
+			Foreground(theme.Muted)
 )
 
 var flowCmd = &cobra.Command{

--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -10,8 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/bmscomp/kates/cli/output"
+	"github.com/bmscomp/kates/cli/pkg/theme"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 )
 
@@ -36,20 +37,20 @@ var (
 
 	profTitleStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("#FFFFFF")).
-			Background(lipgloss.Color("#7C3AED")).
+			Foreground(theme.OnDark).
+			Background(theme.Accent).
 			Padding(0, 1)
 
 	profUpStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#22C55E")).
+			Foreground(theme.Success).
 			Bold(true)
 
 	profDownStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#EF4444")).
+			Foreground(theme.Error).
 			Bold(true)
 
 	profDimStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#6B7280"))
+			Foreground(theme.Muted)
 )
 
 var profileCmd = &cobra.Command{
@@ -138,10 +139,10 @@ var profileListCmd = &cobra.Command{
 				savedDate = t.Format("Jan 02")
 			}
 			fmt.Printf("  %-22s %-10s %-12s %-10s %-10s %s\n",
-				lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#06B6D4")).Render(p.Name),
+				lipgloss.NewStyle().Bold(true).Foreground(theme.Info).Render(p.Name),
 				p.TestType,
 				profUpStyle.Render(fmtAdvisorNum(p.Throughput)+" rec/s"),
-				lipgloss.NewStyle().Foreground(lipgloss.Color("#F59E0B")).Render(fmt.Sprintf("%.0fms", p.P99Ms)),
+				lipgloss.NewStyle().Foreground(theme.Warning).Render(fmt.Sprintf("%.0fms", p.P99Ms)),
 				profDimStyle.Render(savedDate),
 				profDimStyle.Render(p.RunID[:minLen(len(p.RunID), 8)]),
 			)

--- a/cli/cmd/report_heatmap.go
+++ b/cli/cmd/report_heatmap.go
@@ -7,8 +7,9 @@ import (
 	"math"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/bmscomp/kates/cli/output"
+	"github.com/bmscomp/kates/cli/pkg/theme"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 )
 
@@ -54,12 +55,14 @@ type timeSlice struct {
 
 var heatBlocks = []string{"░", "▒", "▓", "█"}
 
-var heatGradient = []lipgloss.Color{
-	lipgloss.Color("#1a1a2e"),
-	lipgloss.Color("#16213e"),
-	lipgloss.Color("#0f3460"),
-	lipgloss.Color("#533483"),
-	lipgloss.Color("#e94560"),
+// heatGradient is a cold-to-hot intensity ramp built from theme tokens:
+// faint separators up through the error red at peak latency.
+var heatGradient = []lipgloss.AdaptiveColor{
+	theme.Subtle,
+	theme.Muted,
+	theme.Accent,
+	theme.Secondary,
+	theme.Error,
 }
 
 func renderHeatmap(data heatmapData) {
@@ -109,19 +112,19 @@ func renderHeatmap(data heatmapData) {
 			block := heatBlock(intensity)
 			row.WriteString(block)
 		}
-		fmt.Printf("%s%s\n", lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280")).Render(label), row.String())
+		fmt.Printf("%s%s\n", lipgloss.NewStyle().Foreground(theme.Muted).Render(label), row.String())
 	}
 
 	fmt.Printf("%s%s\n",
 		strings.Repeat(" ", labelWidth),
-		lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280")).Render("time →"))
+		lipgloss.NewStyle().Foreground(theme.Muted).Render("time →"))
 
 	legend := "  "
 	for i, block := range heatBlocks {
 		pct := float64(i+1) / float64(len(heatBlocks)) * 100
 		legend += fmt.Sprintf("%s %.0f%%  ", colorizeHeat(block, float64(i+1)/float64(len(heatBlocks))), pct)
 	}
-	fmt.Println(lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280")).Render("Legend:") + legend)
+	fmt.Println(lipgloss.NewStyle().Foreground(theme.Muted).Render("Legend:") + legend)
 }
 
 func heatBlock(intensity float64) string {

--- a/cli/cmd/snapshot.go
+++ b/cli/cmd/snapshot.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/bmscomp/kates/cli/output"
+	"github.com/bmscomp/kates/cli/pkg/theme"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 )
 
@@ -29,16 +30,16 @@ type ClusterSnapshot struct {
 var (
 	snapTitleStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("#FFFFFF")).
-			Background(lipgloss.Color("#7C3AED")).
+			Foreground(theme.OnDark).
+			Background(theme.Accent).
 			Padding(0, 1)
 
 	snapDimStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#6B7280"))
+			Foreground(theme.Muted)
 
 	snapNameStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("#06B6D4"))
+			Foreground(theme.Info)
 )
 
 var snapshotCmd = &cobra.Command{
@@ -166,13 +167,13 @@ var snapshotDiffCmd = &cobra.Command{
 
 		added, removed := diffStringLists(s1.TopicList, s2.TopicList)
 		if len(added) > 0 {
-			fmt.Println("  " + lipgloss.NewStyle().Foreground(lipgloss.Color("#22C55E")).Bold(true).Render("+ Topics added:"))
+			fmt.Println("  " + lipgloss.NewStyle().Foreground(theme.Success).Bold(true).Render("+ Topics added:"))
 			for _, t := range added {
 				fmt.Printf("    + %s\n", t)
 			}
 		}
 		if len(removed) > 0 {
-			fmt.Println("  " + lipgloss.NewStyle().Foreground(lipgloss.Color("#EF4444")).Bold(true).Render("- Topics removed:"))
+			fmt.Println("  " + lipgloss.NewStyle().Foreground(theme.Error).Bold(true).Render("- Topics removed:"))
 			for _, t := range removed {
 				fmt.Printf("    - %s\n", t)
 			}
@@ -180,13 +181,13 @@ var snapshotDiffCmd = &cobra.Command{
 
 		addedG, removedG := diffStringLists(s1.GroupList, s2.GroupList)
 		if len(addedG) > 0 {
-			fmt.Println("  " + lipgloss.NewStyle().Foreground(lipgloss.Color("#22C55E")).Bold(true).Render("+ Groups added:"))
+			fmt.Println("  " + lipgloss.NewStyle().Foreground(theme.Success).Bold(true).Render("+ Groups added:"))
 			for _, g := range addedG {
 				fmt.Printf("    + %s\n", g)
 			}
 		}
 		if len(removedG) > 0 {
-			fmt.Println("  " + lipgloss.NewStyle().Foreground(lipgloss.Color("#EF4444")).Bold(true).Render("- Groups removed:"))
+			fmt.Println("  " + lipgloss.NewStyle().Foreground(theme.Error).Bold(true).Render("- Groups removed:"))
 			for _, g := range removedG {
 				fmt.Printf("    - %s\n", g)
 			}
@@ -201,9 +202,9 @@ func printSnapDiff(label string, a, b int) {
 	delta := b - a
 	var indicator string
 	if delta > 0 {
-		indicator = lipgloss.NewStyle().Foreground(lipgloss.Color("#22C55E")).Render(fmt.Sprintf(" (+%d)", delta))
+		indicator = lipgloss.NewStyle().Foreground(theme.Success).Render(fmt.Sprintf(" (+%d)", delta))
 	} else if delta < 0 {
-		indicator = lipgloss.NewStyle().Foreground(lipgloss.Color("#EF4444")).Render(fmt.Sprintf(" (%d)", delta))
+		indicator = lipgloss.NewStyle().Foreground(theme.Error).Render(fmt.Sprintf(" (%d)", delta))
 	}
 	fmt.Printf("  %-16s %-14d %-14d%s\n", label, a, b, indicator)
 }

--- a/cli/cmd/test.go
+++ b/cli/cmd/test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"strconv"
 	"strings"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/bmscomp/kates/cli/output"
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 )
 
 var (
@@ -162,7 +160,15 @@ var testGetCmd = &cobra.Command{
 			}
 			if maxThroughput > 0 {
 				fmt.Println()
-				output.MetricBar("Throughput", maxThroughput, 100000)
+				// Only draw a bar when the test declared a target: a bar needs
+				// a meaningful ceiling, and the old hardcoded 100k made high
+				// throughput render RED (the consumption palette read "good"
+				// as "dangerous") while any slow test looked healthily green.
+				if result.Spec != nil && result.Spec.TargetThroughput > 0 {
+					output.MetricBarDir("Throughput", maxThroughput, float64(result.Spec.TargetThroughput), true)
+				} else {
+					output.KeyValue("Peak Throughput", fmtNum(maxThroughput)+" rec/s")
+				}
 			}
 
 			for _, r := range result.Results {
@@ -314,7 +320,11 @@ var testCreateCmd = &cobra.Command{
   kates test create --type LOAD --records 100000 --consumers 4 --consumer-group perf-cg
   kates test create --type LOAD --records 100000 --throughput 10000 --fetch-min-bytes 1048576`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if !plainOutput && cmd.Flags().NFlag() == 0 && term.IsTerminal(int(os.Stdout.Fd())) {
+		// IsInteractive is the one guard: the previous check looked at stdout
+		// only, so `echo | kates test create` (TTY stdout, piped stdin) sent
+		// huh hunting for input on a pipe. It also ignored isTesting and
+		// TERM=dumb.
+		if cmd.Flags().NFlag() == 0 && IsInteractive() {
 			if err := runInteractiveTestCreate(); err != nil {
 				return err
 			}
@@ -443,10 +453,12 @@ func runInteractiveTestCreate() error {
 			huh.NewInput().
 				Title("Number of Records").
 				Description("Leave blank if specifying duration").
+				Validate(optionalPositiveInt).
 				Value(&recordsStr),
 			huh.NewInput().
 				Title("Duration (seconds)").
 				Description("Leave blank if specifying records").
+				Validate(optionalPositiveInt).
 				Value(&durationStr),
 			huh.NewConfirm().
 				Title("Wait for completion?").
@@ -458,15 +470,28 @@ func runInteractiveTestCreate() error {
 		return err
 	}
 
+	// The form validated these, so Atoi cannot fail here — but the old code
+	// silently discarded errors, meaning a typo like "10k" created a test
+	// with zero records and no explanation.
 	if recordsStr != "" {
-		if val, err := strconv.Atoi(recordsStr); err == nil {
-			createRecords = val
-		}
+		createRecords, _ = strconv.Atoi(recordsStr)
 	}
 	if durationStr != "" {
-		if val, err := strconv.Atoi(durationStr); err == nil {
-			createDuration = val
-		}
+		createDuration, _ = strconv.Atoi(durationStr)
+	}
+	return nil
+}
+
+// optionalPositiveInt validates a wizard field that may be blank or a positive
+// integer — rejecting input at the form, where the user can fix it, instead of
+// silently dropping it after.
+func optionalPositiveInt(s string) error {
+	if s == "" {
+		return nil
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n <= 0 {
+		return fmt.Errorf("enter a positive whole number (or leave blank)")
 	}
 	return nil
 }

--- a/cli/cmd/tldr.go
+++ b/cli/cmd/tldr.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bmscomp/kates/cli/pkg/theme"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 )
@@ -81,17 +82,17 @@ var tldrGroups = []tldrGroup{
 var (
 	tldrTitleStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("#7C3AED"))
+			Foreground(theme.Primary)
 
 	tldrDescStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#6B7280"))
+			Foreground(theme.Muted)
 
 	tldrCmdStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#06B6D4"))
+			Foreground(theme.Info)
 
 	tldrCatStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("#F59E0B")).
+			Foreground(theme.Secondary).
 			MarginTop(1)
 )
 

--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -19,7 +19,7 @@ var topCmd = &cobra.Command{
 		tick := 0
 
 		for {
-			fmt.Print("\033[2J\033[H")
+			output.ClearFrame(IsInteractive())
 
 			health, _ := apiClient.Health(context.Background())
 			paged, err := apiClient.ListTests(context.Background(), "", "", 0, 50)

--- a/cli/cmd/watch.go
+++ b/cli/cmd/watch.go
@@ -23,83 +23,27 @@ var testWatchCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		id := args[0]
-		tick := 0
-		var throughputHistory []float64
 
-		for {
-			result, err := apiClient.GetTest(context.Background(), id)
-			if err != nil {
-				return cmdErr("Failed to fetch test: " + err.Error())
-			}
-
-			status := strings.ToUpper(result.Status)
-
-			var currentThroughput float64
-			for _, r := range result.Results {
-				if r.ThroughputRecordsPerSec > currentThroughput {
-					currentThroughput = r.ThroughputRecordsPerSec
-				}
-			}
-			throughputHistory = append(throughputHistory, currentThroughput)
-
-			fmt.Print("\033[2J\033[H")
-
-			output.Banner("Test Watch", fmt.Sprintf("%s · %s", result.TestType, truncID(id)))
-
-			output.SubHeader("Status")
-			output.KeyValue("Test ID", id)
-			output.KeyValue("Type", result.TestType)
-			output.KeyValue("Backend", result.Backend)
-			output.KeyValue("Status", output.StatusBadge(status))
-			output.KeyValue("Created", formatTime(result.CreatedAt))
-
-			if len(result.Results) > 0 {
-				output.SubHeader(fmt.Sprintf("Results (%d phases)", len(result.Results)))
-				rows := make([][]string, 0, len(result.Results))
-				for _, r := range result.Results {
-					phase := r.PhaseName
-					if phase == "" {
-						phase = "main"
-					}
-					rows = append(rows, []string{
-						phase,
-						r.Status,
-						fmtNum(r.RecordsSent),
-						fmtFloat(r.ThroughputRecordsPerSec, 1),
-						fmtFloat(r.AvgLatencyMs, 2),
-						fmtFloat(r.P99LatencyMs, 2),
-					})
-				}
-				output.Table(
-					[]string{"Phase", "Status", "Records", "Throughput", "Avg Lat.", "P99 Lat."},
-					rows,
-				)
-			}
-
-			if len(throughputHistory) > 1 {
-				fmt.Println()
-				sparkline := output.Sparkline(throughputHistory)
-				output.KeyValue("Throughput Trend", sparkline+" "+fmtNum(currentThroughput)+" rec/s")
-			}
-
-			switch status {
-			case "DONE", "COMPLETED":
-				output.Success("Test completed successfully")
-				output.Hint(fmt.Sprintf("View report: kates report show %s", id))
-				return nil
-			case "FAILED", "ERROR":
-				return cmdErr("Test failed")
-			default:
-				fmt.Println()
-				fmt.Printf("  %s Refreshing every %ds... (Ctrl+C to stop)\n",
-					spinnerFrame(tick),
-					watchInterval,
-				)
-			}
-
-			tick++
-			time.Sleep(time.Duration(watchInterval) * time.Second)
+		// One follower for the whole test family. `watch` used to be its own
+		// clear-screen loop — a second implementation with its own rendering,
+		// its own polling, and (until wave 1) DIFFERENT exit semantics from
+		// `create --wait`. pollUntilDone gives the rich TUI on a terminal and
+		// the append-only line format everywhere else.
+		if watchInterval > 0 {
+			origInterval := pollInterval
+			pollInterval = time.Duration(watchInterval) * time.Second
+			defer func() { pollInterval = origInterval }()
 		}
+
+		status, err := pollUntilDone(id)
+		if err != nil {
+			return cmdErr("Lost track of test " + truncID(id) + ": " + err.Error())
+		}
+		if isFailedStatus(status) {
+			return cmdErr("Test failed — details: kates test get " + id)
+		}
+		output.Hint(fmt.Sprintf("View report: kates report show %s", id))
+		return nil
 	},
 }
 

--- a/cli/cmd/watch_events.go
+++ b/cli/cmd/watch_events.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bmscomp/kates/cli/pkg/theme"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 )
@@ -16,21 +17,21 @@ var (
 	watchFollow bool
 
 	watchInfoStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#06B6D4"))
+			Foreground(theme.Info)
 
 	watchWarnStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#F59E0B")).
+			Foreground(theme.Warning).
 			Bold(true)
 
 	watchErrStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#EF4444")).
+			Foreground(theme.Error).
 			Bold(true)
 
 	watchOkStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#22C55E"))
+			Foreground(theme.Success)
 
 	watchTimeStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#6B7280"))
+			Foreground(theme.Muted)
 )
 
 var watchEventsCmd = &cobra.Command{
@@ -44,7 +45,7 @@ Like 'kubectl get events --watch' but for Kafka testing.`,
   kates watch --type test
   kates watch --id abc123`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Println(lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#7C3AED")).Render("  Kates Event Stream"))
+		fmt.Println(lipgloss.NewStyle().Bold(true).Foreground(theme.Primary).Render("  Kates Event Stream"))
 		fmt.Println(watchTimeStyle.Render("  Watching for events… (Ctrl+C to stop)"))
 		fmt.Println()
 

--- a/cli/output/output.go
+++ b/cli/output/output.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/bmscomp/kates/cli/pkg/theme"
 	"github.com/charmbracelet/lipgloss"
@@ -142,6 +143,20 @@ func StatusBadge(status string) string {
 	default:
 		return DimStyle.Render(Glyphs().Ring + " " + status)
 	}
+}
+
+// ClearFrame starts a new frame of a refreshing display. When clear is true
+// (an interactive terminal) it clears the screen; otherwise it emits a
+// timestamped separator so redirected output stays append-only — a log full
+// of clear-screen sequences is unreadable in an editor and unparseable by
+// tools, and `... | head` used to emit them forever.
+func ClearFrame(clear bool) {
+	if clear {
+		fmt.Fprint(Out, "\033[2J\033[H")
+		return
+	}
+	g := Glyphs()
+	fmt.Fprintln(Out, DimStyle.Render(strings.Repeat(g.Rule, 8)+" "+time.Now().Format("15:04:05")+" "+strings.Repeat(g.Rule, 8)))
 }
 
 func Header(text string) {
@@ -296,7 +311,17 @@ func Banner(title, subtitle string) {
 	fmt.Fprintln(Out, box.Render(content))
 }
 
+// MetricBar renders a consumption-style bar where approaching max is BAD —
+// latency against a budget, disk against capacity. Green when low, red when
+// near the ceiling. For metrics where high is good (throughput against a
+// target), use MetricBarDir with higherIsBetter=true; using this one inverts
+// the color story.
 func MetricBar(label string, value, max float64) {
+	MetricBarDir(label, value, max, false)
+}
+
+// MetricBarDir renders a metric bar with an explicit direction of goodness.
+func MetricBarDir(label string, value, max float64, higherIsBetter bool) {
 	barWidth := 20
 	filled := int((value / max) * float64(barWidth))
 	if filled > barWidth {
@@ -308,11 +333,15 @@ func MetricBar(label string, value, max float64) {
 
 	bar := strings.Repeat(Glyphs().BarFull, filled) + strings.Repeat(Glyphs().BarEmpty, barWidth-filled)
 
-	barColor := Green
 	ratio := value / max
-	if ratio > 0.8 {
+	good := ratio
+	if !higherIsBetter {
+		good = 1 - ratio
+	}
+	barColor := Green
+	if good < 0.2 {
 		barColor = Red
-	} else if ratio > 0.5 {
+	} else if good < 0.5 {
 		barColor = Amber
 	}
 

--- a/scripts/check-cli-style.sh
+++ b/scripts/check-cli-style.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Style gate for the kates CLI: every color comes from cli/pkg/theme.
+#
+# WHY THIS EXISTS: the CLI's colors were once scattered across dozens of
+# hardcoded `lipgloss.Color("#…")` literals, so "green" meant five different
+# greens and the blue=OK / red=KO convention was applied file-by-file, or not
+# at all. The hex sweep moved every literal onto the semantic tokens in
+# cli/pkg/theme. This script is the assertion that keeps it that way: no new
+# hex literals, no raw ANSI escapes that bypass lipgloss's terminal handling.
+#
+# Usage:
+#   scripts/check-cli-style.sh          Run every check against tracked files.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+fail=0
+
+# ── No hardcoded hex colors ─────────────────────────────────────────────────
+# cli/pkg/theme is where tokens are defined; cli/cmd/theme.go's hex palette is
+# DATA (user-selectable theme definitions), not styling. Both are excluded —
+# everything else must use theme tokens.
+hex_offenders="$(git grep -n 'lipgloss\.Color("#' -- ':(glob)cli/**/*.go' \
+  ':(exclude)cli/pkg/theme' \
+  ':(exclude)cli/cmd/theme.go' \
+  || true)"
+
+if [[ -n "$hex_offenders" ]]; then
+  echo "  FAIL hardcoded lipgloss hex colors (use cli/pkg/theme tokens instead):"
+  echo "$hex_offenders" | sed 's/^/       /'
+  fail=1
+else
+  echo "  ok   no hardcoded lipgloss hex colors outside the theme"
+fi
+
+# ── No raw ANSI escape literals ─────────────────────────────────────────────
+# Raw \033[ / \x1b[ literals bypass lipgloss's capability detection (NO_COLOR,
+# TERM=dumb, piped output) — exactly the bugs check-cli-compat.sh exists to
+# catch. cli/output/ is the rendering layer and the only package allowed to
+# speak raw escapes (glyph fallbacks, the ClearFrame screen control).
+#
+# _test.go files are excluded: tests for escape-stripping necessarily embed
+# escapes as fixture DATA — they are inputs to assertions, not styling.
+#
+# cli/cmd/deploy_view.go is grandfathered: its remaining raw escapes are
+# removed by the wave-3 deploy summary rewrite, which may land in this same
+# PR. Once `grep -c 'x1b\[' cli/cmd/deploy_view.go` reports 0, delete the
+# exclude line below.
+esc_offenders="$(git grep -nE '\\033\[|\\x1b\[' -- ':(glob)cli/**/*.go' \
+  ':(exclude)cli/output/' \
+  ':(exclude)cli/**/*_test.go' \
+  || true)"
+
+if [[ -n "$esc_offenders" ]]; then
+  echo "  FAIL raw ANSI escape literals (route through cli/output or lipgloss):"
+  echo "$esc_offenders" | sed 's/^/       /'
+  fail=1
+else
+  echo "  ok   no raw ANSI escape literals outside cli/output/"
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+  echo
+  echo "CLI style violations found." >&2
+  exit 1
+fi
+echo "OK: CLI style checks pass"


### PR DESCRIPTION
## Why

Wave 3 of the CLI experience plan (#77 correctness, #78 foundations): the mechanical adoption pass those foundations exist for, plus the remaining correctness strikes.

## One palette, enforced

All **53 remaining hardcoded hex colors** swept onto `cli/pkg/theme` tokens across 10 files. Mapping was by **role, not hue** — a green success mark maps to `theme.Success` (blue) because the repo's documented convention is blue=OK/red=KO; conforming surfaces to the convention is the point of the sweep. Every swept surface also gains the tokens' light/dark adaptivity — the heatmap's cold-to-hot ramp was rebuilt from tokens and now works on light terminals, which its old dark-navy hexes never did.

`scripts/check-cli-style.sh` (wired into CI) makes regression impossible: no hex colors outside the theme, no raw escape literals outside `cli/output/` — the rendering layer that owns screen control. It caught a genuine boundary question during development: my own `ClearFrame` escape landed in `output.go`, and the exemption moved from "one file" to "the rendering package," which is the honest boundary.

## Honest meters

- **MetricBar grew a direction.** Its color scale is consumption-style (approaching max is bad) — right for latency, but `test get` used it for **throughput** against a hardcoded 100k ceiling: a fast test rendered *red*, a slow one healthy green. Throughput now draws against the test's own declared target; with no target it prints the number — a bar against an invented ceiling is the fabricated-histogram disease from #77 again.
- **The deploy summary shows the status recorded during the deploy** instead of re-running `helm status` per row (up to 5s each), which could contradict what the deploy just reported — a component that failed mid-apply can still hold a "deployed" release. The rewrite also removes the last CHA cursor-column escapes for runewidth-measured padding: one layout whether or not output is captured.
- **Phase numbers can no longer lie**: the `[1], [1], [2], [3], [4]` drift is fixed by generating numbers from a counter — collisions and gaps impossible by construction, with a test.

## Gated loops, one follower

- `top`, `dashboard`, and `cluster watch` cleared the screen in an infinite loop regardless of destination. `output.ClearFrame` clears only on a terminal; redirected output gets timestamped separators — append-only and parseable.
- **`test watch` folded onto `pollUntilDone`**: it was a second follower with its own rendering, polling, and (until #77) *different exit semantics* than `create --wait`. One follower now serves the whole family — rich TUI on a terminal, append-only lines everywhere else, same exit codes. Net −60 lines.

## Remaining strikes

- `test cleanup` panicked on short timestamps — and **deleted runs whose timestamps it couldn't parse**. Unknown age is not proven staleness.
- The `test create` wizard guard checked stdout only (piped stdin → huh crash); now the shared `IsInteractive`. Its inputs validate at the form — "10k" used to be silently discarded, creating a test with zero records.
- `kates deploy --dry-run` no longer writes StorageClasses into the cluster.

## Deferred, deliberately

The lab export-error fix: `claude/lab-tui-audit-fixes` diverges on `lab.go` by ~76 lines and should land first — touching the same file now manufactures conflicts. That branch is the one outstanding coordination item before Wave 4's lab work.

## Verification

- Full suite green (`./cmd/... ./pkg/... ./output/ ./tui/`), `go vet` clean.
- Both harnesses pass: `check-cli-compat.sh` (12 runtime checks on the real binary) and the new `check-cli-style.sh` (0 hex offenders, 0 escape offenders).
- New tests: phase-counter monotonicity; the sweep verified `grep 'lipgloss.Color("#' cli/cmd/` returns nothing.
- The hex sweep ran as a scoped subagent with per-file role mappings reviewed; its two judgment calls (cost total → `Highlight` to keep emphasis without claiming pass/fail; tldr category headers → `Secondary` despite their amber hue) are in the mapping table in the commit history.