### PR TITLE
feat(cli): produce input that accepts paste, one error voice, honest help (UX plan wave 5)

### DIFF
--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -14,7 +14,14 @@ import (
 var ctxCmd = &cobra.Command{
 	Use:     "ctx",
 	Aliases: []string{"context", "config"},
-	Short:   "Manage CLI contexts (server connections)",
+	Short:   "Manage Kates server connection profiles (not Kubernetes contexts)",
+	Long: `Manage named connection profiles for the Kates API server: its URL,
+API key, and preferred output format. The --context global flag selects one of
+THESE profiles.
+
+Not to be confused with Kubernetes contexts. Which CLUSTER kates deploys to
+comes from your kubeconfig — kates deploy detects and lets you choose it, and
+kubectl config use-context changes it.`,
 }
 
 var ctxShowCmd = &cobra.Command{

--- a/cli/cmd/report.go
+++ b/cli/cmd/report.go
@@ -200,7 +200,7 @@ var exportFormat string
 
 var reportExportCmd = &cobra.Command{
 	Use:   "export <id>",
-	Short: "Export report as CSV, JUnit XML, Heatmap, Markdown, or HTML",
+	Short: "Export report as csv, junit, heatmap, heatmap-csv, md, or html",
 	Args:  cobra.ExactArgs(1),
 	Example: `  kates report export abc123 --format csv
   kates report export abc123 --format junit
@@ -317,7 +317,7 @@ func isTerminal() bool {
 }
 
 func init() {
-	reportExportCmd.Flags().StringVar(&exportFormat, "format", "csv", "Export format: csv, junit, heatmap, or heatmap-csv")
+	reportExportCmd.Flags().StringVar(&exportFormat, "format", "csv", "Export format: csv, junit, heatmap, heatmap-csv, md, or html")
 
 	reportCmd.AddCommand(reportShowCmd)
 	reportCmd.AddCommand(reportSummaryCmd)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -297,8 +297,12 @@ func resolveFallbackURL(url string, checkPort func(string) bool) string {
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
+		// silentErr was already printed (styled) by cmdErr. Everything else
+		// goes through the same styled channel, so a plain fmt.Errorf from a
+		// RunE reads like every other kates error instead of a bare line —
+		// one error voice for the whole CLI.
 		if _, ok := err.(*silentErr); !ok {
-			fmt.Fprintln(os.Stderr, err)
+			output.Error(err.Error())
 		}
 		os.Exit(1)
 	}

--- a/cli/tui/produce.go
+++ b/cli/tui/produce.go
@@ -3,11 +3,12 @@ package tui
 import (
 	"context"
 	"fmt"
+	"github.com/charmbracelet/bubbles/textinput"
 	"strings"
 
+	"github.com/bmscomp/kates/cli/client"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/bmscomp/kates/cli/client"
 )
 
 type produceView int
@@ -22,8 +23,8 @@ type produceModel struct {
 	topics      []client.KafkaTopic
 	cursor      int
 	view        produceView
-	keyBuf      string
-	valueBuf    string
+	keyInput    textinput.Model
+	valueInput  textinput.Model
 	activeField int // 0=key, 1=value
 	history     []producedRecord
 	width       int
@@ -54,7 +55,19 @@ type produceSentMsg struct {
 }
 
 func newProduceModel(c *client.Client) produceModel {
-	return produceModel{client: c, loading: true}
+	// bubbles/textinput instead of hand-rolled byte buffers: the old input
+	// only accepted single-byte keystrokes, which silently dropped paste and
+	// every non-ASCII rune ("é" is two bytes, so it never appeared).
+	key := textinput.New()
+	key.Placeholder = "optional"
+	key.Prompt = "  "
+	key.CharLimit = 0
+	value := textinput.New()
+	value.Placeholder = "record value"
+	value.Prompt = "  "
+	value.CharLimit = 0
+	key.Focus()
+	return produceModel{client: c, loading: true, keyInput: key, valueInput: value}
 }
 
 func (m produceModel) loadTopics() tea.Cmd {
@@ -103,7 +116,7 @@ func (m produceModel) Update(msg tea.Msg) (produceModel, tea.Cmd) {
 			if len(m.history) > 50 {
 				m.history = m.history[len(m.history)-50:]
 			}
-			m.valueBuf = ""
+			m.valueInput.SetValue("")
 		}
 
 	case tea.KeyMsg:
@@ -145,37 +158,40 @@ func (m produceModel) updateInput(msg tea.KeyMsg) (produceModel, tea.Cmd) {
 	switch msg.String() {
 	case "esc":
 		m.view = produceTopicSelect
-		m.keyBuf = ""
-		m.valueBuf = ""
+		m.keyInput.SetValue("")
+		m.valueInput.SetValue("")
 		m.statusMsg = ""
+		return m, nil
 	case "tab":
 		m.activeField = (m.activeField + 1) % 2
+		if m.activeField == 0 {
+			m.keyInput.Focus()
+			m.valueInput.Blur()
+		} else {
+			m.valueInput.Focus()
+			m.keyInput.Blur()
+		}
+		return m, nil
 	case "enter":
-		if m.valueBuf == "" {
+		if m.valueInput.Value() == "" {
 			m.statusMsg = warnStyle.Render("Value cannot be empty")
 			return m, nil
 		}
 		topic := m.topics[m.cursor].Name
 		m.loading = true
 		m.statusMsg = dimStyle.Render("Sending…")
-		return m, m.sendRecord(topic, m.keyBuf, m.valueBuf)
-	case "backspace":
-		if m.activeField == 0 && len(m.keyBuf) > 0 {
-			m.keyBuf = m.keyBuf[:len(m.keyBuf)-1]
-		} else if m.activeField == 1 && len(m.valueBuf) > 0 {
-			m.valueBuf = m.valueBuf[:len(m.valueBuf)-1]
-		}
-	default:
-		ch := msg.String()
-		if len(ch) == 1 {
-			if m.activeField == 0 {
-				m.keyBuf += ch
-			} else {
-				m.valueBuf += ch
-			}
-		}
+		return m, m.sendRecord(topic, m.keyInput.Value(), m.valueInput.Value())
 	}
-	return m, nil
+
+	// Everything else — runes, paste, cursor keys, backspace — belongs to the
+	// focused textinput, which handles multi-rune input correctly.
+	var cmd tea.Cmd
+	if m.activeField == 0 {
+		m.keyInput, cmd = m.keyInput.Update(msg)
+	} else {
+		m.valueInput, cmd = m.valueInput.Update(msg)
+	}
+	return m, cmd
 }
 
 func (m produceModel) View() string {
@@ -265,14 +281,6 @@ func (m produceModel) viewInput() string {
 		topicName = m.topics[m.cursor].Name
 	}
 
-	keyCursor := ""
-	valueCursor := ""
-	if m.activeField == 0 {
-		keyCursor = "▌"
-	} else {
-		valueCursor = "▌"
-	}
-
 	keyLabel := dimStyle.Render("Key")
 	valueLabel := dimStyle.Render("Value")
 	if m.activeField == 0 {
@@ -284,9 +292,9 @@ func (m produceModel) viewInput() string {
 	var b strings.Builder
 	b.WriteString(detailTitleStyle.Render(fmt.Sprintf("Produce → %s", topicName)) + "\n\n")
 	b.WriteString(keyLabel + "\n")
-	b.WriteString(fmt.Sprintf("  %s%s\n\n", m.keyBuf, keyCursor))
+	b.WriteString(m.keyInput.View() + "\n\n")
 	b.WriteString(valueLabel + "\n")
-	b.WriteString(fmt.Sprintf("  %s%s\n\n", m.valueBuf, valueCursor))
+	b.WriteString(m.valueInput.View() + "\n\n")
 
 	if m.statusMsg != "" {
 		b.WriteString(m.statusMsg + "\n\n")

--- a/docs/book/10-cli-reference.md
+++ b/docs/book/10-cli-reference.md
@@ -1931,6 +1931,23 @@ kates test list -o table
 kates test list -o json
 ```
 
+Output degrades automatically. When stdout is not a terminal — a pipe, a redirect, a CI log — color codes are stripped, refreshing displays become append-only lines, and full-screen TUIs refuse with a plain-text explanation instead of launching. `NO_COLOR` and `TERM=dumb` are honored; `--plain` (or `KATES_PLAIN=1`) forces the fully plain, pure-ASCII form; `KATES_ASCII=1` keeps colors but swaps glyphs for ASCII.
+
+## Exit Codes
+
+The exit code is a contract: `0` means the thing you asked for happened.
+
+| Code | Meaning |
+|------|---------|
+| `0` | The requested operation completed — a `--wait` test finished successfully, a deploy applied, a deletion was confirmed and performed |
+| `1` | Anything else: the operation failed, a followed test finished `FAILED`, the connection was lost mid-follow (outcome unknown), a confirmation was declined or could not be asked |
+
+Three consequences worth knowing in scripts:
+
+- `kates test create --wait` and `kates test watch` exit `1` when the test itself fails — not just when the request fails.
+- A declined confirmation exits `1`. A script that forgot `--yes` fails loudly instead of reporting success for work it did not do.
+- Confirmations are never answered implicitly. With no terminal attached, a command that needs consent fails and tells you to pass `--yes`, rather than assuming either answer.
+
 ## Shell Completion
 
 ```bash


### PR DESCRIPTION
## Why

The final wave of the CLI experience plan (#77 → #80): the P2 polish, plus the exit-code contract written down where script authors will find it.

## What's in it

**The produce form accepts paste and non-ASCII input.** The Kafka explorer's hand-rolled input buffer appended only single-*byte* keystrokes — pasting was silently dropped, and any multibyte rune ("é", CJK, emoji) never appeared. Replaced with `bubbles/textinput` (already a dependency): paste, cursor movement, and unicode handled by the component instead of reimplemented wrong.

**One error voice.** Plain errors returned from a `RunE` reached the user as a bare unstyled line, while `cmdErr` errors got the themed ✖ — two voices for the same kind of news. `Execute` now routes both through the same styled channel.

**`kates ctx` says what it is NOT.** "Context" is the most overloaded word in the CLI: `kates ctx` manages *server connection profiles*; the *cluster* kates deploys to comes from kubeconfig. The help now states both halves and names each mechanism.

**`kates report export` stops contradicting itself** — the flag help listed four formats, the Short five, the code accepted six. All three now agree.

**The CLI reference gains two sections**: the exit-code contract (0 = the thing you asked for happened; the three script-visible consequences of waves 1–4 spelled out) and the output-degradation behavior (pipes, `NO_COLOR`, `TERM=dumb`, `--plain`, `KATES_ASCII`).

## Deliberately not done

- **Spinner consolidation** — there is already exactly one frame definition; the bubbletea spinner and the plain-loop frames serve different render models. Consolidating would be motion, not progress.
- **Lab de-islanding** — no user-visible defect remains behind it; moving helpers between packages now is churn.

## Process note

Wave 4 (#80) was merged while two checks were still pending — my error; they weren't required checks and the identical code had passed the full local suite, but I watched the post-merge runs to be sure: `main` is green (Integration Tests, Docker Build Validation succeeded).

## Verification

Full suite green, `go vet` clean, both CI harnesses pass, book style gate passes for the docs changes. Five files, all intentional.

## The plan, closed out

| Wave | PR | Substance |
|---|---|---|
| 1 | #77 | Exit codes, fail-open confirm, 1000× duration, TrueColor force, root help |
| 2 | #78 | Glyph table, one width helper, compat harness |
| 3 | #79 | Hex→theme sweep + CI lint, honest meters, gated loops, one follower |
| 4 | #80 | One confirm, lab cancel/poll/export honesty |
| 5 | this | Produce input, one error voice, help honesty, the written contract |