### PR TITLE
Feat/mirror maker2 chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Kates ships its platform as independently versioned Helm charts, composable via 
 | [`kates-platform`](charts/kates-platform/) | 0.4.0 | 1.0.0 | Umbrella chart for the full Kates platform — Kafka, Kates, and supporting infrastructure |
 | [`kates`](charts/kates/) | 0.6.0 | 1.21.0 | Kates — Kafka Advanced Testing & Engineering Suite |
 | [`minio`](charts/minio/) | 17.0.22 | 2025.7.23 | MinIO(R) is an object storage server, compatible with Amazon S3 cloud |
+| [`mirror-maker2`](charts/mirror-maker2/) | 0.1.0 | 4.3.0 | Strimzi KafkaMirrorMaker2 — cross-cluster replication / DR / migration |
 | [`monitoring`](charts/monitoring/) | 1.1.0 | 82.4.3 | Kates Monitoring — wraps kube-prometheus-stack with Kates-specific dashboards and configuration |
 | [`strimzi-operator`](charts/strimzi-operator/) | 0.1.0 | 1.1.0 | The Strimzi Kafka Operator — wraps the upstream chart with pinned kates defaults, an owned CRD-upgrade hook, and a strict values schema |
 | [`velero`](charts/velero/) | 11.3.3 | 1.17.1 | A Helm chart for velero |

--- a/charts/kafka-cluster/values.yaml
+++ b/charts/kafka-cluster/values.yaml
@@ -496,6 +496,42 @@ users:
               type: cluster
             operations: ["Describe"]
             host: "*"
+    # MirrorMaker 2 TARGET-side user (mirror-maker2 chart). Writes replicated
+    # topics + owns the MM2 Connect internal/offset-sync/checkpoint topics and
+    # groups on this (target) cluster. The SOURCE-side user lives on the remote
+    # cluster and is provisioned there.
+    - name: kates-mm2
+      authentication:
+        type: scram-sha-512
+      quotas:
+        producerByteRate: 52428800
+        consumerByteRate: 52428800
+        requestPercentage: 25
+      authorization:
+        type: simple
+        acls:
+          - resource:
+              type: topic
+              name: "*"
+              patternType: literal
+            operations: ["Read", "Write", "Create", "Describe", "DescribeConfigs", "Alter"]
+            host: "*"
+          - resource:
+              type: group
+              name: "mirror-maker2"
+              patternType: prefix
+            operations: ["Read", "Describe"]
+            host: "*"
+          - resource:
+              type: group
+              name: "connect-"
+              patternType: prefix
+            operations: ["Read", "Describe"]
+            host: "*"
+          - resource:
+              type: cluster
+            operations: ["Describe", "DescribeConfigs", "Create"]
+            host: "*"
 
 # -- PrometheusRule alerting configuration
 alerts:

--- a/charts/mirror-maker2/.helmignore
+++ b/charts/mirror-maker2/.helmignore
@@ -1,0 +1,10 @@
+.DS_Store
+*.swp
+*.bak
+*.tmp
+*.orig
+.git/
+.gitignore
+.idea/
+*.tmproj
+.vscode/

--- a/charts/mirror-maker2/Chart.yaml
+++ b/charts/mirror-maker2/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: mirror-maker2
+description: A Helm chart for deploying a Strimzi KafkaMirrorMaker2 cluster (cross-cluster replication / DR / migration)
+type: application
+version: 0.1.0
+# Tracks the Kafka line the MM2 Connect workers run (STRIMZI_KAFKA_VERSION).
+appVersion: "4.3.0"
+kubeVersion: ">=1.27.0-0"
+home: https://github.com/bmscomp/kates
+sources:
+  - https://github.com/bmscomp/kates
+maintainers:
+  - name: bmscomp
+    url: https://github.com/bmscomp
+keywords:
+  - kafka
+  - mirrormaker2
+  - mirror-maker
+  - replication
+  - disaster-recovery
+  - strimzi
+icon: https://raw.githubusercontent.com/bmscomp/kates/main/docs/icon.png

--- a/charts/mirror-maker2/README.md
+++ b/charts/mirror-maker2/README.md
@@ -1,0 +1,131 @@
+# mirror-maker2
+
+Deploys a Strimzi **KafkaMirrorMaker2** cluster for cross-cluster replication —
+active/passive DR, cluster migration, or aggregation. MM2 runs on Kafka Connect,
+so the worker surface (replicas, JVM, resources, metrics, NetworkPolicy) matches
+the `connect-cluster` chart. The difference: MM2 spans **two Kafka clusters**.
+
+## Model (Strimzi v1 API)
+
+- **`target`** — the cluster MM2's Connect runtime runs against; it owns the
+  Connect internal config/offset/status topics. Defaults to the in-repo
+  `krafter` cluster.
+- **`mirrors[]`** — one entry per replication flow, each with its own
+  **`source`** cluster (bootstrap + tls + auth) plus `topicsPattern`,
+  `groupsPattern`, and the `sourceConnector` / `checkpointConnector` config
+  (replication factors, offset sync).
+
+Out of the box the chart is a **loopback** (source == target == `krafter`) so it
+renders and smoke-tests without a second cluster. Replace `mirrors[].source`
+with the real external cluster for a genuine mirror.
+
+### Configuring source & target clusters
+
+Both `target` and each `mirrors[].source` accept **either** an in-cluster
+reference (`clusterName` + `namespace`, bootstrap FQDN computed —
+`<clusterName>-kafka-bootstrap.<namespace>.svc.<clusterDomain>:<9092|9093>`)
+**or** an explicit `bootstrapServers` (external / inter-cluster), which wins
+when set. The port follows `tls.enabled` (9093) for computed addresses. This
+covers every topology with one model:
+
+| Topology | source | target |
+|---|---|---|
+| Same cluster (loopback / rename) | `clusterName: krafter, namespace: kafka` | `clusterName: krafter, namespace: kafka` |
+| Same cluster, different namespaces | `namespace: kafka-a` | `namespace: kafka-b` |
+| Two in-cluster Strimzi clusters | `clusterName: krafter-dr, namespace: kafka-dr` | `clusterName: krafter, namespace: kafka` |
+| External / cross-datacenter | `bootstrapServers: kafka-east.example.com:9094` | `clusterName: krafter, namespace: kafka` |
+
+## The credential contract (read this)
+
+MM2 needs a `KafkaUser` on **both** ends:
+
+| End | Who provisions it | ACLs |
+|---|---|---|
+| **target** | `kafka-cluster` chart (`kates-mm2`), or this chart with `kafkaUser.create=true` | write replicated topics, own MM2 internal + offset-sync + checkpoint topics, Connect groups, cluster Describe/Create |
+| **source** | **you, out-of-band** — it's an external cluster this chart cannot touch | READ + DESCRIBE on the mirrored topics and consumer groups |
+
+A missing **source** ACL does not error — the `MirrorSourceConnector` just
+stalls and nothing replicates. Grant it before expecting data.
+
+### Cross-namespace / inter-cluster checklist
+
+MM2 reads each cluster's `passwordSecret` and TLS cert **from its own
+namespace**. When a source or target Kafka cluster is in a different namespace
+(or an external cluster), do all of:
+
+1. **Credentials present here.** The credential Secret (and CA cert for TLS)
+   must exist in the MM2 release namespace. Either enable `secretSync` to copy
+   them from their home namespaces on every install/upgrade:
+
+   ```yaml
+   secretSync:
+     enabled: true
+     secrets:
+       - { name: kates-mm2, fromNamespace: kafka }             # target creds
+       - { name: kates-mm2-source, fromNamespace: kafka-dr }   # source creds
+       - { name: krafter-cluster-ca-cert, fromNamespace: kafka }  # target CA (TLS)
+   ```
+
+   …or annotate the KafkaUser Secrets for kubernetes-reflector. For a truly
+   external source, create its Secret in this namespace by hand.
+2. **CA certs for TLS.** Set `tls.enabled: true` + `trustedCertificateSecret`
+   per cluster and make sure that Secret is one of the synced/created ones.
+3. **NetworkPolicy egress.** The default policy allows Kafka egress to any IP on
+   `networkPolicy.kafka.ports`. For an external source on a non-standard port,
+   add it there or via `networkPolicy.extraEgress`.
+4. **ACLs on both ends** (see the table above) — target managed in-repo, source
+   granted out-of-band.
+
+## Durability
+
+`sourceConnector.config.replication.factor` and the offset-syncs / checkpoints
+topic factors must not exceed the target's broker count. The defaults are RF3
+(production); the `values-kind.yaml` / `values-dev.yaml` overlays drop to RF1 for
+single-broker clusters. RF1 is **not** durable — never use it for real DR.
+`checkpointConnector.config.sync.group.offsets.enabled: true` translates consumer
+offsets to the target so consumers can fail over.
+
+## Common overrides
+
+```yaml
+mirrors:
+  - source:
+      alias: dc-east
+      bootstrapServers: kafka-east.example.com:9093
+      tls: { enabled: true, trustedCertificateSecret: dc-east-ca }
+      authentication: { type: scram-sha-512, username: mm2-reader, secretName: mm2-east }
+    topicsPattern: "orders\\..*|payments\\..*"
+```
+
+### mTLS (turnkey, no external PKI)
+
+`-f values-mtls.yaml` runs MM2 over the `kafka-cluster` mTLS listener (9093)
+using Strimzi's built-in Clients CA — it provisions a `type: tls` KafkaUser
+(`kates-mm2-tls`, certs issued + auto-rotated by the operator), trusts the
+Cluster CA via `krafter-cluster-ca-cert`, and narrows egress to 9093. No
+cert-manager or external CA needed for the in-repo cluster.
+
+```bash
+helm install mm2 charts/mirror-maker2 -n kafka -f charts/mirror-maker2/values-mtls.yaml
+```
+
+Assumes MM2 is in the same namespace as the cluster (`kafka`); if elsewhere,
+also enable `secretSync` for `kates-mm2-tls` + `krafter-cluster-ca-cert`. A real
+**external** source needs its own `type: tls` KafkaUser issued by *that*
+cluster's Clients CA, with its Cluster CA cert trusted here — for federated
+trust across clusters, front Strimzi with cert-manager (bring-your-own-CA).
+
+Production overlay: `-f values-prod.yaml` (HA, RF3, monitoring). The PodMonitor is
+capability-guarded, so enabling metrics on a cluster without the Prometheus
+Operator never fails the install — but `podMonitors.enabled` requires
+`metrics.enabled=true` (Strimzi only opens the scrape port then), which the chart
+enforces with a loud failure.
+
+**`keepOnDelete` (default true)** annotates the MM2 CR and target KafkaUser with
+`helm.sh/resource-policy: keep`, so `helm uninstall` leaves replication running.
+The flip side: a later `helm install` with the same release name fails on the
+kept objects — delete them manually first, or set `keepOnDelete: false`.
+
+**Autoscaling:** `autoscaling.enabled=true` renders an HPA targeting the MM2 CR
+(which exposes the scale subresource); `spec.replicas` is still seeded from
+`minReplicas` because the v1 CRD requires it.

