### PR TITLE
fix(cli): deploy summary tells one story — statuses recorded, counted, and aligned

### DIFF
--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -204,6 +204,17 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		return runDeployDryRun(sharedEntries)
 	}
 
+	// Record each component's outcome BEFORE the pipeline runs, from the same
+	// predicate the skip logic uses: a release that already exists gets skipped
+	// ("already present"), one that does not gets deployed. Status was never
+	// recorded at all before this — the summary's table read the empty string
+	// as "Skipped" while its footer counted the same empty string as
+	// "deployed", producing eight Skipped rows above "8 components deployed
+	// successfully!".
+	markEntryStatuses(sharedEntries, func(release, namespace string) bool {
+		return isHelmReleaseDeployedFn(context.Background(), release, namespace)
+	})
+
 	// 4. Execution Plan (Helm)
 	PrintPhaseHeader(nextDeployPhase(), "Executing Deployment Pipeline")
 

--- a/cli/cmd/deploy_dashboard_test.go
+++ b/cli/cmd/deploy_dashboard_test.go
@@ -100,3 +100,46 @@ func TestDashboardRowsShareOneWidth(t *testing.T) {
 		}
 	}
 }
+
+// The summary's table and footer must agree. They previously interpreted the
+// (never-recorded) empty status independently: the table rendered "Skipped"
+// while the footer counted "deployed" — eight Skipped rows above
+// "8 components deployed successfully!".
+func TestClassifyStatus_UnrecordedIsUnknownNotBoth(t *testing.T) {
+	if got := classifyStatus(""); got != "unknown" {
+		t.Errorf("classifyStatus(\"\") = %q — the empty status must be visibly unknown, not silently success or skip", got)
+	}
+	for _, s := range []string{"deployed", "skipped", "failed"} {
+		if got := classifyStatus(s); got != s {
+			t.Errorf("classifyStatus(%q) = %q", s, got)
+		}
+	}
+}
+
+func TestMarkEntryStatuses(t *testing.T) {
+	entries := []DeploySummaryEntry{
+		{Release: "strimzi-operator", Namespace: "strimzi-operator"},
+		{Release: "krafter", Namespace: "kafka"},
+		{Release: "kates", Namespace: "kates"},
+	}
+
+	// Everything already present: components are skipped — except Strimzi,
+	// which is reconciled unconditionally and therefore always does work.
+	markEntryStatuses(entries, func(string, string) bool { return true })
+	if entries[0].Status != "deployed" {
+		t.Errorf("strimzi = %q, want deployed (reconciled every run)", entries[0].Status)
+	}
+	for _, e := range entries[1:] {
+		if e.Status != "skipped" {
+			t.Errorf("%s = %q, want skipped when already present", e.Release, e.Status)
+		}
+	}
+
+	// Nothing present: everything deploys.
+	markEntryStatuses(entries, func(string, string) bool { return false })
+	for _, e := range entries {
+		if e.Status != "deployed" {
+			t.Errorf("%s = %q, want deployed on fresh cluster", e.Release, e.Status)
+		}
+	}
+}

