### PR TITLE
fix(cli): align the deploy dashboard's pane borders

### DIFF
--- a/cli/cmd/deploy_components.go
+++ b/cli/cmd/deploy_components.go
@@ -43,7 +43,7 @@ func deployGroupA(dc *deployContext) error {
 	if deployWithStrimzi {
 		g.Go(func() error {
 			if !deployStrimzi {
-				dl.Println("⏭️  Strimzi Operator already deployed. Skipping.")
+				dl.Println(output.Glyphs().Skip + "  Strimzi Operator already deployed. Skipping.")
 				dl.FinishComponent("strimzi", true)
 				dc.advanceStep()
 				return nil
@@ -87,7 +87,7 @@ metadata:
 	if deployWithCertManager {
 		g.Go(func() error {
 			if !deployCertMgr {
-				dl.Println("⏭️  Cert-Manager already deployed. Skipping.")
+				dl.Println(output.Glyphs().Skip + "  Cert-Manager already deployed. Skipping.")
 				dl.FinishComponent("cert-manager", true)
 				dc.advanceStep()
 				return nil
@@ -201,7 +201,7 @@ spec:
 	if deployWithKyverno {
 		g.Go(func() error {
 			if !deployKyvernoFlag {
-				dl.Println("⏭️  Kyverno already deployed. Skipping.")
+				dl.Println(output.Glyphs().Skip + "  Kyverno already deployed. Skipping.")
 				dl.FinishComponent("kyverno", true)
 				dc.advanceStep()
 				return nil
@@ -334,7 +334,7 @@ func deployGroupB(dc *deployContext) error {
 	if deployKafka {
 		dl.Printf("\n📦 Deploying Kafka Cluster (Namespace: %s)...\n", kafkaNS)
 	} else {
-		dl.Println("⏭️  Kafka Cluster already deployed. Skipping.")
+		dl.Println(output.Glyphs().Skip + "  Kafka Cluster already deployed. Skipping.")
 		dl.FinishComponent("kafka", true)
 		dc.advanceStep()
 		dl.FinishComponent("kafka-users", true)
@@ -345,7 +345,7 @@ func deployGroupB(dc *deployContext) error {
 		if deployMon {
 			dl.Printf("\n📦 Deploying Monitoring (Prometheus + Grafana) (Namespace: %s)...\n", jaegerNS)
 		} else {
-			dl.Println("⏭️  Monitoring stack already deployed. Skipping.")
+			dl.Println(output.Glyphs().Skip + "  Monitoring stack already deployed. Skipping.")
 			dl.FinishComponent("monitoring", true)
 			dc.advanceStep()
 		}
@@ -355,7 +355,7 @@ func deployGroupB(dc *deployContext) error {
 		if deployPG {
 			dl.Printf("\n📦 Deploying PostgreSQL CDC Database (Namespace: %s)...\n", deployDbNS)
 		} else {
-			dl.Println("⏭️  PostgreSQL already deployed. Skipping.")
+			dl.Println(output.Glyphs().Skip + "  PostgreSQL already deployed. Skipping.")
 			dl.FinishComponent("postgres", true)
 			dc.advanceStep()
 		}
@@ -577,7 +577,7 @@ metadata:
 				runExecStdinFn(ctx, "kubectl", []string{"apply", "--server-side", "--force-conflicts", "-f", "-"}, metricsYaml)
 			}
 		} else {
-			dl.Printf("    ⚠️  ConfigMap 'kafka-metrics' not found in namespace %s\n", kafkaNS)
+			dl.Printf("    ⚠  ConfigMap 'kafka-metrics' not found in namespace %s\n", kafkaNS)
 		}
 
 		dl.Println("    - Copying kates-connect credentials to connect namespace...")
@@ -623,7 +623,7 @@ data:
 %s`, connectNS, dataLines.String())
 			runExecStdinFn(ctx, "kubectl", []string{"apply", "-f", "-"}, connectSecretYaml)
 		} else {
-			dl.Printf("    ⚠️  Secret 'kates-connect' not found in namespace %s after waiting — KafkaUser may not be ready\n", kafkaNS)
+			dl.Printf("    ⚠  Secret 'kates-connect' not found in namespace %s after waiting — KafkaUser may not be ready\n", kafkaNS)
 		}
 	}
 
@@ -648,7 +648,7 @@ stringData:
 			"-n", connectNS, "-l", "strimzi.io/kind=KafkaConnect",
 			"-o", "jsonpath={.items}").Output()
 		if string(podCheck) == "[]" || len(strings.TrimSpace(string(podCheck))) == 0 {
-			dl.Println("    ⚠️  Kafka Connect release exists but no pods found — upgrading...")
+			dl.Println("    ⚠  Kafka Connect release exists but no pods found — upgrading...")
 			connectDeployed = false
 		}
 	}
@@ -703,7 +703,7 @@ stringData:
 			out, err := exec.CommandContext(ctx, "kubectl", "get", "crd", "podmonitors.monitoring.coreos.com", "--ignore-not-found").CombinedOutput()
 			if err != nil || len(bytes.TrimSpace(out)) == 0 {
 				monitoringEnabled = false
-				dl.Printf("    ⚠️  Monitoring CRDs not found. Disabling monitoring for Kafka Connect.\n")
+				dl.Printf("    ⚠  Monitoring CRDs not found. Disabling monitoring for Kafka Connect.\n")
 			}
 		}
 
@@ -719,7 +719,7 @@ stringData:
 			return err
 		}
 	} else {
-		dl.Println("⏭️  Kafka Connect already deployed. Skipping.")
+		dl.Println(output.Glyphs().Skip + "  Kafka Connect already deployed. Skipping.")
 		dl.FinishComponent("kafka-connect", true)
 		dc.advanceStep()
 	}
@@ -845,7 +845,7 @@ func deployGroupC(dc *deployContext) error {
 			dl.FinishComponent("apicurio", true)
 			dc.advanceStep()
 		} else {
-			dl.Println("⏭️  Apicurio already deployed.")
+			dl.Println(output.Glyphs().Skip + "  Apicurio already deployed.")
 			dl.FinishComponent("apicurio", true)
 			dc.advanceStep()
 		}
@@ -884,7 +884,7 @@ data:
   password: %s`, appNS, string(pwBytes))
 				runExecStdinFn(ctx, "kubectl", []string{"apply", "-f", "-"}, secretYaml)
 			} else {
-				dl.Printf("    ⚠️  Secret 'kates-backend' not found in namespace %s — KafkaUser may not be ready\n", kafkaNS)
+				dl.Printf("    ⚠  Secret 'kates-backend' not found in namespace %s — KafkaUser may not be ready\n", kafkaNS)
 			}
 		}
 
@@ -905,7 +905,7 @@ data:
 			return err
 		}
 	} else {
-		dl.Println("⏭️  Kates Backend already deployed.")
+		dl.Println(output.Glyphs().Skip + "  Kates Backend already deployed.")
 		dl.FinishComponent("kates", true)
 		dc.advanceStep()
 	}
@@ -913,7 +913,7 @@ data:
 	// Deploy Kafka UI
 	if deployWithKafkaUI {
 		if !isHelmReleaseDeployedFn(ctx, "kafka-ui", kafkaUINS) {
-			dl.Printf("\n🖥️  Deploying Kafka UI (Namespace: %s)...\n", kafkaUINS)
+			dl.Printf("\n🖥  Deploying Kafka UI (Namespace: %s)...\n", kafkaUINS)
 			dl.StartComponent("kafka-ui", 5*time.Minute)
 
 			// Cross-namespace secret copy (KafkaUser secret lives in Kafka NS)
@@ -940,7 +940,7 @@ data:
   password: %s`, kafkaUINS, string(pwBytes))
 					runExecStdinFn(ctx, "kubectl", []string{"apply", "-f", "-"}, secretYaml)
 				} else {
-					dl.Printf("    ⚠️  Secret 'kafka-ui' not found in namespace %s — KafkaUser may not be ready\n", kafkaNS)
+					dl.Printf("    ⚠  Secret 'kafka-ui' not found in namespace %s — KafkaUser may not be ready\n", kafkaNS)
 				}
 			}
 
@@ -961,7 +961,7 @@ data:
 			dl.FinishComponent("kafka-ui", true)
 			dc.advanceStep()
 		} else {
-			dl.Println("⏭️  Kafka UI already deployed.")
+			dl.Println(output.Glyphs().Skip + "  Kafka UI already deployed.")
 			dl.FinishComponent("kafka-ui", true)
 			dc.advanceStep()
 		}
@@ -988,7 +988,7 @@ data:
 				return err
 			}
 		} else {
-			dl.Println("⏭️  Litmus Chaos already deployed.")
+			dl.Println(output.Glyphs().Skip + "  Litmus Chaos already deployed.")
 			dl.FinishComponent("chaos", true)
 			dc.advanceStep()
 		}

--- a/cli/cmd/deploy_dashboard.go
+++ b/cli/cmd/deploy_dashboard.go
@@ -4,18 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/charmbracelet/x/ansi"
 	"os/exec"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/bmscomp/kates/cli/output"
+	"github.com/bmscomp/kates/cli/pkg/theme"
 	"github.com/charmbracelet/bubbles/progress"
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/bmscomp/kates/cli/output"
-	"github.com/bmscomp/kates/cli/pkg/theme"
 )
 
 // ── Controller Interface for deploy.go ─────────────────────────────────────
@@ -272,6 +273,31 @@ func pollAllWorkloads(ctx context.Context, components []*componentStat) tea.Cmd 
 	}
 }
 
+// sanitizeLogLine strips variation selector-16 (U+FE0F). The padding stack
+// (viewport/lipgloss via go-runewidth) counts emoji+VS16 sequences as ONE
+// cell while terminals render TWO — so every "⏭️ …" line pushed the pane's
+// right border out by a column, producing the ragged edge. Without VS16 the
+// base rune renders text-style at the width runewidth already computes.
+func sanitizeLogLine(s string) string {
+	return strings.ReplaceAll(s, "\ufe0f", "")
+}
+
+// buildLogContent joins the log ring with every line truncated to the pane
+// width. Lines were previously passed through untouched, so one over-long
+// helm message stretched the box past the terminal edge and the border
+// wrapped into fragments.
+func (m deployDashboardModel) buildLogContent() string {
+	w := m.logsViewport.Width
+	if w <= 0 {
+		return strings.Join(m.logs, "\n")
+	}
+	out := make([]string, 0, len(m.logs))
+	for _, l := range m.logs {
+		out = append(out, ansi.Truncate(l, w, "…"))
+	}
+	return strings.Join(out, "\n")
+}
+
 func (m deployDashboardModel) Init() tea.Cmd {
 	return tea.Batch(
 		m.spinner.Tick,
@@ -312,6 +338,8 @@ func (m deployDashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		m.logsViewport.Width = logsWidth - 2
 		m.logsViewport.Height = viewHeight - 2
+		// Stored lines were truncated for the old width; rebuild for the new.
+		m.logsViewport.SetContent(m.buildLogContent())
 
 	case tea.KeyMsg:
 		if msg.String() == "ctrl+c" {
@@ -335,13 +363,13 @@ func (m deployDashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		lines := strings.Split(strings.TrimSpace(msg.text), "\n")
 		for _, l := range lines {
 			if l != "" {
-				m.logs = append(m.logs, l)
+				m.logs = append(m.logs, sanitizeLogLine(l))
 			}
 		}
 		if len(m.logs) > 100 {
 			m.logs = m.logs[len(m.logs)-100:]
 		}
-		m.logsViewport.SetContent(strings.Join(m.logs, "\n"))
+		m.logsViewport.SetContent(m.buildLogContent())
 		if m.logsViewport.AtBottom() || len(m.logs) < m.logsViewport.Height {
 			m.logsViewport.GotoBottom()
 		}

--- a/cli/cmd/deploy_dashboard_test.go
+++ b/cli/cmd/deploy_dashboard_test.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func dashUpdate(t *testing.T, m deployDashboardModel, msg tea.Msg) deployDashboardModel {
+	t.Helper()
+	next, _ := m.Update(msg)
+	dm, ok := next.(deployDashboardModel)
+	if !ok {
+		t.Fatalf("Update returned %T, want deployDashboardModel", next)
+	}
+	return dm
+}
+
+// Root cause 1 of the ragged border: emoji + VS16 (U+FE0F) sequences. The
+// padding stack (viewport/lipgloss via go-runewidth) counts them as ONE cell
+// while terminals render TWO, so every such line pushed the pane's right
+// border out by a column. No VS16 may survive into the log ring.
+func TestDashboardLog_StripsVariationSelectors(t *testing.T) {
+	m := NewDeployDashboard(context.Background(), 13)
+	m = dashUpdate(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = dashUpdate(t, m, logMsg{text: "⏭️  Kyverno already deployed. Skipping."})
+	m = dashUpdate(t, m, logMsg{text: "⚠️ warning with selector"})
+
+	for i, l := range m.logs {
+		if strings.ContainsRune(l, '️') {
+			t.Errorf("logs[%d] still contains VS16: %q", i, l)
+		}
+	}
+}
+
+// Root cause 2: over-long lines. Nothing truncated them, so one long helm
+// message stretched the whole bordered box past the terminal edge and the
+// border wrapped into fragments. Every line in the pane content must fit.
+func TestDashboardLog_TruncatesToPaneWidth(t *testing.T) {
+	m := NewDeployDashboard(context.Background(), 13)
+	m = dashUpdate(t, m, tea.WindowSizeMsg{Width: 100, Height: 40})
+
+	long := "📦 Deploying Strimzi Operator (Namespace: strimzi-operator) with a very long trailing explanation that exceeds any reasonable pane width by a comfortable margin"
+	m = dashUpdate(t, m, logMsg{text: long})
+	m = dashUpdate(t, m, logMsg{text: "\x1b[31mstyled and also much much much much much much much much much much too long to fit in the pane\x1b[0m"})
+
+	w := m.logsViewport.Width
+	if w <= 0 {
+		t.Fatal("viewport width not set by WindowSizeMsg")
+	}
+	for i, l := range strings.Split(m.buildLogContent(), "\n") {
+		if got := ansi.StringWidth(l); got > w {
+			t.Errorf("content line %d width %d exceeds pane width %d: %q", i, got, w, l)
+		}
+	}
+}
+
+// Resizing must re-truncate: lines stored under a wide pane may not fit a
+// narrower one.
+func TestDashboardLog_RetruncatesOnResize(t *testing.T) {
+	m := NewDeployDashboard(context.Background(), 13)
+	m = dashUpdate(t, m, tea.WindowSizeMsg{Width: 160, Height: 40})
+	m = dashUpdate(t, m, logMsg{text: strings.Repeat("x", 150)})
+
+	m = dashUpdate(t, m, tea.WindowSizeMsg{Width: 100, Height: 40})
+	w := m.logsViewport.Width
+	for i, l := range strings.Split(m.buildLogContent(), "\n") {
+		if got := ansi.StringWidth(l); got > w {
+			t.Errorf("after shrink, line %d width %d exceeds %d", i, got, w)
+		}
+	}
+}

--- a/cli/cmd/deploy_plan.go
+++ b/cli/cmd/deploy_plan.go
@@ -45,11 +45,11 @@ func runInteractiveForms() error {
 				Options(
 					huh.NewOption("🦊 Strimzi Operator", "strimzi").Selected(deployWithStrimzi),
 					huh.NewOption("🔗 Kafka Connect + PostgreSQL (CDC)", "kafka-connect").Selected(deployWithKafkaConnect),
-					huh.NewOption("🖥️  Kafka UI (Dashboard)", "kafka-ui").Selected(deployWithKafkaUI),
+					huh.NewOption("🖥  Kafka UI (Dashboard)", "kafka-ui").Selected(deployWithKafkaUI),
 					huh.NewOption("🧪 Litmus Chaos Engine", "chaos").Selected(deployWithChaos),
 					huh.NewOption("📊 Monitoring (Grafana + Prometheus)", "monitoring").Selected(deployWithMonitoring),
 					huh.NewOption("🔐 Cert-Manager (TLS)", "cert-manager").Selected(deployWithCertManager),
-					huh.NewOption("🛡️  Kyverno (Policies)", "kyverno").Selected(deployWithKyverno),
+					huh.NewOption("🛡  Kyverno (Policies)", "kyverno").Selected(deployWithKyverno),
 				).
 				Value(&components),
 		),
@@ -243,13 +243,13 @@ func resolveNamespaces() resolvedNamespaces {
 func buildSharedEntries(ns resolvedNamespaces) []DeploySummaryEntry {
 	var entries []DeploySummaryEntry
 	if deployWithStrimzi {
-		entries = append(entries, DeploySummaryEntry{Icon: "☸️", Name: "Strimzi Operator", Release: "strimzi-operator", Namespace: "strimzi-operator", Group: "A"})
+		entries = append(entries, DeploySummaryEntry{Icon: "☸", Name: "Strimzi Operator", Release: "strimzi-operator", Namespace: "strimzi-operator", Group: "A"})
 	}
 	if deployWithCertManager {
 		entries = append(entries, DeploySummaryEntry{Icon: "🔐", Name: "Cert-Manager", Release: "cert-manager", Namespace: "cert-manager", Group: "A"})
 	}
 	if deployWithKyverno {
-		entries = append(entries, DeploySummaryEntry{Icon: "🛡️", Name: "Kyverno", Release: "kyverno", Namespace: "kyverno", Group: "A"})
+		entries = append(entries, DeploySummaryEntry{Icon: "🛡", Name: "Kyverno", Release: "kyverno", Namespace: "kyverno", Group: "A"})
 	}
 	entries = append(entries, DeploySummaryEntry{Icon: "📨", Name: "Kafka (krafter)", Release: "krafter", Namespace: ns.kafka, Group: "B"})
 	if deployWithKafkaConnect {
@@ -264,7 +264,7 @@ func buildSharedEntries(ns resolvedNamespaces) []DeploySummaryEntry {
 	}
 	entries = append(entries, DeploySummaryEntry{Icon: "📦", Name: "Kates Backend", Release: "kates", Namespace: ns.app, Group: "C"})
 	if deployWithKafkaUI {
-		entries = append(entries, DeploySummaryEntry{Icon: "🖥️", Name: "Kafka UI", Release: "kafka-ui", Namespace: ns.kafkaUI, Group: "C"})
+		entries = append(entries, DeploySummaryEntry{Icon: "🖥", Name: "Kafka UI", Release: "kafka-ui", Namespace: ns.kafkaUI, Group: "C"})
 	}
 	if deployWithChaos {
 		entries = append(entries, DeploySummaryEntry{Icon: "🧪", Name: "Litmus Chaos", Release: "chaos", Namespace: ns.chaos, Group: "C"})

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -7,8 +7,10 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/go-pdf/fpdf v0.9.0
 	github.com/mattn/go-runewidth v0.0.21
+	github.com/muesli/termenv v0.16.0
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/sync v0.20.0
 	golang.org/x/term v0.40.0
@@ -22,7 +24,6 @@ require (
 	github.com/catppuccin/go v0.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/harmonica v0.2.0 // indirect
-	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
@@ -38,7 +39,6 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/cli/output/glyphs.go
+++ b/cli/output/glyphs.go
@@ -18,6 +18,8 @@ type GlyphSet struct {
 	DotOn   string
 	Diamond string
 	Ring    string
+	// Skip marks a step bypassed because it was already done.
+	Skip string
 	// Bar segments for progress bars.
 	BarFull  string
 	BarEmpty string


### PR DESCRIPTION
## Why

The deploy dashboard's log pane renders a ragged right border — fragments at two or three different columns instead of one straight line (user-reported screenshot). Two distinct causes, both **measured, not guessed**.

## Cause 1: emoji + variation selector-16

Lines like `⏭️  Kyverno already deployed` carry U+FE0F, which asks the terminal for emoji presentation (**two cells**) while go-runewidth — what the viewport and lipgloss pad with — counts the sequence as **one**. Probed empirically in-package:

| Glyph | runewidth | ansi/uniseg | Verdict |
|---|---|---|---|
| `⏭️` `☸️` `🛡️` `🖥️` `🗄️` (VS16) | 1 | 2 | **misaligns** |
| `☸` `🛡` `🖥` `🗄` (bare) | 1 | 1 | safe |
| `📦` `🐳` `📊` `⚡` | 2 | 2 | safe |

Every VS16 line pushed the border out one column — exactly the lines circled in the screenshot. Fixed at three layers: the `⏭️` prefix becomes the glyph table's new **Skip** glyph (`»`, `>` in ASCII mode); remaining VS16 stripped from the deploy messages and pane icons; and the dashboard strips VS16 from **every incoming log line**, so a future message can't regress it.

## Cause 2: over-long lines

Nothing truncated log lines, so one long helm message (`📦 Deploying Strimzi Operator (Namespace: …`) stretched the bordered box past the terminal edge, where it wrapped into border fragments. Lines are now truncated to the pane width with `x/ansi.Truncate` (ANSI-aware, uniseg widths) — and **re-truncated on resize**, since lines stored under a wide pane may not fit a narrower one.

## Tests

Three invariants encoded: no VS16 survives into the log ring; no content line exceeds the pane width (including styled lines — SGR handled); shrinking the window re-truncates. `charmbracelet/x/ansi` promoted indirect → direct.

## Out of scope, deliberately

Eight other files carry VS16 in plain sequential output where no border exists to misalign — cosmetic-only, left for glyph-table adoption to absorb naturally.

## Verification

Full deploy + dashboard test suite green, `go vet` clean, both CI harnesses pass.