### PR TITLE
fix(cli): dashboard header and panes share one row width

### DIFF
--- a/cli/cmd/deploy_dashboard.go
+++ b/cli/cmd/deploy_dashboard.go
@@ -328,7 +328,13 @@ func (m deployDashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			compWidth = 50
 		}
 		m.compWidth = compWidth - 2
-		logsWidth := msg.Width - compWidth - 4 // 4 for spacing/margins
+
+		// One row width for the whole dashboard: header and panes must end at
+		// the same column. The header renders at msg.Width-2 total (content
+		// width + its border), while the old pane math produced msg.Width-4 —
+		// so the panes row sat 2-4 columns short of the header's right edge.
+		rowWidth := msg.Width - 2
+		logsWidth := rowWidth - compWidth // rendered log pane incl. its border
 		if logsWidth < 20 {
 			logsWidth = 20
 		}
@@ -588,7 +594,9 @@ func (m deployDashboardModel) View() string {
 		Padding(0, 1).
 		Border(lipgloss.RoundedBorder(), true).
 		BorderForeground(theme.Accent).
-		Width(m.width - 2)
+		// Content width; +2 border columns renders the header at m.width-2 —
+		// the same rowWidth the panes fill, so the right edges align.
+		Width(m.width - 4)
 
 	headerContent := fmt.Sprintf("📦 Kates Cluster Deployment: %s %.0f%% (%d/%d Steps) │ Helm: %s", bar, pct*100, m.currentStep, m.totalSteps, m.helmVersion)
 	out.WriteString(headerStyle.Render(headerContent) + "\n")

--- a/cli/cmd/deploy_dashboard_test.go
+++ b/cli/cmd/deploy_dashboard_test.go
@@ -73,3 +73,30 @@ func TestDashboardLog_RetruncatesOnResize(t *testing.T) {
 		}
 	}
 }
+
+// The header box and the panes row must end at the same column. The header
+// rendered at m.width while the panes row filled m.width-4, so the dashboard's
+// right edge was a staircase: header sticking out past the panes below it.
+func TestDashboardRowsShareOneWidth(t *testing.T) {
+	for _, w := range []int{80, 100, 120, 160} {
+		m := NewDeployDashboard(context.Background(), 13)
+		m = dashUpdate(t, m, tea.WindowSizeMsg{Width: w, Height: 40})
+		m = dashUpdate(t, m, logMsg{text: "a log line"})
+
+		view := m.View()
+		var topBorders []int
+		for _, line := range strings.Split(view, "\n") {
+			if strings.Contains(line, "╭") {
+				topBorders = append(topBorders, ansi.StringWidth(line))
+			}
+		}
+		// Two top-border lines: the header box, and the joined panes row.
+		if len(topBorders) < 2 {
+			t.Fatalf("width %d: found %d top-border lines, want 2", w, len(topBorders))
+		}
+		if topBorders[0] != topBorders[1] {
+			t.Errorf("width %d: header renders %d cols, panes row %d — right edges misaligned",
+				w, topBorders[0], topBorders[1])
+		}
+	}
+}


### PR DESCRIPTION
## Why

The deploy dashboard's right edge was a staircase (user-reported screenshot): the blue header box ended 2–4 columns to the right of the panes below it.

## The arithmetic

- **Header**: content `Width(m.width-2)` + 2 border columns → rendered at **`m.width`**.
- **Panes row**: comp pane `compWidth` + log pane `m.width - compWidth - 4` → rendered at **`m.width - 4`**.

Two independent width computations for rows that must visually agree — so they didn't.

## The fix

One `rowWidth = m.width - 2` drives both: the header's content width becomes `m.width-4` (rendered box = rowWidth), and the log viewport takes `rowWidth - compWidth - 2` (joined panes row = rowWidth). The rows can't drift apart again because they are the same number. The log pane also gains two columns of usable width.

## Test

At 80/100/120/160 columns, the two `╭` top-border lines of the rendered View — header box and joined panes row — must measure identically (`ansi.StringWidth`). Fails before the fix, passes after.

## Verification

Deploy + dashboard suites green, `go vet` clean, both CI harnesses pass. Log truncation follows the viewport width automatically, so #82's invariants hold at the new width (covered by the existing tests).