### PR TITLE
fix(chaos): restore kates-chaos appVersion, resync stale docs gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Kates ships its platform as independently versioned Helm charts, composable via 
 | Chart | Version | App Version | Description |
 |:------|:--------|:------------|:------------|
 | [`apicurio-registry`](charts/apicurio-registry/) | 0.1.5 | 3.3.0 | A Helm chart for Kubernetes of Apicurio Registry |
-| [`connect-cluster`](charts/connect-cluster/) | 1.3.0 | 4.3.0 | A Helm chart for deploying Strimzi Kafka Connect clusters |
+| [`connect-cluster`](charts/connect-cluster/) | 1.3.0 | 3.6.0 | A Helm chart for deploying Strimzi Kafka Connect clusters |
 | [`headlamp`](charts/headlamp/) | 0.1.0 | 0.40.1 | Headlamp — Kubernetes Dashboard for cluster visualization and management |
 | [`kafka-cluster`](charts/kafka-cluster/) | 0.2.0 | 4.3.0 | Strimzi-based Kafka cluster deployment with KRaft, zone-aware broker pools, and full observability |
 | [`kafka-ui`](charts/kafka-ui/) | 0.3.0 | v1.5.0 | A Helm chart for deploying Kafka UI (Kafbat) with Strimzi SCRAM-SHA-512 authentication |

--- a/charts/kates-chaos/Chart.yaml
+++ b/charts/kates-chaos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kates-chaos
 version: 2.0.0
 # Tracks the LitmusChaos execution-plane version this chart deploys.
-appVersion: "1.21.0"
+appVersion: "3.28.0"
 description: Kates Chaos Engineering — wraps the LitmusChaos execution plane (operator, exporter, CRDs) with Kafka-specific RBAC, experiment/engine templating, and monitoring
 home: https://github.com/bmscomp/kates
 sources:

--- a/docs/book/appendix-d-versions.md
+++ b/docs/book/appendix-d-versions.md
@@ -15,7 +15,7 @@ Every version the platform pins, in one place. This table is generated from the 
 | Quarkus | 3.15.7 | `kates/pom.xml` |
 | Go (CLI) | 1.25.7 | `cli/go.mod` |
 | `apicurio-registry` chart | 0.1.5 (app 3.3.0) | `charts/apicurio-registry/Chart.yaml` |
-| `connect-cluster` chart | 1.3.0 (app 4.3.0) | `charts/connect-cluster/Chart.yaml` |
+| `connect-cluster` chart | 1.3.0 (app 3.6.0) | `charts/connect-cluster/Chart.yaml` |
 | `headlamp` chart | 0.1.0 (app 0.40.1) | `charts/headlamp/Chart.yaml` |
 | `kafka-cluster` chart | 0.2.0 (app 4.3.0) | `charts/kafka-cluster/Chart.yaml` |
 | `kafka-ui` chart | 0.3.0 (app v1.5.0) | `charts/kafka-ui/Chart.yaml` |


### PR DESCRIPTION
## Why

Two prior `[skip ci]` commits left the **version-matrix and chart-table gates broken on `main`** — the next PR touching any `charts/*/Chart.yaml` would fail the Docs workflow. Found while doing the v1.21.0 image bump (#87).

## The two problems

**1. `kates-chaos` appVersion was a typo.** `115bd3a chore: bump chart appVersions to [skip ci]` blanket-set it `3.28.0 → 1.21.0`. But every other chart's appVersion tracks *the version of the thing it deploys*, not the kates release:

| Chart | appVersion | Tracks |
|---|---|---|
| connect-cluster | 3.6.0 | connect image / Debezium |
| kafka-cluster | 4.3.0 | Kafka |
| strimzi-operator | 1.1.0 | Strimzi |
| monitoring | 82.4.3 | kube-prometheus-stack |
| kates | 1.21.0 | the backend (this *is* the release) |
| **kates-chaos** | **~~1.21.0~~ → 3.28.0** | **LitmusChaos** |

`kates-chaos` deploys the LitmusChaos execution plane, so its appVersion is the LitmusChaos version — `3.28.0`, exactly as the chart's own comment says (*"Tracks the LitmusChaos execution-plane version"*) and as `versions.env` `LITMUS_VERSION` pins. Restored to its pre-`115bd3a` value.

**2. The generated tables never caught up to `ef610af`**, which set `connect-cluster` appVersion to `3.6.0` but also skipped CI. Regenerated `appendix-d-versions.md` and the README chart table: `connect-cluster` app `4.3.0 → 3.6.0`.

## Verification

Both gates green (`gen-version-matrix --check`, `gen-chart-table --check`), book style passes, kates-chaos chart still renders. This restores the Docs workflow to green for all future chart PRs.