--- a/cli/cmd/deploy_view.go
+++ b/cli/cmd/deploy_view.go
@@ -99,7 +99,7 @@ func RenderDeployDashboard(ctx context.Context, entries []DeploySummaryEntry, el
 
 	var deployedCount, skippedCount, failedCount int
 	for _, e := range entries {
-		switch e.Status {
+		switch classifyStatus(e.Status) {
 		case "failed":
 			failedCount++
 		case "skipped":
@@ -111,7 +111,7 @@ func RenderDeployDashboard(ctx context.Context, entries []DeploySummaryEntry, el
 
 	if failedCount > 0 {
 		fmt.Println(lipgloss.NewStyle().Bold(true).Foreground(clrRed).
-			Render(fmt.Sprintf("  ⚠️  %d deployed, %d failed", deployedCount, failedCount)))
+			Render(fmt.Sprintf("  %s %d deployed, %d failed", output.Glyphs().Warn, deployedCount, failedCount)))
 		for _, e := range entries {
 			if e.Status == "failed" && e.Error != "" {
 				fmt.Printf("     %s %s: %s\n",
@@ -120,9 +120,18 @@ func RenderDeployDashboard(ctx context.Context, entries []DeploySummaryEntry, el
 					lipgloss.NewStyle().Foreground(clrDim).Render(e.Error))
 			}
 		}
+	} else if deployedCount == 0 && skippedCount > 0 {
+		// The state the old footer lied about: nothing was deployed because
+		// everything already was. "8 deployed successfully!" over a column of
+		// skips contradicted the table two lines above it.
+		fmt.Println(lipgloss.NewStyle().Bold(true).Foreground(clrGreen).
+			Render(fmt.Sprintf("  %s All %d components already deployed — nothing to do", output.Glyphs().Check, skippedCount)))
+	} else if skippedCount > 0 {
+		fmt.Println(lipgloss.NewStyle().Bold(true).Foreground(clrGreen).
+			Render(fmt.Sprintf("  %s %d deployed, %d already present", output.Glyphs().Check, deployedCount, skippedCount)))
 	} else {
 		fmt.Println(lipgloss.NewStyle().Bold(true).Foreground(clrGreen).
-			Render(fmt.Sprintf("  ✅ %d components deployed successfully!", deployedCount)))
+			Render(fmt.Sprintf("  %s %d components deployed successfully", output.Glyphs().Check, deployedCount)))
 	}
 
 	fmt.Println()
@@ -139,6 +148,37 @@ const (
 	summaryNsWidth   = 18
 )
 
+// markEntryStatuses records each component's outcome from the same predicate
+// the skip logic uses: already present → "skipped", absent → about to be
+// "deployed". Strimzi is the exception — it is reconciled unconditionally
+// (its pre-upgrade hook keeps the CRDs current), so work happens every run.
+func markEntryStatuses(entries []DeploySummaryEntry, present func(release, namespace string) bool) {
+	for i := range entries {
+		if entries[i].Release == "strimzi-operator" {
+			entries[i].Status = "deployed"
+			continue
+		}
+		if present(entries[i].Release, entries[i].Namespace) {
+			entries[i].Status = "skipped"
+		} else {
+			entries[i].Status = "deployed"
+		}
+	}
+}
+
+// classifyStatus is the ONE interpretation of a recorded component status.
+// The table renderer and the footer counter both use it — they previously
+// each had their own switch, and the empty string meant "Skipped" to one and
+// "deployed" to the other.
+func classifyStatus(s string) string {
+	switch s {
+	case "deployed", "skipped", "failed":
+		return s
+	default:
+		return "unknown"
+	}
+}
+
 // padCell pads a raw (unstyled) cell to a display width, measured with
 // runewidth so emoji and CJK count their true two cells. Padding happens
 // BEFORE styling: ANSI sequences are zero-width and must not enter the math.
@@ -150,21 +190,34 @@ func padCell(s string, w int) string {
 	return s + strings.Repeat(" ", gap)
 }
 
-// printRow renders one summary row from the status recorded during deploy
-// ("deployed", "skipped", "failed").
+// printRow renders one summary row from the status recorded during deploy.
 func printRow(icon, name, namespace, status string) {
 	g := output.Glyphs()
-	nameCol := lipgloss.NewStyle().Bold(true).Foreground(clrText).Render(padCell(icon+" "+name, summaryNameWidth))
+	// Icons vary between 1 and 2 display cells (☸ vs 🔐), which used to shift
+	// every name's start column by the difference — the left edge of the
+	// component names zig-zagged. Pad the icon to a fixed 2-cell cell first.
+	iconPad := 2 - visualWidth(icon)
+	if iconPad < 0 {
+		iconPad = 0
+	}
+	cell := icon + strings.Repeat(" ", iconPad) + " " + name
+	nameCol := lipgloss.NewStyle().Bold(true).Foreground(clrText).Render(padCell(cell, summaryNameWidth))
 	nsCol := lipgloss.NewStyle().Foreground(clrDim).Render(padCell(namespace, summaryNsWidth))
 
 	var statusStr string
-	switch status {
+	switch classifyStatus(status) {
 	case "deployed":
 		statusStr = lipgloss.NewStyle().Bold(true).Foreground(clrGreen).Render(g.Check + " Deployed")
 	case "failed":
 		statusStr = lipgloss.NewStyle().Bold(true).Foreground(clrRed).Render(g.Cross + " Failed")
+	case "skipped":
+		// Dim, not warning-orange: a component that was already running is a
+		// fine state, not a caution.
+		statusStr = lipgloss.NewStyle().Foreground(clrDim).Render(g.Ring + " Already present")
 	default:
-		statusStr = lipgloss.NewStyle().Foreground(clrOrange).Render(g.Ring + " Skipped")
+		// A status nothing recorded is a bug worth seeing, not disguising as
+		// either success or a skip.
+		statusStr = lipgloss.NewStyle().Foreground(clrOrange).Render(g.Warn + " Unknown")
 	}
 
 	fmt.Printf("  %s%s%s\n", nameCol, nsCol, statusStr)


### PR DESCRIPTION
## Why

User-reported screenshot: eight rows of `○ Skipped` directly above `✅ 8 components deployed successfully!` — the table and the footer contradict each other **in the same view**.

## Root cause: nobody ever wrote the status

`DeploySummaryEntry.Status` was never recorded anywhere. `buildSharedEntries` creates entries without it; nothing sets it during the deploy. The empty string then hit two independent switches:

- the row renderer's `default:` branch → **"Skipped"**
- the footer counter's `default:` branch → **`deployedCount++`**

Same nothing, two opposite stories. (#79 made the table read the recorded status — which turned out to be recorded by no one; the old code had masked the gap by re-querying helm per row.)

## The fix

**Record it** — once, up front, race-free, from the *same predicate the skip logic uses* (`isHelmReleaseDeployedFn`): already present → `skipped`, absent → `deployed`. Strimzi is the deliberate exception: it's reconciled unconditionally (its pre-upgrade hook keeps CRDs current), so it's always `deployed`.

**One interpretation** — `classifyStatus()` feeds both the renderer and the counter, so they cannot diverge again. An unrecorded status renders as a visible **"Unknown"** rather than masquerading as either success or a skip — if a future entry misses recording, you'll see it.

**Honest words, honest colors** — "All 8 components already deployed — nothing to do" for your exact screenshot's state; "X deployed, Y already present" for mixes. Skipped rows render **dim** ("Already present"), not warning-orange: a component that was already running is a fine state, not a caution.

**Aligned icons** (the second circle) — icons vary between 1 and 2 display cells (`☸` vs `🔐`), which shifted each component name's start column by the difference. Icons now pad to a fixed 2-cell column, so the names form a straight left edge.

## Tests

- `classifyStatus("")` must be `"unknown"` — the divergence killer.
- `markEntryStatuses`: present → skipped, absent → deployed, Strimzi always deployed.

## Verification

Deploy + dashboard suites green, `go vet` clean, both CI harnesses pass.