### PR TITLE
feat(cli): one confirm, a lab that cancels and tells the truth (UX plan wave 4)

### DIFF
--- a/cli/cmd/confirm.go
+++ b/cli/cmd/confirm.go
@@ -1,0 +1,26 @@
+package cmd
+
+import "fmt"
+
+// confirm is the CLI's one yes/no prompt. Every command-level confirmation
+// goes through here — the repo previously had three hand-rolled
+// implementations (bufio.Scanner, two fmt.Scanln variants), one of which
+// failed OPEN on closed stdin and deleted a Kafka topic without consent.
+//
+// Policy, uniform everywhere:
+//   - Default No. Enter, q, esc, ctrl+c, or anything that is not an explicit
+//     yes declines.
+//   - Without a terminal it REFUSES with an error rather than assuming either
+//     answer. Unattended runs state intent with the command's --yes flag.
+//
+// Callers decide what a decline means, but per the exit-code contract a
+// declined destructive action returns a non-nil error: a script that forgot
+// --yes must fail loudly, not report success.
+func confirm(question string) (bool, error) {
+	if !IsInteractive() {
+		return false, fmt.Errorf("cannot prompt for confirmation without a terminal — pass --yes to proceed unattended")
+	}
+	// confirmPrompt (cluster_picker.go) is the single rendering engine: a
+	// themed bubbletea model, already default-No.
+	return confirmFn(question)
+}

--- a/cli/cmd/deploy_recovery.go
+++ b/cli/cmd/deploy_recovery.go
@@ -3,12 +3,9 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
 	"time"
 
 	"github.com/bmscomp/kates/cli/output"
-	"golang.org/x/term"
 )
 
 // DeployError wraps a component deployment failure with context for retry/display.
@@ -49,17 +46,11 @@ func retryableHelmDeploy(ctx context.Context, componentID string, maxRetries int
 			}
 
 			// Check if we can prompt the user