--- a/charts/mirror-maker2/templates/NOTES.txt
+++ b/charts/mirror-maker2/templates/NOTES.txt
@@ -1,0 +1,24 @@
+MirrorMaker 2 {{ .Chart.AppVersion }} — release {{ .Release.Name }} in {{ include "mirror-maker2.namespace" . }}.
+
+Target (MM2 Connect runtime): {{ .Values.target.alias }} @ {{ include "mirror-maker2.bootstrap" (dict "c" .Values.target "ctx" $) }}
+Mirror flows:
+{{- range .Values.mirrors }}
+  - {{ .source.alias }} → {{ $.Values.target.alias }}  topics={{ .topicsPattern | default ".*" }}  groups={{ .groupsPattern | default ".*" }}  (source: {{ include "mirror-maker2.bootstrap" (dict "c" .source "ctx" $) }})
+{{- end }}
+
+⚠ CREDENTIALS ARE A TWO-CLUSTER CONTRACT:
+  • TARGET: provisioned in-repo as KafkaUser "{{ .Values.target.authentication.username }}"
+    by the kafka-cluster chart (or by this chart when kafkaUser.create=true).
+  • SOURCE: on an EXTERNAL cluster — this chart CANNOT create its user. Grant it
+    READ + DESCRIBE on the mirrored topics and groups out-of-band, or the
+    MirrorSourceConnector stalls silently with no data replicated.
+
+Watch it come up:
+  kubectl -n {{ include "mirror-maker2.namespace" . }} get kafkamirrormaker2 {{ include "mirror-maker2.fullname" . }} -w
+  kubectl -n {{ include "mirror-maker2.namespace" . }} wait kafkamirrormaker2/{{ include "mirror-maker2.fullname" . }} --for=condition=Ready --timeout=300s
+
+Verify replication (topics appear as <sourceAlias>.<topic> on the target):
+  kubectl -n kafka get kafkatopics | grep '^{{ (index .Values.mirrors 0).source.alias | default "source" }}\.'
+
+Smoke test:
+  helm test {{ .Release.Name }} -n {{ include "mirror-maker2.namespace" . }}

