### PR TITLE
fix(connect): tag the image by its full build identity, not Debezium alone

### DIFF
--- a/.github/workflows/publish-connect.yml
+++ b/.github/workflows/publish-connect.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
+      image_tag: ${{ steps.version.outputs.image_tag }}
       debezium_version: ${{ steps.version.outputs.debezium_version }}
       platforms: ${{ steps.set.outputs.platforms }}
       platform_matrix: ${{ steps.set.outputs.platform_matrix }}
@@ -61,9 +62,23 @@ jobs:
           fi
           echo "debezium_version=${DBZ_VERSION}" >> "$GITHUB_OUTPUT"
 
-          # Image version = Debezium version without .Final suffix
-          VERSION="${DBZ_VERSION%.Final}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          # Clean Debezium version (drop .Final): appVersion + moving alias tag.
+          DBZ_CLEAN="${DBZ_VERSION%.Final}"
+          echo "version=${DBZ_CLEAN}" >> "$GITHUB_OUTPUT"
+
+          # The image's identity is (Debezium, Kafka base). Tagging by Debezium
+          # ALONE meant a base bump (e.g. #74's Kafka 4.2.0 -> 4.3.0) did not
+          # move the tag, so connect:<debezium> silently changed content under a
+          # fixed name. Fold the Kafka base version into the tag.
+          KAFKA_VERSION=$(grep -m1 '^FROM quay.io/strimzi/kafka:' Dockerfile.connect \
+            | sed -E 's/.*-kafka-([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+          if [[ -z "${KAFKA_VERSION}" || "${KAFKA_VERSION}" == *FROM* ]]; then
+            echo "::error::could not parse Kafka version from the base FROM line"
+            exit 1
+          fi
+          IMAGE_TAG="${DBZ_CLEAN}-kafka-${KAFKA_VERSION}"
+          echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "connect image tag: ${IMAGE_TAG} (Debezium ${DBZ_CLEAN} on Kafka ${KAFKA_VERSION})"
 
       - name: Set build matrix
         id: set
@@ -166,6 +181,7 @@ jobs:
             ${{ env.DOCKERHUB_REPO }}
             ${{ env.GHCR_REPO }}
           tags: |
+            type=raw,value=${{ needs.meta.outputs.image_tag }}
             type=raw,value=${{ needs.meta.outputs.version }}
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=,format=short
@@ -273,14 +289,14 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Update Chart versions
         env:
-          VERSION: ${{ needs.meta.outputs.version }}
+          # appVersion tracks the Debezium version (the chart's headline
+          # component); the image pin carries the full build identity.
+          APP_VERSION: ${{ needs.meta.outputs.version }}
+          IMAGE_TAG: ${{ needs.meta.outputs.image_tag }}
         run: |
-          # Remove leading 'v' if present
-          CLEAN_VERSION=${VERSION#v}
-          
-          # Update connect-cluster chart
-          sed -i "s/appVersion: .*/appVersion: \"${CLEAN_VERSION}\"/" charts/connect-cluster/Chart.yaml
-          sed -i "s/image: .*/image: \"ghcr.io\/bmscomp\/connect:${CLEAN_VERSION}\"/" charts/connect-cluster/values.yaml
+          # Anchored to ^ so the commented example image: line is left alone.
+          sed -i "s/^appVersion: .*/appVersion: \"${APP_VERSION}\"/" charts/connect-cluster/Chart.yaml
+          sed -i "s|^image: .*|image: \"ghcr.io/bmscomp/connect:${IMAGE_TAG}\"|" charts/connect-cluster/values.yaml
           
       - name: Commit and Push
         run: |
@@ -290,6 +306,6 @@ jobs:
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else
-            git commit -m "chore: bump connect-cluster appVersion to ${VERSION} [skip ci]"
+            git commit -m "chore: pin connect-cluster to connect:${IMAGE_TAG} [skip ci]"
             git push
           fi

--- a/.github/workflows/publish-connect.yml
+++ b/.github/workflows/publish-connect.yml
@@ -18,9 +18,12 @@ on:
   workflow_dispatch:
     inputs:
       debezium_version:
-        description: "Debezium version to build"
+        # Empty = read the version from Dockerfile.connect (the source of
+        # truth). A hardcoded default here silently overrode the Dockerfile on
+        # manual dispatches and produced wrongly-versioned image tags.
+        description: "Debezium version override (blank = use Dockerfile.connect)"
         type: string
-        default: "3.0.2.Final"
+        default: ""
       platforms:
         description: "Target platforms"
         type: choice

--- a/Dockerfile.connect
+++ b/Dockerfile.connect
@@ -1,5 +1,4 @@
 FROM quay.io/strimzi/kafka:1.1.0-kafka-4.3.0 AS base
-# Trigger build
 # ─── Stage 1: Download connector plugins ─────────────────────────────────────
 #
 # This stage downloads all enterprise connector plugins from Maven Central
@@ -95,7 +94,7 @@ RUN mkdir -p debezium-scripting && \
 # ─── Stage 2: Final production image ─────────────────────────────────────────
 FROM base
 
-ARG DEBEZIUM_VERSION=3.1.3.Final
+ARG DEBEZIUM_VERSION=3.6.0.Final
 ARG AIVEN_JDBC_VERSION=6.10.0
 
 USER root:root
@@ -104,7 +103,7 @@ USER 1001
 
 # ─── OCI Image Labels (https://github.com/opencontainers/image-spec) ─────────
 LABEL org.opencontainers.image.title="connect"
-LABEL org.opencontainers.image.description="Enterprise Kafka Connect image with Debezium CDC (PostgreSQL, MySQL, MongoDB, SQL Server, Oracle, Db2), Apicurio Schema Registry (Avro, JSON Schema, Protobuf), Debezium JDBC Sink, and Aiven JDBC source/sink. Built on Strimzi Kafka 4.2.0."
+LABEL org.opencontainers.image.description="Enterprise Kafka Connect image with Debezium CDC (PostgreSQL, MySQL, MongoDB, SQL Server, Oracle, Db2), Apicurio Schema Registry (Avro, JSON Schema, Protobuf), Debezium JDBC Sink, and Aiven JDBC source/sink. Built on Strimzi Kafka 4.3.0."
 LABEL org.opencontainers.image.source="https://github.com/bmscomp/kates"
 LABEL org.opencontainers.image.url="https://github.com/bmscomp/kates/pkgs/container/connect"
 LABEL org.opencontainers.image.documentation="https://github.com/bmscomp/kates/blob/main/docs/kafka-connect.md"

--- a/charts/connect-cluster/values.yaml
+++ b/charts/connect-cluster/values.yaml
@@ -20,7 +20,7 @@ testImages:
 # -- Number of Kafka Connect worker replicas
 replicas: 3
 # -- Kafka Connect image (leave empty to use Strimzi default)
-image: "ghcr.io/bmscomp/connect:3.6.0"
+image: "ghcr.io/bmscomp/connect:3.6.0-kafka-4.3.0"
 # -- Kafka version
 version: "4.3.0"
 # -- Group ID for the Connect cluster
@@ -307,7 +307,7 @@ livenessProbe:
 build: {}
   # output:
   #   type: docker
-  #   image: "ghcr.io/bmscomp/connect:3.6.0"
+  #   image: "ghcr.io/bmscomp/connect:3.6.0-kafka-4.3.0"
   #   pushSecret: my-registry-credentials
   # plugins:
   #   # --- Cloud Storage ---


### PR DESCRIPTION
## Why

Investigating "the Dockerfile changed but the image didn't": the connect image was tagged **solely** from `DEBEZIUM_VERSION` (`grep ARG DEBEZIUM_VERSION | head -1` → `3.6.0`). So when PR #74 changed the Dockerfile's **base** (`1.0.0-kafka-4.2.0` → `1.1.0-kafka-4.3.0`, a real content change), the derived tag stayed `3.6.0`.

The v1.21.0 release rebuilt and pushed `connect:3.6.0` with the new base — **silently changing the content under a fixed tag**. Consumers with `3.6.0` cached never re-pull, and the chart pinned a moving reference whose bytes shifted underneath it.

## The versioning fix

- `publish-connect` now derives the tag as **`<debezium>-kafka-<kafka>`** (`3.6.0-kafka-4.3.0`) by parsing the base `FROM` line — mirroring Strimzi's own `X-kafka-Y` scheme. A base bump now produces a **new tag**. The bare `3.6.0` stays as a *moving convenience alias* (like `latest`) so docs and quick pulls stay simple.
- **The chart pins the full tag** (`3.6.0-kafka-4.3.0`), and the workflow's auto-update job pins the image to it — while keeping `appVersion` the clean Debezium version. That decoupling matters: if `appVersion` had become `3.6.0-kafka-4.3.0`, the `[skip ci]` auto-commit would re-break the version-matrix gate — the exact trap that produced #88.

## Image self-description fixes (found on the way)

- The final stage's `ARG DEBEZIUM_VERSION` was `3.1.3.Final` while the download stage bundles `3.6.0` — so a **local** `docker build` labeled `io.debezium.version=3.1.3` (CI masks it by overriding the label). Aligned to `3.6.0`.
- The description label still said *"Built on Strimzi Kafka 4.2.0"*; the base is 4.3.0. Corrected.
- Removed the `# Trigger build` hack at the top — a symptom of the tag never moving, now unnecessary.

## Materializing the tag

The new tag doesn't exist until a build runs, and the chart must never pin a missing image. So I **dispatched `publish-connect` from this branch** to build and push `connect:3.6.0-kafka-4.3.0` *before* merge — verified present below. (The auto-repin job is tag-gated and correctly no-ops on a branch dispatch, so no conflicting commit.)

## Verification

Chart renders; docs gates unaffected (values-only, `appVersion` untouched); the Kafka-version parse tested against the real `FROM` line → `3.6.0-kafka-4.3.0`.