-			if !term.IsTerminal(int(os.Stdin.Fd())) {
-				// Non-TTY: fail immediately
-				break
-			}
-
-			// Interactive retry prompt
-			fmt.Printf("\n  %s Retry %s? [y/N]: ", output.WarningStyle.Render("⚠"), componentID)
-			var response string
-			fmt.Scanln(&response)
-			response = strings.TrimSpace(strings.ToLower(response))
-			if response != "y" && response != "yes" {
+			// One confirm implementation for the whole CLI. confirm refuses
+			// without a terminal, which covers the old explicit TTY check.
+			fmt.Println()
+			ok, err := confirm(fmt.Sprintf("%s Retry %s?", output.WarningStyle.Render("⚠"), componentID))
+			if err != nil || !ok {
 				break
 			}
 			continue

--- a/cli/cmd/kafka.go
+++ b/cli/cmd/kafka.go
@@ -516,18 +516,12 @@ var kafkaDeleteTopicCmd = &cobra.Command{
 		name := args[0]
 
 		if !deleteTopicYes {
-			fmt.Printf("%s Delete topic %s? This cannot be undone. [y/N] ",
-				errorBadge("⚠"), output.WarningStyle.Render(name))
-			scanner := bufio.NewScanner(os.Stdin)
-			// Fail CLOSED. The previous version only checked the answer when
-			// Scan() succeeded — on EOF or closed stdin it fell straight
-			// through to the delete, so `kates kafka delete-topic x </dev/null`
-			// destroyed the topic without consent. No answer is a "no".
-			if !scanner.Scan() {
-				return cmdErr("aborted: no confirmation received (stdin closed) — use --yes to skip the prompt")
+			ok, err := confirm(fmt.Sprintf("%s Delete topic %s? This cannot be undone.",
+				errorBadge("⚠"), output.WarningStyle.Render(name)))
+			if err != nil {
+				return cmdErr("aborted: " + err.Error())
 			}
-			answer := strings.TrimSpace(strings.ToLower(scanner.Text()))
-			if answer != "y" && answer != "yes" {
+			if !ok {
 				// A declined destructive action exits non-zero so scripts that
 				// forgot --yes fail loudly instead of reporting success.
 				return cmdErr("aborted: topic not deleted")

--- a/cli/cmd/kyverno_apply.go
+++ b/cli/cmd/kyverno_apply.go
@@ -120,12 +120,16 @@ It uses Helm to apply the exact configuration needed.`,
 		}
 
 		if !kyvernoApplyYes {
-			fmt.Print("Apply these policies? [y/N]: ")
-			var response string
-			fmt.Scanln(&response)
-			if strings.ToLower(strings.TrimSpace(response)) != "y" {
-				output.Warn("Aborted by user.")
-				return nil
+			// The old prompt had no TTY guard — a piped run hit Scanln, read
+			// EOF, and "aborted" with exit 0, indistinguishable from success.
+			// confirm() refuses without a terminal, and declining is now
+			// non-zero per the exit-code contract.
+			ok, err := confirm("Apply these policies?")
+			if err != nil {
+				return cmdErr("aborted: " + err.Error())
+			}
+			if !ok {
+				return cmdErr("aborted: policies not applied")
 			}
 		}
 

--- a/cli/tui/lab.go
+++ b/cli/tui/lab.go
@@ -139,6 +139,10 @@ type labProgressMsg struct {
 	records    int64
 	throughput float64
 	latency    float64
+	// pollErr carries a failed poll to the status line. Retrying is correct —
+	// silence about WHY the spinner spins is the bug this fixes: polls used to
+	// fail invisibly for up to the 20-minute deadline.
+	pollErr string
 }
 
 func NewLab(c *client.Client, url string) LabModel {
@@ -166,7 +170,20 @@ func NewLab(c *client.Client, url string) LabModel {
 func RunLab(c *client.Client, url string) error {
 	m := NewLab(c, url)
 	p := tea.NewProgram(m, tea.WithAltScreen())
-	_, err := p.Run()
+	final, err := p.Run()
+	// Quitting mid-run used to cancel only the local context; the server-side
+	// test kept running, orphaned, burning cluster resources with nothing
+	// watching it. Best-effort cancel after the program exits — commands
+	// dispatched during Quit never run, so this cannot live inside Update.
+	if fm, ok := final.(LabModel); ok && fm.quitting && fm.runTestID != "" {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if cerr := c.CancelTest(ctx, fm.runTestID); cerr == nil {
+			fmt.Println("Cancelled running test " + fm.runTestID)
+		} else {
+			fmt.Println("Note: test " + fm.runTestID + " may still be running on the server (cancel failed: " + cerr.Error() + ")")
+		}
+	}
 	return err
 }
 
@@ -193,8 +210,18 @@ func (m LabModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "x":
 				if m.cancelFn != nil {
 					m.cancelFn()
-					if m.runTestID != "" {
-						_ = m.client.CancelTest(context.Background(), m.runTestID)
+					// Fire the server-side cancel as a command. It used to run
+					// synchronously HERE, inside Update — freezing the entire
+					// TUI for up to the 30s client timeout.
+					var cancelCmd tea.Cmd
+					if id := m.runTestID; id != "" {
+						c := m.client
+						cancelCmd = func() tea.Msg {
+							ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+							defer cancel()
+							_ = c.CancelTest(ctx, id)
+							return nil
+						}
 					}
 					m.running = false
 					m.runTestID = ""
@@ -203,6 +230,7 @@ func (m LabModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.medianResults = nil
 					m.warmupRemaining = 0
 					m.status = warnStyle.Render("⏹ Test cancelled")
+					return m, cancelCmd
 				}
 				return m, nil
 			}
@@ -326,12 +354,21 @@ func (m LabModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case "e":
 			if len(m.iterations) > 0 {
-				path := m.exportCSV()
-				m.status = healthyStyle.Render("✓ Exported to " + path)
+				// Report what actually happened. This used to render
+				// "✓ Exported" unconditionally — a full disk or read-only
+				// home directory produced a success message and no file.
+				if path, err := m.exportCSV(); err != nil {
+					m.status = warnStyle.Render("⚠ Export failed: " + err.Error())
+				} else {
+					m.status = healthyStyle.Render("✓ Exported to " + path)
+				}
 			}
 		case "w":
-			path := m.saveSession()
-			m.status = healthyStyle.Render("✓ Session saved to " + path)
+			if path, err := m.saveSession(); err != nil {
+				m.status = warnStyle.Render("⚠ Save failed: " + err.Error())
+			} else {
+				m.status = healthyStyle.Render("✓ Session saved to " + path)
+			}
 		case "L":
 			if path, ok := m.loadSession(); ok {
 				m.status = healthyStyle.Render("✓ Session loaded from " + path)
@@ -456,6 +493,11 @@ func (m LabModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.liveRecords = msg.records
 			m.liveThroughput = msg.throughput
 			m.liveLatency = msg.latency
+		}
+		if msg.pollErr != "" {
+			m.status = warnStyle.Render("⚠ poll failed (retrying): " + msg.pollErr)
+		} else if msg.hasStats {
+			m.status = filterActiveStyle.Render("⏳ Running iteration #" + fmt.Sprintf("%d", len(m.iterations)+1) + "…")
 		}
 		return m, m.pollTestOnce(msg.testID, msg.deadline, msg.maxWait)
 
@@ -1064,7 +1106,7 @@ func (m LabModel) pollTestOnce(testID string, deadline time.Time, maxWait time.D
 
 		updated, err := m.client.GetTest(context.Background(), testID)
 		if err != nil {
-			return labProgressMsg{testID: testID, deadline: deadline, maxWait: maxWait}
+			return labProgressMsg{testID: testID, deadline: deadline, maxWait: maxWait, pollErr: err.Error()}
 		}
 
 		status := strings.ToUpper(updated.Status)
@@ -1214,7 +1256,7 @@ func (m *LabModel) nextSweepStep() tea.Cmd {
 	return nil
 }
 
-func (m LabModel) exportCSV() string {
+func (m LabModel) exportCSV() (string, error) {
 	dir, _ := os.UserHomeDir()
 	path := filepath.Join(dir, fmt.Sprintf("kates-lab-%s.csv", time.Now().Format("20060102-150405")))
 
@@ -1239,8 +1281,10 @@ func (m LabModel) exportCSV() string {
 		sb.WriteString("\n")
 	}
 
-	_ = os.WriteFile(path, []byte(sb.String()), 0644)
-	return path
+	if err := os.WriteFile(path, []byte(sb.String()), 0644); err != nil {
+		return "", err
+	}
+	return path, nil
 }
 
 type labSession struct {
@@ -1263,7 +1307,7 @@ type labSessionParam struct {
 	Current int    `json:"current"`
 }
 
-func (m LabModel) saveSession() string {
+func (m LabModel) saveSession() (string, error) {
 	dir, _ := os.UserHomeDir()
 	path := filepath.Join(dir, ".kates-lab-session.json")
 
@@ -1286,9 +1330,14 @@ func (m LabModel) saveSession() string {
 		})
 	}
 
-	data, _ := json.MarshalIndent(session, "", "  ")
-	_ = os.WriteFile(path, data, 0644)
-	return path
+	data, err := json.MarshalIndent(session, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return "", err
+	}
+	return path, nil
 }
 
 func (m *LabModel) loadSession() (string, bool) {

--- a/cli/tui/lab_test.go
+++ b/cli/tui/lab_test.go
@@ -187,8 +187,14 @@ func TestLabCancelKey(t *testing.T) {
 		m.warmupRemaining = 2
 
 		m, cmd := updateLab(t, m, keyMsg("x"))
-		if cmd != nil {
-			t.Error("cmd = non-nil, want nil after cancel")
+		// The server-side cancel is dispatched as a COMMAND. The old assertion
+		// (cmd == nil) enshrined the synchronous version, which ran the HTTP
+		// cancel inside Update and froze the whole TUI for up to the client's
+		// 30s timeout.
+		if cmd == nil {
+			t.Error("cmd = nil, want the async server-side cancel command")
+		} else {
+			_ = cmd() // must complete without panicking (10s-bounded cancel)
 		}
 		if m.running {
 			t.Error("running = true, want false")
@@ -660,7 +666,10 @@ func TestExportCSVColumnAlignment(t *testing.T) {
 		Params:     params,
 	}}
 
-	path := m.exportCSV()
+	path, exportErr := m.exportCSV()
+	if exportErr != nil {
+		t.Fatalf("exportCSV: %v", exportErr)
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("reading exported CSV: %v", err)
@@ -724,7 +733,10 @@ func TestSaveLoadSessionRoundTrip(t *testing.T) {
 		{Number: 1, Throughput: 100, P99Ms: 5, AvgMs: 2.5, ErrorRate: 0.1, TestID: "t1", Params: map[string]string{"acks": "all"}},
 		{Number: 2, Throughput: 200, P99Ms: 6, AvgMs: 3.5, ErrorRate: 0.2, TestID: "t2", Params: map[string]string{"acks": "1"}},
 	}
-	savedPath := a.saveSession()
+	savedPath, saveErr := a.saveSession()
+	if saveErr != nil {
+		t.Fatalf("saveSession: %v", saveErr)
+	}
 
 	b := NewLab(nil, "")
 	loadedPath, ok := b.loadSession()


### PR DESCRIPTION
## Why

Wave 4 of the CLI experience plan (#77 correctness, #78 foundations, #79 adoption): interaction consolidation and lab hardening.

## The blocker resolved itself — by being dead

The plan gated this wave on `claude/lab-tui-audit-fixes`. Investigating it: its PR (#69) **merged days ago**, and the branch's only remaining delta against `main` was the *old* code `main` has since deleted — including the fabricated latency histogram removed in #77. Merging it would have resurrected deleted code. The branch is deleted; `lab.go` is safe to work on.

## One confirm

`confirm()` is now the CLI's only yes/no prompt: default-No, themed, and it **refuses without a terminal** rather than assuming either answer — unattended runs state intent with `--yes`. Three hand-rolled prompts migrated:

- kafka delete-topic (#77's fail-closed scanner, now on the shared engine)
- the deploy retry prompt (its own TTY check subsumed)
- **kyverno apply — which had no TTY guard at all**: a piped run hit `Scanln`, read EOF, and "aborted" with exit 0, indistinguishable from success.

Declining a destructive action now exits non-zero at every site, uniformly.

## Lab hardening

- **'x' no longer freezes the TUI.** The server-side `CancelTest` ran *synchronously inside `Update`* — blocking every keystroke and render for up to the client's 30s timeout. Now a bounded async command. The existing test asserted `cmd == nil` after cancel — **enshrining the freeze** — and now asserts the async dispatch instead. (Same pattern as #77's duration test that asserted the 1000× bug: the test suite confirms what the code does, not what it should do, until someone checks.)
- **Quitting no longer orphans the server-side test.** ctrl+c cancelled only the local context; the test kept running on the cluster with nothing watching it. `RunLab` now fires a bounded best-effort cancel *after* the program exits — commands dispatched during `Quit` never run, so this cannot live inside `Update` — and reports whether it worked.
- **Poll failures surface in the status line** instead of retrying silently for up to the 20-minute deadline while the user watches a spinner.
- **Export and session-save tell the truth.** Both discarded `WriteFile` errors and rendered "✓ Exported" unconditionally — a full disk produced a success message and no file.

## Deferred to wave 5

Spinner/banner consolidation and lab de-islanding — P2 polish, and the plan's "five local banner copies" turned out to be **two** on inspection. Small enough to not hold this wave.

## Verification

- Full suite green, `go vet` clean, both CI harnesses pass (`check-cli-compat.sh`, `check-cli-style.sh`).
- Six files changed, all intentional — the lab edits that were deferred from #79 are now in, conflict-free.