--- a/charts/mirror-maker2/templates/_helpers.tpl
+++ b/charts/mirror-maker2/templates/_helpers.tpl
@@ -1,0 +1,115 @@
+{{/* Expand the name of the chart. */}}
+{{- define "mirror-maker2.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Fully qualified app name. */}}
+{{- define "mirror-maker2.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Release namespace, overridable. */}}
+{{- define "mirror-maker2.namespace" -}}
+{{- .Values.namespaceOverride | default .Release.Namespace }}
+{{- end }}
+
+{{- define "mirror-maker2.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "mirror-maker2.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mirror-maker2.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "mirror-maker2.labels" -}}
+helm.sh/chart: {{ include "mirror-maker2.chart" . }}
+{{ include "mirror-maker2.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: mirror-maker2
+app.kubernetes.io/part-of: kates
+{{- with .Values.extraLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "mirror-maker2.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- .Values.serviceAccount.name | default (include "mirror-maker2.fullname" .) }}
+{{- else }}
+{{- .Values.serviceAccount.name | default "default" }}
+{{- end }}
+{{- end }}
+
+{{/* Strimzi labels the MM2 Connect pods <cluster>-mirrormaker2. */}}
+{{- define "mirror-maker2.podSelectorLabels" -}}
+strimzi.io/name: {{ include "mirror-maker2.fullname" . }}-mirrormaker2
+strimzi.io/kind: KafkaMirrorMaker2
+{{- end }}
+
+{{/*
+Bootstrap servers for a cluster entry (target or a mirror source).
+Call with (dict "c" <clusterValues> "ctx" $).
+- If `bootstrapServers` is set, it wins verbatim (external / inter-cluster).
+- Otherwise the FQDN is computed from `clusterName` + `namespace` for an
+  in-cluster Strimzi cluster: <clusterName>-kafka-bootstrap.<namespace>.svc.
+  <clusterDomain>:<9093 if tls else 9092>. This makes intra-cluster (same or
+  different namespace) and inter-cluster topologies configurable uniformly.
+*/}}
+{{- define "mirror-maker2.bootstrap" -}}
+{{- $c := .c -}}{{- $ctx := .ctx -}}
+{{- if $c.bootstrapServers -}}
+{{- $c.bootstrapServers -}}
+{{- else -}}
+{{- $name := $c.clusterName | default "krafter" -}}
+{{- $ns := $c.namespace | default "kafka" -}}
+{{- $domain := $ctx.Values.clusterDomain | default "cluster.local" -}}
+{{- $port := 9092 -}}
+{{- if and $c.tls $c.tls.enabled -}}{{- $port = 9093 -}}{{- end -}}
+{{- printf "%s-kafka-bootstrap.%s.svc.%s:%v" $name $ns $domain $port -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Render the tls + authentication blocks for a cluster entry (target or a
+mirror source). Call with (dict "c" <clusterValues>). Emits at column 0; the
+caller applies nindent.
+*/}}
+{{- define "mirror-maker2.clusterTlsAuth" -}}
+{{- $c := .c -}}
+{{- if and $c.tls $c.tls.enabled }}
+tls:
+  trustedCertificates:
+    - secretName: {{ required "tls.trustedCertificateSecret is required when tls.enabled" $c.tls.trustedCertificateSecret }}
+      certificate: {{ $c.tls.certificateKey | default "ca.crt" }}
+{{- end }}
+{{- with $c.authentication }}
+{{- if .type }}
+authentication:
+  type: {{ .type }}
+  {{- if or (eq .type "scram-sha-512") (eq .type "scram-sha-256") (eq .type "plain") }}
+  username: {{ .username | quote }}
+  passwordSecret:
+    secretName: {{ .secretName | default .username | quote }}
+    password: {{ .secretKey | default "password" }}
+  {{- else if eq .type "tls" }}
+  certificateAndKey:
+    secretName: {{ .secretName | default (printf "%s-tls" .username) | quote }}
+    certificate: {{ .certificate | default "user.crt" }}
+    key: {{ .key | default "user.key" }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/mirror-maker2/templates/hpa.yaml
+++ b/charts/mirror-maker2/templates/hpa.yaml
@@ -1,0 +1,45 @@
+{{- /*
+Optional HPA. KafkaMirrorMaker2 exposes the scale subresource, so the HPA can
+target the CR directly. spec.replicas is still emitted on the CR (the v1 CRD
+requires it) seeded from minReplicas; the HPA then owns the live count.
+*/ -}}
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "mirror-maker2.fullname" . }}
+  namespace: {{ include "mirror-maker2.namespace" . }}
+  labels:
+    {{- include "mirror-maker2.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: kafka.strimzi.io/v1
+    kind: KafkaMirrorMaker2
+    name: {{ include "mirror-maker2.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas | default 2 }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas | default 6 }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- with .Values.autoscaling.extraMetrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/mirror-maker2/templates/kafka-mirror-maker2.yaml
+++ b/charts/mirror-maker2/templates/kafka-mirror-maker2.yaml
@@ -1,0 +1,166 @@
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaMirrorMaker2
+metadata:
+  name: {{ include "mirror-maker2.fullname" . }}
+  namespace: {{ include "mirror-maker2.namespace" . }}
+  labels:
+    {{- include "mirror-maker2.labels" . | nindent 4 }}
+  annotations:
+    {{- if not (eq (toString .Values.keepOnDelete) "false") }}
+    helm.sh/resource-policy: keep
+    {{- end }}
+    strimzi.io/use-connector-resources: "false"
+spec:
+  version: {{ .Values.version | quote }}
+  {{- if .Values.image }}
+  image: {{ .Values.image | quote }}
+  {{- end }}
+  {{- /* replicas is REQUIRED by the v1 CRD (no default). When the HPA owns
+         scaling it seeds the initial count from minReplicas; the operator's
+         scale subresource lets the HPA adjust it afterwards. */}}
+  replicas: {{ if .Values.autoscaling.enabled }}{{ .Values.autoscaling.minReplicas | default 2 }}{{ else }}{{ .Values.replicas }}{{ end }}
+  {{- $t := .Values.target }}
+  {{- $gid := $t.groupId | default "mirror-maker2" }}
+  target:
+    alias: {{ $t.alias | default "target" | quote }}
+    bootstrapServers: {{ include "mirror-maker2.bootstrap" (dict "c" $t "ctx" $) | quote }}
+    groupId: {{ $gid | quote }}
+    configStorageTopic: {{ $t.configStorageTopic | default (printf "%s-configs" $gid) | quote }}
+    offsetStorageTopic: {{ $t.offsetStorageTopic | default (printf "%s-offsets" $gid) | quote }}
+    statusStorageTopic: {{ $t.statusStorageTopic | default (printf "%s-status" $gid) | quote }}
+    {{- include "mirror-maker2.clusterTlsAuth" (dict "c" $t) | nindent 4 }}
+    {{- with $t.config }}
+    config:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  mirrors:
+    {{- range .Values.mirrors }}
+    - source:
+        alias: {{ .source.alias | default "source" | quote }}
+        bootstrapServers: {{ include "mirror-maker2.bootstrap" (dict "c" .source "ctx" $) | quote }}
+        {{- include "mirror-maker2.clusterTlsAuth" (dict "c" .source) | nindent 8 }}
+        {{- with .source.config }}
+        config:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      topicsPattern: {{ .topicsPattern | default ".*" | quote }}
+      {{- with .topicsExcludePattern }}
+      topicsExcludePattern: {{ . | quote }}
+      {{- end }}
+      groupsPattern: {{ .groupsPattern | default ".*" | quote }}
+      {{- with .groupsExcludePattern }}
+      groupsExcludePattern: {{ . | quote }}
+      {{- end }}
+      {{- with .sourceConnector }}
+      sourceConnector:
+        {{- with .tasksMax }}
+        tasksMax: {{ . }}
+        {{- end }}
+        {{- with .config }}
+        config:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- end }}
+      {{- with .checkpointConnector }}
+      checkpointConnector:
+        {{- with .tasksMax }}
+        tasksMax: {{ . }}
+        {{- end }}
+        {{- with .config }}
+        config:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  resources:
+    {{- toYaml .Values.resources | nindent 4 }}
+  jvmOptions:
+    {{- toYaml .Values.jvmOptions | nindent 4 }}
+  {{- with .Values.livenessProbe }}
+  livenessProbe:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.readinessProbe }}
+  readinessProbe:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.logging }}
+  logging:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.tracing }}
+  tracing:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.rack.enabled }}
+  rack:
+    topologyKey: {{ .Values.rack.topologyKey }}
+  {{- end }}
+  {{- if .Values.metrics.enabled }}
+  metricsConfig:
+    type: jmxPrometheusExporter
+    valueFrom:
+      configMapKeyRef:
+        name: {{ include "mirror-maker2.fullname" . }}-metrics
+        key: metrics-config.yml
+  {{- end }}
+  template:
+    {{- if and .Values.podDisruptionBudget.enabled (gt (int .Values.replicas) 1) }}
+    # Strimzi manages the PDB for its own pods; setting maxUnavailable here
+    # avoids a second, overlapping standalone PDB fighting the operator's.
+    podDisruptionBudget:
+      maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+    {{- end }}
+    pod:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      terminationGracePeriodSeconds: 30
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      # nodeSelector is set via affinity below to co-exist with pod anti-affinity
+      {{- end }}
+      {{- if or .Values.podAntiAffinity.enabled .Values.nodeSelector }}
+      affinity:
+        {{- if .Values.podAntiAffinity.enabled }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    {{- include "mirror-maker2.podSelectorLabels" . | nindent 20 }}
+                topologyKey: {{ .Values.podAntiAffinity.topologyKey }}
+        {{- end }}
+        {{- with .Values.nodeSelector }}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  {{- range $k, $v := . }}
+                  - key: {{ $k }}
+                    operator: In
+                    values: [{{ $v | quote }}]
+                  {{- end }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.topologySpreadConstraints.enabled }}
+      topologySpreadConstraints:
+        - maxSkew: {{ .Values.topologySpreadConstraints.maxSkew }}
+          topologyKey: {{ .Values.topologySpreadConstraints.topologyKey }}
+          whenUnsatisfiable: {{ .Values.topologySpreadConstraints.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              {{- include "mirror-maker2.podSelectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/charts/mirror-maker2/templates/kafka-user.yaml
+++ b/charts/mirror-maker2/templates/kafka-user.yaml
@@ -1,0 +1,87 @@
+{{- /*
+Optional TARGET-side KafkaUser for MM2. Off by default — the in-repo
+kafka-cluster chart provisions `kates-mm2` centrally. Enable when the target
+cluster is co-located and you want this chart to own the user.
+
+Grants the ACLs MM2 needs on the TARGET: write the replicated topics, own the
+MM2 internal + offset-sync + checkpoint + heartbeat topics, and use the Connect
+groups. The SOURCE-side user is on an external cluster and is NOT created here.
+*/ -}}
+{{- if .Values.kafkaUser.create }}
+{{- $target := .Values.target }}
+{{- $username := .Values.kafkaUser.name | default $target.authentication.username | default "kates-mm2" }}
+{{- $authz := .Values.kafkaUser.authorization | default dict }}
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaUser
+metadata:
+  name: {{ $username }}
+  namespace: {{ .Values.kafkaUser.namespace | default "kafka" }}
+  labels:
+    {{- include "mirror-maker2.labels" . | nindent 4 }}
+    strimzi.io/cluster: {{ .Values.kafkaUser.clusterName | default "krafter" }}
+  annotations:
+    {{- if not (eq (toString .Values.keepOnDelete) "false") }}
+    helm.sh/resource-policy: keep
+    {{- end }}
+spec:
+  authentication:
+    type: {{ $target.authentication.type | default "scram-sha-512" }}
+  {{- with .Values.kafkaUser.quotas }}
+  quotas:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.kafkaUser.template }}
+  template:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if $authz.enabled | default true }}
+  {{- $gid := $target.groupId | default "mirror-maker2" }}
+  authorization:
+    type: {{ $authz.type | default "simple" }}
+    acls:
+      {{- if eq ($authz.mode | default "auto") "custom" }}
+      {{- if not .Values.kafkaUser.acls }}{{- fail "kafkaUser.authorization.mode=custom requires kafkaUser.acls" }}{{- end }}
+      {{- toYaml .Values.kafkaUser.acls | nindent 6 }}
+      {{- else }}
+      # ── MM2 Connect internal topics (<groupId>-configs/offsets/status) ──
+      - resource: { type: topic, name: {{ $gid | quote }}, patternType: prefix }
+        operations: ["Read", "Write", "Create", "Describe", "DescribeConfigs"]
+        host: "*"
+      # ── Replicated data + checkpoints per source alias (<alias>.*) ──────
+      {{- range .Values.mirrors }}
+      - resource: { type: topic, name: {{ printf "%s." (.source.alias | default "source") | quote }}, patternType: prefix }
+        operations: ["Read", "Write", "Create", "Describe", "DescribeConfigs", "Alter"]
+        host: "*"
+      {{- end }}
+      # ── Offset-sync + heartbeat internal topics ────────────────────────
+      - resource: { type: topic, name: "mm2-offset-syncs.", patternType: prefix }
+        operations: ["Read", "Write", "Create", "Describe"]
+        host: "*"
+      - resource: { type: topic, name: "heartbeats", patternType: literal }
+        operations: ["Read", "Write", "Create", "Describe"]
+        host: "*"
+      # ── Extra topic grants (e.g. IdentityReplicationPolicy) ────────────
+      {{- range .Values.kafkaUser.topicGrants }}
+      - resource: { type: topic, name: {{ .name | quote }}, patternType: {{ .patternType | default "prefix" }} }
+        operations: {{ .operations | default (list "Read" "Write" "Create" "Describe") | toJson }}
+        host: "*"
+      {{- end }}
+      # ── Connect worker groups ──────────────────────────────────────────
+      - resource: { type: group, name: {{ $gid | quote }}, patternType: prefix }
+        operations: ["Read", "Describe"]
+        host: "*"
+      - resource: { type: group, name: "connect-", patternType: prefix }
+        operations: ["Read", "Describe"]
+        host: "*"
+      {{- range .Values.kafkaUser.groupGrants }}
+      - resource: { type: group, name: {{ .name | quote }}, patternType: {{ .patternType | default "prefix" }} }
+        operations: ["Read", "Describe"]
+        host: "*"
+      {{- end }}
+      # ── Cluster metadata + topic creation ──────────────────────────────
+      - resource: { type: cluster }
+        operations: ["Describe", "DescribeConfigs", "Create"]
+        host: "*"
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/mirror-maker2/templates/metrics-configmap.yaml
+++ b/charts/mirror-maker2/templates/metrics-configmap.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mirror-maker2.fullname" . }}-metrics
+  namespace: {{ include "mirror-maker2.namespace" . }}
+  labels:
+    {{- include "mirror-maker2.labels" . | nindent 4 }}
+data:
+  metrics-config.yml: |
+    # JMX Prometheus exporter rules for MM2 (Connect) workers.
+    lowercaseOutputName: true
+    rules:
+      - pattern: "kafka.connect<type=connect-worker-metrics>([^:]+):"
+        name: kafka_connect_worker_$1
+      - pattern: "kafka.connect<type=connect-metrics, client-id=([^:]+)><>([^:]+)"
+        name: kafka_connect_$2
+        labels:
+          client: "$1"
+      - pattern: "kafka.connect<type=MirrorSourceConnector.*"
+        name: kafka_connect_mirror_source
+      - pattern: kafka.connect<type=(.+), client-id=(.+)><>(.+): (.+)
+        name: kafka_connect_$1_$3
+        labels:
+          client: "$2"
+{{- end }}

--- a/charts/mirror-maker2/templates/networkpolicy.yaml
+++ b/charts/mirror-maker2/templates/networkpolicy.yaml
@@ -1,0 +1,85 @@
+{{- if .Values.networkPolicy.enabled }}
+{{- $np := .Values.networkPolicy }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "mirror-maker2.fullname" . }}
+  namespace: {{ include "mirror-maker2.namespace" . }}
+  labels:
+    {{- include "mirror-maker2.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "mirror-maker2.podSelectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    {{- if $np.workerToWorker }}
+    # Worker-to-worker Connect REST (leader forwarding) on 8083
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "mirror-maker2.podSelectorLabels" . | nindent 14 }}
+      ports:
+        - port: 8083
+          protocol: TCP
+    {{- end }}
+    {{- if $np.monitoring }}
+    # Metrics scrape
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $np.monitoring.namespace }}
+      ports:
+        - port: {{ $np.monitoring.port }}
+          protocol: TCP
+    {{- end }}
+    {{- with $np.extraIngress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  egress:
+    # DNS
+    - to:
+        {{- if or $np.dns.namespaceSelector $np.dns.podSelector }}
+        - {{- if $np.dns.namespaceSelector }}
+          namespaceSelector:
+            matchLabels:
+              {{- toYaml $np.dns.namespaceSelector | nindent 14 }}
+          {{- end }}
+          {{- if $np.dns.podSelector }}
+          podSelector:
+            matchLabels:
+              {{- toYaml $np.dns.podSelector | nindent 14 }}
+          {{- end }}
+        {{- else }}
+        - namespaceSelector: {}
+        {{- end }}
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Kafka brokers — source AND target, arbitrary IPs
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        {{- range $np.kafka.ports }}
+        - port: {{ . }}
+          protocol: TCP
+        {{- end }}
+    {{- if $np.workerToWorker }}
+    # Worker-to-worker egress (8083)
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "mirror-maker2.podSelectorLabels" . | nindent 14 }}
+      ports:
+        - port: 8083
+          protocol: TCP
+    {{- end }}
+    {{- with $np.extraEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/mirror-maker2/templates/podmonitor.yaml
+++ b/charts/mirror-maker2/templates/podmonitor.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.podMonitors.enabled (not .Values.metrics.enabled) }}
+{{- fail "podMonitors.enabled requires metrics.enabled=true — Strimzi only opens the tcp-prometheus port (which the PodMonitor scrapes) when metricsConfig is set." }}
+{{- end }}
+{{- if and .Values.podMonitors.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "mirror-maker2.fullname" . }}
+  namespace: {{ include "mirror-maker2.namespace" . }}
+  labels:
+    {{- include "mirror-maker2.labels" . | nindent 4 }}
+    {{- with .Values.podMonitors.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "mirror-maker2.podSelectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+    - port: tcp-prometheus
+      path: /metrics
+      {{- with .Values.monitoring.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.monitoring.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+{{- end }}

--- a/charts/mirror-maker2/templates/secret-sync.yaml
+++ b/charts/mirror-maker2/templates/secret-sync.yaml
@@ -1,0 +1,158 @@
+{{- /*
+Copy each source/target credential (and CA cert) Secret from its own namespace
+into this release's namespace, so MM2's per-cluster passwordSecret/tls refs
+resolve. A post-install/post-upgrade hook Job, re-run each upgrade to pick up
+rotation. RBAC is scoped by name in the source namespaces and by name in the
+destination. No-op when secretSync.secrets is empty.
+*/ -}}
+{{- $dstNs := include "mirror-maker2.namespace" . }}
+{{- /* Skip secrets already in the release namespace — nothing to copy. */}}
+{{- $secrets := list }}{{- range .Values.secretSync.secrets }}{{- if ne .fromNamespace $dstNs }}{{- $secrets = append $secrets . }}{{- end }}{{- end }}
+{{- if and .Values.secretSync.enabled $secrets }}
+{{- $fullname := include "mirror-maker2.fullname" . }}
+{{- $syncImage := .Values.secretSync.image | default .Values.testImages.kubectl }}
+{{- $names := list }}{{- range $secrets }}{{- $names = append $names .name }}{{- end }}
+{{- $srcNamespaces := list }}{{- range $secrets }}{{- $srcNamespaces = append $srcNamespaces .fromNamespace }}{{- end }}
+{{- $srcNamespaces = $srcNamespaces | uniq }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $fullname }}-secret-sync
+  namespace: {{ $dstNs }}
+  labels:
+    {{- include "mirror-maker2.labels" . | nindent 4 }}
+{{- /* Read Role per distinct source namespace, scoped to the names from that ns */}}
+{{- range $srcNs := $srcNamespaces }}
+{{- $nsNames := list }}
+{{- range $secrets }}{{- if eq .fromNamespace $srcNs }}{{- $nsNames = append $nsNames .name }}{{- end }}{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $fullname }}-secret-sync-read
+  namespace: {{ $srcNs }}
+  labels:
+    {{- include "mirror-maker2.labels" $ | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: {{ $nsNames | uniq | toJson }}
+    verbs: ["get", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $fullname }}-secret-sync-read
+  namespace: {{ $srcNs }}
+  labels:
+    {{- include "mirror-maker2.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $fullname }}-secret-sync-read
+subjects:
+  - kind: ServiceAccount
+    name: {{ $fullname }}-secret-sync
+    namespace: {{ $dstNs }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $fullname }}-secret-sync-write
+  namespace: {{ $dstNs }}
+  labels:
+    {{- include "mirror-maker2.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: {{ $names | uniq | toJson }}
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $fullname }}-secret-sync-write
+  namespace: {{ $dstNs }}
+  labels:
+    {{- include "mirror-maker2.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $fullname }}-secret-sync-write
+subjects:
+  - kind: ServiceAccount
+    name: {{ $fullname }}-secret-sync
+    namespace: {{ $dstNs }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $fullname }}-secret-sync
+  namespace: {{ $dstNs }}
+  labels:
+    {{- include "mirror-maker2.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 2
+  activeDeadlineSeconds: {{ .Values.secretSync.timeoutSeconds | default 300 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mirror-maker2.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ $fullname }}-secret-sync
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: sync
+          # Needs kubectl + jq + sh. Defaults to the tester image; override
+          # with secretSync.image for a dedicated runtime image.
+          image: {{ $syncImage }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests: { cpu: 10m, memory: 32Mi }
+            limits: { cpu: 100m, memory: 64Mi }
+          env:
+            - name: DST_NS
+              value: {{ $dstNs | quote }}
+            # Space-separated "<srcNamespace>/<name>" pairs
+            - name: PAIRS
+              value: {{ range $i, $s := $secrets }}{{ if $i }} {{ end }}{{ $s.fromNamespace }}/{{ $s.name }}{{ end }}
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              for pair in ${PAIRS}; do
+                SRC_NS="${pair%%/*}"; NAME="${pair##*/}"
+                echo "Waiting for ${SRC_NS}/${NAME}..."
+                i=0
+                until kubectl -n "${SRC_NS}" get secret "${NAME}" >/dev/null 2>&1; do
+                  i=$((i+1)); [ "$i" -ge 48 ] && { echo "Timed out on ${SRC_NS}/${NAME}" >&2; exit 1; }
+                  sleep 5
+                done
+                echo "Copying ${SRC_NS}/${NAME} -> ${DST_NS}/${NAME}"
+                kubectl -n "${SRC_NS}" get secret "${NAME}" -o json \
+                  | jq --arg ns "${DST_NS}" --arg src "${SRC_NS}/${NAME}" '
+                      {apiVersion:"v1", kind:"Secret", type:.type, data:.data,
+                       metadata:{name:.metadata.name, namespace:$ns,
+                                 labels:(.metadata.labels // {}),
+                                 annotations:{"kates.io/synced-from":$src}}}' \
+                  | kubectl apply -f -
+              done
+              echo "All secrets synced."
+{{- end }}

--- a/charts/mirror-maker2/templates/serviceaccount.yaml
+++ b/charts/mirror-maker2/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mirror-maker2.serviceAccountName" . }}
+  namespace: {{ include "mirror-maker2.namespace" . }}
+  labels:
+    {{- include "mirror-maker2.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/mirror-maker2/templates/tests/test-mm2.yaml
+++ b/charts/mirror-maker2/templates/tests/test-mm2.yaml
@@ -1,0 +1,93 @@
+{{- $kubectl := .Values.testImages.kubectl }}
+{{- $sa := printf "%s-test" (include "mirror-maker2.fullname" .) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $sa }}
+  namespace: {{ include "mirror-maker2.namespace" . }}
+  labels:
+    {{- include "mirror-maker2.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $sa }}
+  namespace: {{ include "mirror-maker2.namespace" . }}
+  labels:
+    {{- include "mirror-maker2.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ["kafka.strimzi.io"]
+    resources: ["kafkamirrormaker2s"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $sa }}
+  namespace: {{ include "mirror-maker2.namespace" . }}
+  labels:
+    {{- include "mirror-maker2.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $sa }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $sa }}
+    namespace: {{ include "mirror-maker2.namespace" . }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "mirror-maker2.fullname" . }}-test-ready
+  namespace: {{ include "mirror-maker2.namespace" . }}
+  labels:
+    {{- include "mirror-maker2.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  serviceAccountName: {{ $sa }}
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: test
+      image: {{ $kubectl }}
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop: ["ALL"]
+      command: ['sh', '-c']
+      args:
+        - |
+          MM2={{ include "mirror-maker2.fullname" . }}
+          NS={{ include "mirror-maker2.namespace" . }}
+          echo "Waiting for KafkaMirrorMaker2/${MM2} to be Ready..."
+          if kubectl wait "kafkamirrormaker2/${MM2}" -n "${NS}" \
+              --for=condition=Ready --timeout=240s; then
+            echo "✅ MM2 is Ready — clusters connected and connectors running"
+            exit 0
+          fi
+          echo "❌ MM2 did not become Ready. Status:"
+          kubectl get "kafkamirrormaker2/${MM2}" -n "${NS}" -o jsonpath='{.status.conditions}' || true
+          echo
+          echo "  Common cause: a source-cluster ACL/credential is missing, so the"
+          echo "  MirrorSourceConnector cannot read. See the chart NOTES."
+          exit 1

--- a/charts/mirror-maker2/values-dev.yaml
+++ b/charts/mirror-maker2/values-dev.yaml
@@ -1,0 +1,44 @@
+# dev overlay — single worker, small heap, verbose logs, no monitoring CRDs.
+replicas: 1
+
+target:
+  config:
+    config.storage.replication.factor: 1
+    offset.storage.replication.factor: 1
+    status.storage.replication.factor: 1
+
+mirrors:
+  - source:
+      alias: source
+      clusterName: "krafter"
+      namespace: "kafka"
+      authentication:
+        type: scram-sha-512
+        username: "kates-mm2-source"
+        secretName: "kates-mm2-source"
+        secretKey: "password"
+    topicsPattern: ".*"
+    groupsPattern: ".*"
+    sourceConnector:
+      tasksMax: 1
+      config:
+        replication.factor: 1
+        offset-syncs.topic.replication.factor: 1
+    checkpointConnector:
+      tasksMax: 1
+      config:
+        checkpoints.topic.replication.factor: 1
+        sync.group.offsets.enabled: "true"
+
+jvmOptions:
+  -Xms: 256m
+  -Xmx: 512m
+
+resources:
+  requests: { memory: 512Mi, cpu: 250m }
+  limits: { memory: 1Gi, cpu: 1000m }
+
+podMonitors:
+  enabled: false
+metrics:
+  enabled: false

--- a/charts/mirror-maker2/values-generic.yaml
+++ b/charts/mirror-maker2/values-generic.yaml
@@ -1,0 +1,10 @@
+# Generic overlay — for unknown clusters (EKS/GKE/AKS/on-prem). Disables
+# components that need extra operators (Prometheus CRDs). Set the source
+# bootstrap + credentials and RF to match your target cluster's broker count.
+podMonitors:
+  enabled: false
+metrics:
+  enabled: false
+
+networkPolicy:
+  enabled: true

--- a/charts/mirror-maker2/values-kind.yaml
+++ b/charts/mirror-maker2/values-kind.yaml
@@ -1,0 +1,45 @@
+# kind overlay — single-broker cluster, so RF1 everywhere and no Prometheus CRDs.
+replicas: 1
+
+target:
+  config:
+    config.storage.replication.factor: 1
+    offset.storage.replication.factor: 1
+    status.storage.replication.factor: 1
+
+mirrors:
+  - source:
+      alias: source
+      clusterName: "krafter"
+      namespace: "kafka"
+      authentication:
+        type: scram-sha-512
+        username: "kates-mm2-source"
+        secretName: "kates-mm2-source"
+        secretKey: "password"
+    topicsPattern: "kates\\..*"
+    groupsPattern: ".*"
+    sourceConnector:
+      tasksMax: 1
+      config:
+        replication.factor: 1
+        offset-syncs.topic.replication.factor: 1
+        sync.topic.acls.enabled: "false"
+    checkpointConnector:
+      tasksMax: 1
+      config:
+        checkpoints.topic.replication.factor: 1
+        sync.group.offsets.enabled: "true"
+
+jvmOptions:
+  -Xms: 256m
+  -Xmx: 256m
+
+resources:
+  requests: { memory: 512Mi, cpu: 250m }
+  limits: { memory: 1Gi, cpu: 1000m }
+
+podMonitors:
+  enabled: false
+metrics:
+  enabled: false

--- a/charts/mirror-maker2/values-mtls.yaml
+++ b/charts/mirror-maker2/values-mtls.yaml
@@ -1,0 +1,73 @@
+# mTLS overlay — MM2 over the kafka-cluster mTLS (9093) listener using Strimzi's
+# built-in Clients CA. NO external PKI.
+#
+# What this does:
+#   - provisions a `type: tls` KafkaUser (kates-mm2-tls) whose user.crt/user.key
+#     are issued + rotated by the cluster's Clients CA (kafkaUser.create=true)
+#   - connects target AND source over TLS on 9093, trusting the Cluster CA via
+#     the Strimzi-managed krafter-cluster-ca-cert Secret
+#   - narrows Kafka egress to 9093
+#
+# Assumes MM2 is installed in the SAME namespace as the krafter cluster (kafka),
+# so the user.crt/key + CA Secrets are already local. If MM2 runs elsewhere, ALSO
+# enable secretSync to copy them into the release namespace:
+#   secretSync:
+#     enabled: true
+#     secrets:
+#       - { name: kates-mm2-tls, fromNamespace: kafka }
+#       - { name: krafter-cluster-ca-cert, fromNamespace: kafka }
+#
+# NOTE: the default source is a LOOPBACK on krafter and reuses kates-mm2-tls. A
+# real external source needs its OWN tls KafkaUser on that cluster (issued by ITS
+# Clients CA) and its Cluster CA cert trusted here — see the README checklist.
+
+kafkaUser:
+  create: true
+  clusterName: krafter
+  namespace: kafka
+
+target:
+  alias: target
+  clusterName: krafter
+  namespace: kafka
+  tls:
+    enabled: true
+    trustedCertificateSecret: krafter-cluster-ca-cert
+    certificateKey: ca.crt
+  authentication:
+    type: tls
+    username: kates-mm2-tls
+    secretName: kates-mm2-tls
+
+mirrors:
+  - source:
+      alias: source
+      clusterName: krafter
+      namespace: kafka
+      tls:
+        enabled: true
+        trustedCertificateSecret: krafter-cluster-ca-cert
+        certificateKey: ca.crt
+      authentication:
+        type: tls
+        username: kates-mm2-tls
+        secretName: kates-mm2-tls
+    topicsPattern: ".*"
+    groupsPattern: ".*"
+    sourceConnector:
+      tasksMax: 3
+      config:
+        replication.factor: 3
+        offset-syncs.topic.replication.factor: 3
+        sync.topic.acls.enabled: "false"
+    checkpointConnector:
+      tasksMax: 1
+      config:
+        checkpoints.topic.replication.factor: 3
+        sync.group.offsets.enabled: "true"
+
+# TLS listener only — bootstrap computes :9093 because tls.enabled is set.
+networkPolicy:
+  enabled: true
+  kafka:
+    ports: [9093]

--- a/charts/mirror-maker2/values-prod.yaml
+++ b/charts/mirror-maker2/values-prod.yaml
@@ -1,0 +1,61 @@
+# Production overlay — HA workers, RF3 durability, monitoring on. Set the REAL
+# source bootstrap + credentials for a genuine cross-cluster mirror (the
+# defaults are an in-repo loopback).
+#
+# TLS is NOT forced on here: the repo's kafka-cluster 9093 listener is mTLS
+# (authentication.type: tls), which needs a tls-type KafkaUser (user.crt/key),
+# not the SCRAM kates-mm2 user. To run over TLS, set on target AND each source:
+#   tls: { enabled: true, trustedCertificateSecret: <cluster>-cluster-ca-cert }
+#   authentication: { type: tls, secretName: <tls-kafka-user> }
+# then narrow networkPolicy.kafka.ports to [9093]. Until then, keep SCRAM/9092.
+replicas: 3
+
+topologySpreadConstraints:
+  enabled: true
+  maxSkew: 1
+  topologyKey: topology.kubernetes.io/zone
+  whenUnsatisfiable: DoNotSchedule
+
+podAntiAffinity:
+  enabled: true
+  topologyKey: kubernetes.io/hostname
+
+rack:
+  enabled: true
+  topologyKey: topology.kubernetes.io/zone
+
+jvmOptions:
+  -Xms: 2048m
+  -Xmx: 2048m
+  gcLoggingEnabled: true
+
+resources:
+  requests: { memory: 4Gi, cpu: 2000m }
+  limits: { memory: 6Gi, cpu: 4000m }
+
+podDisruptionBudget:
+  enabled: true
+  maxUnavailable: 1
+
+priorityClassName: "system-cluster-critical"
+
+# Metrics + PodMonitor (capability-guarded; needs the Prometheus Operator CRDs)
+metrics:
+  enabled: true
+podMonitors:
+  enabled: true
+  labels:
+    release: kafka
+
+networkPolicy:
+  enabled: true
+  # Pin DNS egress to kube-dns on strict clusters
+  dns:
+    namespaceSelector:
+      kubernetes.io/metadata.name: kube-system
+    podSelector:
+      k8s-app: kube-dns
+  # Allow both the plaintext (9092/SCRAM) and TLS (9093) broker ports so egress
+  # works whichever auth mode is configured. Narrow to [9093] once TLS is on.
+  kafka:
+    ports: [9092, 9093]

--- a/charts/mirror-maker2/values.schema.json
+++ b/charts/mirror-maker2/values.schema.json
@@ -1,0 +1,213 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "mirror-maker2 values",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["target", "mirrors"],
+  "properties": {
+    "replicas": { "type": "integer", "minimum": 1 },
+    "version": { "type": "string", "minLength": 1 },
+    "image": { "type": "string" },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "namespaceOverride": { "type": "string" },
+    "keepOnDelete": { "type": ["boolean", "string"] },
+    "extraLabels": { "type": "object" },
+    "clusterDomain": { "type": "string" },
+    "testImages": {
+      "type": "object",
+      "properties": { "kubectl": { "type": "string" } }
+    },
+    "jvmOptions": { "type": "object" },
+    "livenessProbe": { "type": "object" },
+    "readinessProbe": { "type": "object" },
+    "logging": { "type": "object" },
+    "tracing": { "type": "object" },
+    "resources": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "imagePullSecrets": { "type": "array" },
+    "priorityClassName": { "type": "string" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array" },
+    "rack": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "topologyKey": { "type": "string" }
+      }
+    },
+    "podAntiAffinity": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "topologyKey": { "type": "string" }
+      }
+    },
+    "topologySpreadConstraints": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "maxSkew": { "type": "integer" },
+        "topologyKey": { "type": "string" },
+        "whenUnsatisfiable": { "enum": ["ScheduleAnyway", "DoNotSchedule"] }
+      }
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "maxUnavailable": { "type": ["integer", "string"] }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": { "type": "boolean" },
+        "name": { "type": "string" }
+      }
+    },
+    "autoscaling": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minReplicas": { "type": "integer", "minimum": 1 },
+        "maxReplicas": { "type": "integer", "minimum": 1 },
+        "targetCPUUtilizationPercentage": { "type": "integer" },
+        "targetMemoryUtilizationPercentage": { "type": "integer" }
+      }
+    },
+    "monitoring": {
+      "type": "object",
+      "properties": {
+        "interval": { "type": "string" },
+        "scrapeTimeout": { "type": "string" }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "defaultDeny": { "type": "boolean" },
+        "workerToWorker": { "type": "boolean" },
+        "dns": { "type": "object" },
+        "kafka": {
+          "type": "object",
+          "properties": { "ports": { "type": "array", "items": { "type": "integer" } } }
+        },
+        "monitoring": { "type": ["object", "null"] },
+        "extraEgress": { "type": "array" },
+        "extraIngress": { "type": "array" }
+      }
+    },
+    "target": {
+      "type": "object",
+      "properties": {
+        "alias": { "type": "string" },
+        "clusterName": { "type": "string" },
+        "namespace": { "type": "string" },
+        "bootstrapServers": { "type": "string" },
+        "groupId": { "type": "string" },
+        "configStorageTopic": { "type": "string" },
+        "offsetStorageTopic": { "type": "string" },
+        "statusStorageTopic": { "type": "string" },
+        "tls": { "$ref": "#/definitions/tls" },
+        "authentication": { "$ref": "#/definitions/auth" },
+        "config": { "type": "object" }
+      }
+    },
+    "mirrors": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["source"],
+        "properties": {
+          "source": {
+            "type": "object",
+            "properties": {
+              "alias": { "type": "string" },
+              "clusterName": { "type": "string" },
+              "namespace": { "type": "string" },
+              "bootstrapServers": { "type": "string" },
+              "tls": { "$ref": "#/definitions/tls" },
+              "authentication": { "$ref": "#/definitions/auth" },
+              "config": { "type": "object" }
+            }
+          },
+          "topicsPattern": { "type": "string" },
+          "groupsPattern": { "type": "string" },
+          "sourceConnector": { "type": "object" },
+          "checkpointConnector": { "type": "object" }
+        }
+      }
+    },
+    "kafkaUser": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean" },
+        "clusterName": { "type": "string" },
+        "namespace": { "type": "string" },
+        "name": { "type": "string" },
+        "authorization": { "type": "object" },
+        "quotas": { "type": "object" },
+        "template": { "type": "object" }
+      }
+    },
+    "podMonitors": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "labels": { "type": "object" }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "properties": { "enabled": { "type": "boolean" } }
+    },
+    "secretSync": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "timeoutSeconds": { "type": "integer", "minimum": 1 },
+        "image": { "type": "string" },
+        "secrets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "fromNamespace"],
+            "properties": {
+              "name": { "type": "string" },
+              "fromNamespace": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "tls": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "trustedCertificateSecret": { "type": "string" },
+        "certificateKey": { "type": "string" }
+      }
+    },
+    "auth": {
+      "type": "object",
+      "properties": {
+        "type": { "enum": ["scram-sha-512", "scram-sha-256", "tls", "plain", ""] },
+        "username": { "type": "string" },
+        "secretName": { "type": "string" },
+        "secretKey": { "type": "string" },
+        "certificate": { "type": "string" },
+        "key": { "type": "string" }
+      }
+    }
+  }
+}

--- a/charts/mirror-maker2/values.yaml
+++ b/charts/mirror-maker2/values.yaml
@@ -1,0 +1,279 @@
+# mirror-maker2 values.yaml
+#
+# Deploys a Strimzi KafkaMirrorMaker2 cluster. MM2 runs on Kafka Connect, so the
+# worker surface (replicas, JVM, resources, metrics, NetworkPolicy) mirrors the
+# connect-cluster chart. The DIFFERENCE: MM2 spans TWO Kafka clusters — a source
+# and a target — declared under `clusters:` and wired by `mirrors:`.
+
+# -- Override the chart name
+nameOverride: ""
+# -- Override the full release name
+fullnameOverride: ""
+# -- Override the release namespace
+namespaceOverride: ""
+
+# -- Keep the CR on `helm uninstall` (avoids tearing down replication by accident)
+keepOnDelete: true
+
+# -- Extra labels added to every resource
+extraLabels: {}
+
+# -- Images used by the Helm test pods
+testImages:
+  kubectl: "ghcr.io/bmscomp/kates-tester:1.21.0"
+
+# -- Number of MM2 (Connect) worker replicas
+replicas: 3
+# -- MM2 worker image (empty = Strimzi default for the Kafka version)
+image: ""
+# -- Kafka version the workers run
+version: "4.3.0"
+# -- Kubernetes cluster domain (bootstrap FQDN computation)
+clusterDomain: cluster.local
+
+# ── Target cluster ──────────────────────────────────────────────────────────
+# MM2's Connect runtime runs against the TARGET (Strimzi v1 API: spec.target).
+# It owns the Connect internal config/offset/status topics.
+#
+# Reference an in-cluster Strimzi cluster by clusterName + namespace (the
+# bootstrap FQDN is computed), or set bootstrapServers explicitly for an
+# external/inter-cluster target.
+target:
+  alias: target
+  # -- Strimzi cluster name (for computed bootstrap)
+  clusterName: "krafter"
+  # -- Namespace where that Kafka cluster lives
+  namespace: "kafka"
+  # -- Explicit bootstrap override (external/inter-cluster). Wins over
+  # clusterName+namespace when set.
+  bootstrapServers: ""
+  # -- Connect worker group ID; internal topics default to <groupId>-{configs,offsets,status}
+  groupId: "mirror-maker2"
+  configStorageTopic: ""
+  offsetStorageTopic: ""
+  statusStorageTopic: ""
+  tls:
+    enabled: false
+    trustedCertificateSecret: "krafter-cluster-ca-cert"
+    certificateKey: "ca.crt"
+  authentication:
+    type: scram-sha-512
+    username: "kates-mm2"
+    secretName: "kates-mm2"
+    secretKey: "password"
+  # -- Connect internal-topic replication. RF3 for durability; overlays lower
+  # it to 1 for single-broker (kind).
+  config:
+    config.storage.replication.factor: 3
+    offset.storage.replication.factor: 3
+    status.storage.replication.factor: 3
+
+# ── Mirror flows ────────────────────────────────────────────────────────────
+# One entry per source cluster → the target. Each has its OWN source bootstrap,
+# tls and auth. replication.factor and the offset-syncs/checkpoints topic
+# factors must match the TARGET's durability (RF3 in prod, RF1 on kind).
+mirrors:
+  - source:
+      alias: source
+      # -- Reference an in-cluster Strimzi cluster by name + namespace (bootstrap
+      # computed), OR set bootstrapServers for an external/inter-cluster source.
+      # Default is a LOOPBACK on the in-repo krafter cluster (source == target)
+      # so the chart renders and smoke-tests out of the box.
+      clusterName: "krafter"
+      namespace: "kafka"
+      # -- Explicit bootstrap override (external/inter-cluster). Wins when set.
+      bootstrapServers: ""
+      tls:
+        enabled: false
+        trustedCertificateSecret: ""
+        certificateKey: "ca.crt"
+      authentication:
+        # -- scram-sha-512 | scram-sha-256 | tls | plain (empty = none)
+        type: scram-sha-512
+        username: "kates-mm2-source"
+        # -- Secret holding the credential (defaults to username when empty)
+        secretName: ""
+        secretKey: "password"
+      config: {}
+    # -- Topics to mirror (regex)
+    topicsPattern: ".*"
+    # -- Consumer groups whose offsets to checkpoint (regex)
+    groupsPattern: ".*"
+    sourceConnector:
+      tasksMax: 3
+      config:
+        replication.factor: 3
+        offset-syncs.topic.replication.factor: 3
+        # Do not mirror source topic ACLs (target ACLs are managed here)
+        sync.topic.acls.enabled: "false"
+        refresh.topics.interval.seconds: 60
+    checkpointConnector:
+      tasksMax: 1
+      config:
+        checkpoints.topic.replication.factor: 3
+        # Translate consumer group offsets to the target (failover readiness)
+        sync.group.offsets.enabled: "true"
+        refresh.groups.interval.seconds: 60
+
+# ── JVM & Resources ─────────────────────────────────────────────────────────
+jvmOptions:
+  -Xms: 1024m
+  -Xmx: 1024m
+  gcLoggingEnabled: true
+
+# -- Optional CR passthroughs (empty = Strimzi defaults). Shapes match the
+# KafkaMirrorMaker2 CRD verbatim.
+# livenessProbe:  { initialDelaySeconds: 60, timeoutSeconds: 5 }
+# readinessProbe: { initialDelaySeconds: 60, timeoutSeconds: 5 }
+# logging: { type: inline, loggers: { "log4j.logger.org.apache.kafka.connect.mirror": INFO } }
+# tracing: { type: opentelemetry }
+livenessProbe: {}
+readinessProbe: {}
+logging: {}
+tracing: {}
+
+resources:
+  requests:
+    memory: 2Gi
+    cpu: 1000m
+  limits:
+    memory: 4Gi
+    cpu: 4000m
+
+# ── Scheduling ──────────────────────────────────────────────────────────────
+topologySpreadConstraints:
+  enabled: true
+  maxSkew: 1
+  topologyKey: topology.kubernetes.io/zone
+  whenUnsatisfiable: ScheduleAnyway
+
+podAntiAffinity:
+  enabled: true
+  topologyKey: kubernetes.io/hostname
+
+rack:
+  enabled: false
+  topologyKey: topology.kubernetes.io/zone
+
+podDisruptionBudget:
+  # -- Only rendered when replicas > 1. maxUnavailable keeps the CR drain-safe
+  # regardless of replica count.
+  enabled: true
+  maxUnavailable: 1
+
+tolerations: []
+nodeSelector: {}
+priorityClassName: "system-cluster-critical"
+imagePullSecrets: []
+
+# -- Pod-level security context
+podSecurityContext:
+  runAsNonRoot: true
+  fsGroup: 1001
+  seccompProfile:
+    type: RuntimeDefault
+
+# ── ServiceAccount ──────────────────────────────────────────────────────────
+serviceAccount:
+  create: true
+  name: ""
+
+# ── Autoscaling (HPA on the MM2 Connect Deployment) ─────────────────────────
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 6
+  targetCPUUtilizationPercentage: 80
+
+# ── Managed target KafkaUser ────────────────────────────────────────────────
+# Provisions the TARGET-side KafkaUser + MM2 ACLs (write replicated topics,
+# own the MM2 internal + offset-sync + checkpoint + heartbeat topics, and the
+# Connect groups). Off by default: the in-repo kafka-cluster chart provisions
+# `kates-mm2` centrally. The SOURCE-side user is on an external cluster and is
+# NOT created here — grant it READ on the mirrored topics/groups + DESCRIBE
+# out-of-band (see README).
+kafkaUser:
+  create: false
+  # -- Target cluster name (strimzi.io/cluster label) and namespace
+  clusterName: "krafter"
+  namespace: "kafka"
+  # -- Defaults to the target cluster's authentication.username
+  name: ""
+  authorization:
+    enabled: true
+    type: simple
+    # -- auto: least-privilege ACLs derived from the source aliases + target
+    # groupId (replicated topics <alias>.*, MM2 internal/offset-sync/heartbeat/
+    # checkpoint topics, Connect groups). custom: use `acls` verbatim.
+    mode: auto
+  # -- Extra topic grants appended in auto mode (e.g. IdentityReplicationPolicy,
+  # where replicated topics keep their original names — grant those prefixes).
+  topicGrants: []
+  #   - { name: "orders", patternType: prefix }
+  # -- Extra consumer-group grants appended in auto mode
+  groupGrants: []
+  # -- Used only when authorization.mode=custom
+  acls: []
+  quotas: {}
+  template: {}
+
+# ── Credential secret sync (cross-namespace / inter-cluster) ────────────────
+# MM2 reads each cluster's passwordSecret / TLS cert from ITS OWN namespace.
+# When a source or target Kafka cluster lives in a different namespace than this
+# release, the credential Secret (and CA cert for TLS) must be made available
+# here. This hook Job copies the listed Secrets from their source namespaces
+# into the release namespace on every install/upgrade (picking up rotation).
+# No-op when everything is co-located. Alternative: kubernetes-reflector.
+secretSync:
+  enabled: false
+  timeoutSeconds: 300
+  # -- Image for the sync Job (needs kubectl + jq + sh). Defaults to the tester
+  # image; override with a dedicated runtime image if preferred.
+  image: ""
+  # -- Secrets to copy into the release namespace. Each: name + fromNamespace.
+  # Entries whose fromNamespace equals the release namespace are skipped.
+  secrets: []
+  #   - name: kates-mm2                 # target SCRAM credential
+  #     fromNamespace: kafka
+  #   - name: kates-mm2-source          # source SCRAM credential
+  #     fromNamespace: kafka-dr
+  #   - name: krafter-cluster-ca-cert   # target CA cert (TLS)
+  #     fromNamespace: kafka
+
+# ── Monitoring ──────────────────────────────────────────────────────────────
+podMonitors:
+  # -- Create a PodMonitor for the MM2 worker metrics (requires Prometheus
+  # Operator CRDs; capability-guarded so a missing CRD never fails install)
+  enabled: false
+  labels: {}
+monitoring:
+  interval: 30s
+  scrapeTimeout: ""
+
+# -- Enable JMX Prometheus metrics on the workers (needed for podMonitors)
+metrics:
+  enabled: false
+
+# ── NetworkPolicy ───────────────────────────────────────────────────────────
+# Default-deny for the MM2 worker pods; every allowed flow is explicit.
+networkPolicy:
+  enabled: true
+  # -- Deny-all baseline for the MM2 pods
+  defaultDeny: true
+  # -- DNS egress (empty selectors = anywhere; pin to kube-dns on strict clusters)
+  dns:
+    namespaceSelector: {}
+    podSelector: {}
+  # -- Kafka broker egress (source + target). MM2 reaches arbitrary broker IPs,
+  # so egress is to any destination on these ports.
+  kafka:
+    ports: [9092, 9093]
+  # -- Worker-to-worker Connect REST (8083) for leader forwarding
+  workerToWorker: true
+  # -- Metrics scrape ingress
+  monitoring:
+    namespace: monitoring
+    port: 9404
+  # -- Extra egress/ingress rules appended verbatim
+  extraEgress: []
+  extraIngress: []

--- a/docs/book/appendix-d-versions.md
+++ b/docs/book/appendix-d-versions.md
@@ -23,6 +23,7 @@ Every version the platform pins, in one place. This table is generated from the 
 | `kates-platform` chart | 0.4.0 (app 1.0.0) | `charts/kates-platform/Chart.yaml` |
 | `kates` chart | 0.6.0 (app 1.21.0) | `charts/kates/Chart.yaml` |
 | `minio` chart | 17.0.22 (app 2025.7.23) | `charts/minio/Chart.yaml` |
+| `mirror-maker2` chart | 0.1.0 (app 4.3.0) | `charts/mirror-maker2/Chart.yaml` |
 | `monitoring` chart | 1.1.0 (app 82.4.3) | `charts/monitoring/Chart.yaml` |
 | `strimzi-operator` chart | 0.1.0 (app 1.1.0) | `charts/strimzi-operator/Chart.yaml` |
 | `velero` chart | 11.3.3 (app 1.17.1) | `charts/velero/Chart.yaml` |

--- a/docs/mirror-maker2-chart-plan.md
+++ b/docs/mirror-maker2-chart-plan.md
@@ -1,0 +1,98 @@
+# Plan — Introduce a `mirror-maker2` Chart
+
+Branch: `feat/mirror-maker2-chart` (from `main`). Goal: add `charts/mirror-maker2/`, a first-party chart deploying a Strimzi **KafkaMirrorMaker2** cluster for cross-cluster replication (active/passive DR, migration, aggregation), built to the same bar as the repo's existing Strimzi charts.
+
+> **Status: IMPLEMENTED.** Chart built and verified (lint + all overlays + kubeconform against the real Strimzi CRD, schema, docs gates). **API note:** Strimzi 1.1.0's `KafkaMirrorMaker2` **v1** API differs from the v1beta2 shape this plan first sketched — it has no `connectCluster`/`clusters[]`. The chart uses the correct v1 model: a single **`spec.target`** (alias, bootstrapServers, groupId, config/offset/status storage topics, tls, auth, config) plus **`mirrors[].source`** (per-mirror source cluster) with `sourceConnector` + `checkpointConnector` (no separate `heartbeatConnector` in v1). The credential-contract, durability, and CI/docs points below all still hold.
+
+## Why, and what it is
+
+MirrorMaker 2 runs on Kafka Connect — a `KafkaMirrorMaker2` CR *is* a Connect cluster with three built-in connectors (`MirrorSourceConnector`, `MirrorCheckpointConnector`, `MirrorHeartbeatConnector`). So the operational surface (Connect workers: replicas, JVM, probes, metrics, HPA, NetworkPolicies, Connect internal topics) is nearly identical to `charts/connect-cluster`, and that chart is the template to copy from. The **one structural difference that drives the whole design**: MM2 talks to **two or more Kafka clusters** (a source and a target), whereas Connect talks to one. Everything novel in this chart flows from that.
+
+The repo already has the pieces this leans on: the `strimzi-operator` chart owns the `kafkamirrormaker2s.kafka.strimzi.io` CRD (it's in the operator's CRD bundle and the operator's tests already assert it Established), and `kafka-cluster` provisions per-workload `KafkaUser`s + ACLs (e.g. `kates-connect`, `apicurio-registry`). MM2 is the natural next consumer of both.
+
+## The multi-cluster design (the part that isn't Connect)
+
+The `KafkaMirrorMaker2` CR has three top-level pieces the chart must model as values:
+
+1. **`clusters[]`** — every Kafka cluster involved, each with an `alias`, `bootstrapServers`, and its **own** `tls` + `authentication` (each cluster has separate credentials). Minimum two: a source and a target.
+2. **`connectCluster`** — the alias whose brokers host MM2's Connect internal topics (`mm2-configs`, `mm2-offsets`, `mm2-status`). Conventionally the **target**.
+3. **`mirrors[]`** — one entry per source→target flow: `sourceCluster`, `targetCluster`, `topicsPattern`, `groupsPattern`, and per-connector config (`sourceConnector` / `checkpointConnector` / `heartbeatConnector`) including the critical `replication.factor`, `offset-syncs.topic.replication.factor`, `sync.group.offsets.enabled`, and refresh intervals.
+
+Proposed values shape (kept close to the CR so it stays legible against upstream docs, with a curated default that mirrors the in-repo `krafter` cluster to itself as a loopback for smoke-testing):
+
+```yaml
+clusters:
+  - alias: source
+    bootstrapServers: ""          # required; external or another in-repo cluster
+    tls: { enabled: false, trustedCertificateSecret: "", certificateKey: ca.crt }
+    authentication: { type: scram-sha-512, username: kates-mm2-source, secretName: "", secretKey: password }
+  - alias: target
+    bootstrapServers: krafter-kafka-bootstrap.kafka.svc:9092
+    tls: { enabled: false, ... }
+    authentication: { type: scram-sha-512, username: kates-mm2, secretName: kates-mm2, secretKey: password }
+connectCluster: target           # holds the MM2 Connect internal topics
+mirrors:
+  - sourceCluster: source
+    targetCluster: target
+    topicsPattern: ".*"
+    groupsPattern: ".*"
+    sourceConnector:
+      config: { replication.factor: 3, offset-syncs.topic.replication.factor: 3, sync.topic.acls.enabled: "false" }
+    checkpointConnector:
+      config: { checkpoints.topic.replication.factor: 3, sync.group.offsets.enabled: "true" }
+    heartbeatConnector:
+      config: { heartbeats.topic.replication.factor: 3 }
+```
+
+Everything else (replicas, version/image, jvmOptions, resources, HPA, metrics, NetworkPolicies, topologySpread) is lifted from `connect-cluster` with the same value names, so an operator who knows that chart knows this one.
+
+## Credentials & ACLs — the sharp edge
+
+MM2 needs a `KafkaUser` on **both** ends: on the **source** (READ on mirrored topics + groups, DESCRIBE) and on the **target** (READ/WRITE/CREATE on the replicated topics, and full access to the MM2 internal + offset-sync + checkpoint + heartbeat topics, plus the Connect groups). Two realities:
+
+- **Target is usually in-repo (`krafter`).** Provision its `KafkaUser` + ACLs in `charts/kafka-cluster/values.yaml` (a new `kates-mm2` entry alongside `kates-connect`/`apicurio-registry`), and let this chart reference the resulting Secret — same pattern the other consumers use. The chart's own `kafkaUser` block (copied from connect-cluster) can also create it directly when Kafka is co-located.
+- **Source is usually EXTERNAL** (that's the point of replication). The chart **cannot** provision a user on a cluster it doesn't manage — so for the source it consumes a pre-existing Secret (name via values) and documents the exact ACL set the remote operator must grant. `secretSync` (job/reflector, copied from connect-cluster) handles making either Secret present in the MM2 namespace.
+
+This split — provision what we own (target), document what we don't (source) — is the honest contract and must be stated loudly in the README and NOTES, because a silent missing source ACL surfaces only as a stalled `MirrorSourceConnector`.
+
+## File-by-file build (mirror `connect-cluster`)
+
+Copy the structure, adapt the CR and the cluster-plurality:
+
+- `Chart.yaml` — `name: mirror-maker2`, `version: 0.1.0`, `appVersion` tracking the Kafka line (`4.3.0`, from `versions.env STRIMZI_KAFKA_VERSION`), `kubeVersion: ">=1.27.0-0"`, keywords `mirrormaker2`/`replication`/`dr`.
+- `values.yaml` — the multi-cluster block above + the connect-cluster passthroughs (replicas, image, version, jvmOptions, resources, autoscaling, topologySpreadConstraints, metrics, networkPolicy, kafkaUser, secretSync, testImages, keepOnDelete).
+- `values.schema.json` — strict where it matters (cluster alias/auth enums, mirror required fields); follow connect-cluster's schema.
+- `values-{dev,kind,prod,generic}.yaml` — kind: single loopback mirror, RF1, small heap; prod: replicas ≥2, **drain-safe PDB** (apply the P0 lesson — `minAvailable < replicas`), topologySpread, RF3, tightened security, PodMonitor + alerts on.
+- `templates/`:
+  - `kafka-mirror-maker2.yaml` — the CR (`kafka.strimzi.io/v1`, `kind: KafkaMirrorMaker2`), rendering `clusters[]`, `connectCluster`, `mirrors[]`, plus the Connect worker spec (version, image, replicas-unless-HPA, jvmOptions, resources, metrics config, template/securityContext).
+  - `_helpers.tpl`, `serviceaccount.yaml`, `networkpolicies.yaml` (+ default-deny), `podmonitor.yaml`, `alerts.yaml`, `dashboard.yaml`, `hpa.yaml`, `kafka-user.yaml` (target), `kafka-user-secret-sync.yaml`, `metrics-configmap.yaml`, `NOTES.txt`.
+  - `tests/` — `test-mm2.yaml` (CR Ready), `test-connectors.yaml` (the three mirror connectors Running), `test-topics.yaml` (a `<source>.<topic>` replicated topic appears on the target).
+- `README.md`, `.helmignore`.
+
+## Versioning, CI, and docs gates
+
+- **Version pins.** `appVersion` = Kafka `4.3.0`; the worker image = the repo's connect/kafka image. If `scripts/check-versions.sh` grows to know this chart, wire it; otherwise no new pin site.
+- **CI is automatic.** The Helm Lint job's `for chart in charts/*/` loops (lint, template, kubeconform) pick the chart up with no workflow change — provided its Strimzi CR passes kubeconform against the community CRD catalog (it will; `KafkaMirrorMaker2` is in the catalog).
+- **Docs gates are NOT automatic.** `scripts/gen-chart-table.sh --check` and `scripts/gen-version-matrix.sh --check` both iterate `charts/*/`, so adding the chart makes them fail until the README chart table and the book's `appendix-d` matrix are regenerated. Run both generators as the final step (same dance as every chart bump in this repo).
+- **Umbrella (optional).** Add as an optional `kates-platform` dependency (`condition: mirror-maker2.enabled`, default off), following the `apicurio-registry` precedent.
+
+## Testing
+
+- **Helm tests** (ship with the chart): MM2 CR reaches Ready; the three mirror connectors report Running; a replicated topic materialises on the target.
+- **Live smoke (optional, manual `workflow_dispatch`).** A kind job that stands up the in-repo `kafka-cluster`, installs MM2 with a **loopback** mirror (`source` and `target` both = `krafter`, distinct topic prefixes), produces to a source topic, and asserts the `source.<topic>` appears — proves the whole path without needing two clusters. Model it on `ci-apicurio.yml`; keep it manual and single-broker (RF1) to fit a runner. A true two-cluster test is out of scope for CI (resource-prohibitive) and belongs in a staging environment.
+
+## Risks / non-goals
+
+- **Not a general Connect chart** — this deploys MM2 specifically; regular connectors belong in `connect-cluster`.
+- **Source-side provisioning is out of scope** by nature (external cluster); the chart documents the required ACLs but cannot create them.
+- **Offset/checkpoint durability** depends on `replication.factor` ≥3 and `sync.group.offsets.enabled` on the target — prod overlay must set these, and the README must warn that RF1 (kind) is non-durable.
+- **Exactly-once** across clusters is not a MM2 guarantee; the chart should not imply it.
+
+## Sequence
+
+1. Scaffold from `connect-cluster` (Chart.yaml, values, helpers, serviceaccount, NOTES) → lint green.
+2. `kafka-mirror-maker2.yaml` CR with `clusters[]`/`connectCluster`/`mirrors[]` + schema → `helm template` + kubeconform green.
+3. Credentials: target `KafkaUser` (chart + a `kates-mm2` entry in `kafka-cluster`), secretSync, source-Secret consumption + documented ACLs.
+4. Ops surface: NetworkPolicies, PodMonitor, alerts, HPA, topologySpread, prod overlay (drain-safe PDB, RF3, security).
+5. Tests (helm tests) + README/NOTES; regenerate the two docs gates.
+6. Optional: kates-platform dependency + the manual loopback kind smoke test.


### PR DESCRIPTION
Introduces charts/mirror-maker2, a first-party chart deploying a Strimzi KafkaMirrorMaker2 cluster (active/passive DR, migration, aggregation), built to the repo's Strimzi-chart bar. MM2 runs on Kafka Connect, so the worker surface mirrors connect-cluster; the defining difference — MM2 spans a source and a target Kafka cluster — drives the design.

Correct Strimzi 1.1.0 v1 API (spec.target + mirrors[].source; no connectCluster/clusters[]), validated against the operator's real CRD.

Configurable source/target for every topology, one model:
- clusterName + namespace → computed bootstrap FQDN (port follows tls.enabled), or an explicit bootstrapServers override for external/inter-cluster.
- Covers same-cluster loopback, same cluster across namespaces, two in-cluster Strimzi clusters, and external/cross-datacenter. Defaults to an in-repo krafter loopback so it renders and smoke-tests without a second cluster.

Credentials handled as an honest two-cluster contract:
- Target KafkaUser + least-privilege ACLs (auto-scoped from source aliases + groupId, with topicGrants/custom override) — provisioned in-repo (kates-mm2 in kafka-cluster) or by the chart.
- Source user is external and documented (READ/DESCRIBE), never silently assumed.
- secretSync (off by default): hook Job copies per-cluster credential + CA Secrets across namespaces with name-scoped RBAC, skipping same-namespace entries. README carries a cross-namespace / inter-cluster checklist.

mTLS: turnkey values-mtls.yaml over the kafka-cluster 9093 listener using Strimzi's built-in Clients CA (type: tls KafkaUser, auto-rotated certs), no external PKI; README documents the external/federated-trust (cert-manager) route.

Ops surface: default-deny NetworkPolicy with MM2 flows, capability-guarded PodMonitor (fails loudly without metrics), JMX metrics ConfigMap, HPA on the CR scale subresource (replicas always emitted — v1 requires it), Strimzi-managed PodDisruptionBudget (no overlapping standalone), rack/topology-spread/anti- affinity, probes/logging/tracing + per-mirror exclude patterns surfaced, hardened securityContext, a helm test asserting the CR reaches Ready, NOTES documenting the credential contract and reinstall caveat, a strict values.schema.json, and dev/kind/prod/generic/mtls overlays (RF1 single-broker; RF3 + monitoring in prod). kafka-cluster gains the kates-mm2 target user; README chart table + book version matrix updated.

Verified throughout: helm lint, all overlays, kubeconform against the real CRD + community catalog, schema type/rejection checks, and the repo docs gates.