### PR TITLE
chore: pin charts to the v1.21.0 images

### DIFF
--- a/charts/connect-cluster/values.yaml
+++ b/charts/connect-cluster/values.yaml
@@ -15,7 +15,7 @@ extraLabels: {}
 
 # -- Test images used in Helm test pods
 testImages:
-  kubectl: "ghcr.io/bmscomp/kates-tester:1.17.0"
+  kubectl: "ghcr.io/bmscomp/kates-tester:1.21.0"
 
 # -- Number of Kafka Connect worker replicas
 replicas: 3

--- a/charts/kafka-cluster/values.yaml
+++ b/charts/kafka-cluster/values.yaml
@@ -20,9 +20,9 @@ global:
 # Per-component image references for test pods and utilities.
 # -- Test images
 testImages:
-  kafka: "ghcr.io/bmscomp/kates-tester:1.17.0"
+  kafka: "ghcr.io/bmscomp/kates-tester:1.21.0"
   bash: "bash:5.2"
-  kubectl: "ghcr.io/bmscomp/kates-tester:1.17.0"
+  kubectl: "ghcr.io/bmscomp/kates-tester:1.21.0"
 
 kafka:
   # KRaft metadata version, pinned one step behind the Kafka version per the

--- a/charts/kates/values.yaml
+++ b/charts/kates/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Image repository
   repository: ghcr.io/bmscomp/kates
   # -- Image tag
-  tag: "1.18.3"
+  tag: "1.21.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/strimzi-operator/values.yaml
+++ b/charts/strimzi-operator/values.yaml
@@ -44,7 +44,7 @@ strimziVersion: "1.1.0"
 # tests). The operator's own image comes from the subchart.
 testImages:
   # -- kubectl image used by the CRD-upgrade hook Job and the Helm tests
-  kubectl: "ghcr.io/bmscomp/kates-tester:1.17.0"
+  kubectl: "ghcr.io/bmscomp/kates-tester:1.21.0"
 
 # ── CRD lifecycle ────────────────────────────────────────────────────────────
 # Closes the gap Helm leaves: crds/ is applied on install and never on upgrade.


### PR DESCRIPTION
## Why

The v1.21.0 release (#86 + tag) published all four images; the chart pins still pointed at the previous release. This is the customary follow-up chore, kept separate so the charts never referenced images that didn't exist yet.

## What

| Pin | From | To |
|---|---|---|
| `charts/kates` backend `image.tag` | `1.18.3` | `1.21.0` |
| `kates-tester` test-pod image (kafka-cluster ×2, strimzi-operator, connect-cluster) | `1.17.0` | `1.21.0` |

The connect image pin (`ghcr.io/bmscomp/connect:3.6.0`) is already current — it tracks the Debezium version, not the kates release. All five new pins verified present in the registry.

## Scope

Values-only — no `Chart.yaml` touched, so this doesn't trip the version-matrix or chart-table gates. All four charts render; `check-versions.sh` (five-way Strimzi pin) stays green.

## ⚠️ Separate issue found on main — not fixed here

While verifying, I found the **version matrix on `main` is already out of sync**, from two prior `[skip ci]` commits that bumped chart appVersions without regenerating it:

- `115bd3a chore: bump chart appVersions to [skip ci]` set `kates-chaos` appVersion to **1.21.0**
- `ef610af chore: bump connect-cluster appVersion to [skip ci]` set `connect-cluster` to **3.6.0**

The committed matrix in `appendix-d-versions.md` still says `4.3.0` / `3.28.0`, so **the next PR that touches any `charts/*/Chart.yaml` will fail the Docs gate.** Worse, `kates-chaos` appVersion `1.21.0` contradicts that chart's own comment (*"Tracks the LitmusChaos execution-plane version"* → should be `3.28.0`).

I left this alone deliberately: it's a judgment call — regenerate the matrix to bless the current values, or correct `kates-chaos` back to `3.28.0` first. Happy to do either once you decide.