### PR TITLE
fix(cli): drop the generated "All commands:" section from root help

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -327,19 +327,6 @@ func init() {
 		fmt.Println("Usage:")
 		fmt.Printf("  %s [command]\n", cmd.CommandPath())
 		fmt.Println()
-		// The curated template above highlights common workflows, but it is
-		// hand-maintained and had drifted to listing 21 of 48 commands —
-		// hiding deploy, clean, connect, upgrade, and portforward entirely.
-		// This complete list is generated from the registered commands, so it
-		// cannot rot.
-		fmt.Println("All commands:")
-		for _, c := range cmd.Commands() {
-			if c.Hidden || c.Name() == "help" || c.Name() == "completion" {
-				continue
-			}
-			fmt.Printf("  %-16s %s\n", c.Name(), c.Short)
-		}
-		fmt.Println()
 		fmt.Printf("Use \"%s [command] --help\" for more information about a command.\n", cmd.CommandPath())
 	})
 }


### PR DESCRIPTION
## What

Removes the auto-generated `All commands:` block from `kates --help` (added in #77). Root help now shows the curated template, usage line, and the `[command] --help` pointer — nothing else.

## Note

#77 added that block because the hand-maintained template had drifted to listing 21 of 48 commands. Removing it restores that gap: commands not in the curated template (deploy, clean, connect, upgrade, portforward, …) won't appear in `kates --help`. They remain fully discoverable via tab-completion and `kates <command> --help`; this is a deliberate call to keep the top-level help concise.

## Verification

Builds clean, `go vet` clean; `kates --help` no longer prints `All commands:`.